### PR TITLE
「弾ける曲」のみをフィルタ出来るよう修正

### DIFF
--- a/nemupipiano-musiclist-search/css/musiclist-search.css
+++ b/nemupipiano-musiclist-search/css/musiclist-search.css
@@ -206,6 +206,28 @@ body {
     color: var(--page-text);
 }
 
+.stat-filter-button {
+    cursor: pointer;
+    font-family: inherit;
+    transition: border-color .15s ease, background .15s ease, color .15s ease, box-shadow .15s ease;
+}
+
+.stat-filter-button:hover,
+.stat-filter-button:focus {
+    border-color: rgba(180, 83, 9, .45);
+    box-shadow: 0 0 0 .2rem rgba(180, 83, 9, .12);
+}
+
+.stat-filter-button.active {
+    color: var(--page-accent);
+    background: var(--page-accent-soft);
+    border-color: #fed7aa;
+}
+
+.stat-filter-button.active strong {
+    color: var(--page-accent);
+}
+
 .badge-playable {
     color: #15803d;
     background: #f0fdf4;

--- a/nemupipiano-musiclist-search/index.html
+++ b/nemupipiano-musiclist-search/index.html
@@ -139,7 +139,7 @@
   </div>
 
   <footer class="site-footer fixed-bottom mx-0 bg-black bg-opacity-75 text-center text-white">
-    <p>ver.1.1.0 問題点を見つけたら<a href="https://x.com/bonga_bon_bonga">X(旧Twitter)</a>にご連絡ください。</p>
+    <p>ver.1.1.1 問題点を見つけたら<a href="https://x.com/bonga_bon_bonga">X(旧Twitter)</a>にご連絡ください。</p>
   </footer>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"

--- a/nemupipiano-musiclist-search/index.html
+++ b/nemupipiano-musiclist-search/index.html
@@ -17,7 +17,6 @@
 
   <main role="main" class="container app-shell">
     <header class="mb-4">
-      <h1 class="app-title display-4 fw-bold mb-3">ねむぴぴあの＊曲リストサーチ</h1>
       <p class="lead text-secondary mb-0">
         Googleスプレッドシート「<a href="https://docs.google.com/spreadsheets/d/1Dd-oj59leRwLI-Y1v1hD5tpEgk2yiu4w6DL7adkpr9g/edit?gid=0#gid=0" target="_blank" rel="noopener noreferrer">ピアノ曲リスト</a>」を読み取り、曲のフィルタ検索とランダム表示を行うことが出来ます。<br>
         リストに曲が無い時は、ねむぴぴあのでリクエスト！

--- a/nemupipiano-musiclist-search/index.html
+++ b/nemupipiano-musiclist-search/index.html
@@ -172,6 +172,7 @@
     let songs = [];
     let recommendedSongs = [];
     let musiclistItems = {};
+    let playableOnly = false;
 
     // HTMLエスケープを行う関数。& < > " ' をそれぞれ対応するHTMLエンティティに置換する。nullやundefinedも空文字に変換する。
     function escapeHtml(value) {
@@ -412,7 +413,8 @@
       return songs.filter(song => {
         const keywordOk = matchesSearchKeyword(song, keyword, searchScope);
         const genreOk = !genre || song.genre === genre;
-        return keywordOk && genreOk;
+        const playableOk = !playableOnly || isPlayable(song);
+        return keywordOk && genreOk && playableOk;
       });
     }
 
@@ -470,7 +472,7 @@
 
       els.stats.innerHTML = `
         <span class="badge rounded-pill stat-badge px-3 py-2">全<strong>${songs.length}</strong>曲</span>
-        <span class="badge rounded-pill stat-badge px-3 py-2">弾ける曲<strong>${playableCount}</strong>曲</span>
+        <button class="badge rounded-pill stat-badge stat-filter-button px-3 py-2 ${playableOnly ? "active" : ""}" type="button" data-filter="playable" aria-pressed="${playableOnly}">弾ける曲<strong>${playableCount}</strong>曲</button>
         <span class="badge rounded-pill stat-badge px-3 py-2">ジャンル<strong>${genreCount}</strong>種</span>
         <span class="badge rounded-pill stat-badge px-3 py-2">表示中<strong>${items.length}</strong>曲</span>
       `;
@@ -566,6 +568,13 @@
     els.search.addEventListener("input", render);
     els.searchScopes.forEach(scope => scope.addEventListener("change", render));
     els.genre.addEventListener("change", render);
+    els.stats.addEventListener("click", (event) => {
+      const button = event.target.closest("[data-filter='playable']");
+      if (!button) return;
+
+      playableOnly = !playableOnly;
+      render();
+    });
     els.reload.addEventListener("click", loadSheet);
     els.shuffle.addEventListener("click", () => {
       pickRandomSongs();


### PR DESCRIPTION
対応内容:
- 「弾ける曲154曲」の統計バッジをタップ可能なボタンに変更
- タップすると 弾ける曲 判定が付いている曲だけに絞り込み
- もう一度タップすると絞り込み解除
- ON 状態が見た目で分かるように active スタイルを追加