### PR TITLE
「index.html」の表示内容を修正

### DIFF
--- a/nemupipiano-musiclist-search/css/musiclist-search.css
+++ b/nemupipiano-musiclist-search/css/musiclist-search.css
@@ -401,6 +401,30 @@ body {
     display: none;
 }
 
+@media (max-width: 767.98px) {
+    .song-grid[data-columns="1"] .song-card-body {
+    align-items: stretch;
+    display: flex !important;
+    flex-direction: column !important;
+    }
+
+    .song-grid[data-columns="1"] .song-card-header {
+    display: flex !important;
+    }
+
+    .song-grid[data-columns="1"] .song-card-text {
+    align-items: flex-start;
+    display: flex;
+    flex-direction: column;
+    gap: .15rem;
+    }
+
+    .song-grid[data-columns="1"] .song-card-meta {
+    flex-wrap: wrap !important;
+    justify-content: flex-start;
+    }
+}
+
 @media (max-width: 575.98px) {
     .app-panel {
     border-radius: 1.1rem;
@@ -445,31 +469,16 @@ body {
     display: none;
     }
 
-    .song-grid[data-columns="1"] .song-card-body,
     .song-grid[data-columns="2"] .song-card-body {
     align-items: stretch;
     flex-direction: column !important;
     }
 
-    .song-grid[data-columns="1"] .song-card-body {
-    display: flex !important;
-    }
-
-    .song-grid[data-columns="1"] .song-card-text,
     .song-grid[data-columns="2"] .song-card-text {
     display: flex;
     align-items: flex-start;
     flex-direction: column;
     gap: .15rem;
-    }
-
-    .song-grid[data-columns="1"] .song-card-header {
-    display: flex !important;
-    }
-
-    .song-grid[data-columns="1"] .song-card-meta {
-    flex-wrap: wrap !important;
-    justify-content: flex-start;
     }
 
     .back-to-top {

--- a/nemupipiano-musiclist-search/css/musiclist-search.css
+++ b/nemupipiano-musiclist-search/css/musiclist-search.css
@@ -431,6 +431,11 @@ body {
     font-size: 2rem;
     }
 
+    .app-shell header .lead {
+    font-size: .95rem;
+    line-height: 1.55;
+    }
+
     .result-controls {
     align-items: flex-start;
     flex-direction: column;

--- a/nemupipiano-musiclist-search/css/musiclist-search.css
+++ b/nemupipiano-musiclist-search/css/musiclist-search.css
@@ -214,7 +214,8 @@ body {
 }
 
 .song-grid[data-columns="1"] .song-card-body {
-    flex-direction: row !important;
+    display: grid !important;
+    grid-template-columns: minmax(12rem, 1.35fr) minmax(10rem, .95fr) 3rem minmax(10rem, auto);
     align-items: center;
     gap: .75rem !important;
 }
@@ -226,7 +227,7 @@ body {
 }
 
 .song-grid[data-columns="1"] .song-card-header {
-    flex: 1 1 auto;
+    display: contents !important;
 }
 
 .song-grid[data-columns="1"] .song-card-text,
@@ -237,8 +238,7 @@ body {
 }
 
 .song-grid[data-columns="1"] .song-card-text {
-    flex: 1 1 auto;
-    gap: .75rem;
+    display: contents;
 }
 
 .song-grid[data-columns="1"] .song-title,
@@ -252,24 +252,27 @@ body {
 }
 
 .song-grid[data-columns="1"] .song-title {
-    flex: 1 1 42%;
     font-size: 1rem;
+    grid-column: 1;
 }
 
 .song-grid[data-columns="1"] .song-artist {
-    flex: 1 1 32%;
     font-size: .9rem;
+    grid-column: 2;
 }
 
 .song-grid[data-columns="1"] .song-number {
     font-size: .8rem;
+    grid-column: 3;
+    justify-self: end;
 }
 
 .song-grid[data-columns="1"] .song-card-meta {
-    flex: 0 0 auto;
     flex-wrap: nowrap !important;
+    grid-column: 4;
     margin-top: 0 !important;
     justify-content: flex-end;
+    min-width: 0;
 }
 
 .song-grid[data-columns="1"] .song-card-meta .badge {
@@ -439,11 +442,20 @@ body {
     flex-direction: column !important;
     }
 
+    .song-grid[data-columns="1"] .song-card-body {
+    display: flex !important;
+    }
+
     .song-grid[data-columns="1"] .song-card-text,
     .song-grid[data-columns="2"] .song-card-text {
+    display: flex;
     align-items: flex-start;
     flex-direction: column;
     gap: .15rem;
+    }
+
+    .song-grid[data-columns="1"] .song-card-header {
+    display: flex !important;
     }
 
     .song-grid[data-columns="1"] .song-card-meta {

--- a/nemupipiano-musiclist-search/css/musiclist-search.css
+++ b/nemupipiano-musiclist-search/css/musiclist-search.css
@@ -441,6 +441,10 @@ body {
     flex-direction: column;
     }
 
+    .display-columns {
+    display: none;
+    }
+
     .song-grid[data-columns="1"] .song-card-body,
     .song-grid[data-columns="2"] .song-card-body {
     align-items: stretch;

--- a/nemupipiano-musiclist-search/css/musiclist-search.css
+++ b/nemupipiano-musiclist-search/css/musiclist-search.css
@@ -97,6 +97,11 @@ body {
     box-shadow: 0 8px 18px rgba(41, 37, 36, .07);
 }
 
+.reload-button {
+    font-size: 1rem;
+    white-space: nowrap;
+}
+
 .result-controls {
     display: flex;
     flex-wrap: wrap;

--- a/nemupipiano-musiclist-search/css/musiclist-search.css
+++ b/nemupipiano-musiclist-search/css/musiclist-search.css
@@ -97,9 +97,16 @@ body {
     box-shadow: 0 8px 18px rgba(41, 37, 36, .07);
 }
 
+.result-controls {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: .5rem 1rem;
+}
+
 .search-scope,
 .display-columns {
-    display: flex;
+    display: inline-flex;
     flex-wrap: wrap;
     align-items: center;
     gap: .35rem;
@@ -199,6 +206,108 @@ body {
 
 .song-artist {
     overflow-wrap: anywhere;
+}
+
+.song-grid[data-columns="1"] .song-card-body,
+.song-grid[data-columns="2"] .song-card-body {
+    padding: .75rem 1rem !important;
+}
+
+.song-grid[data-columns="1"] .song-card-body {
+    flex-direction: row !important;
+    align-items: center;
+    gap: .75rem !important;
+}
+
+.song-grid[data-columns="1"] .song-card-header,
+.song-grid[data-columns="2"] .song-card-header {
+    align-items: center !important;
+    min-width: 0;
+}
+
+.song-grid[data-columns="1"] .song-card-header {
+    flex: 1 1 auto;
+}
+
+.song-grid[data-columns="1"] .song-card-text,
+.song-grid[data-columns="2"] .song-card-text {
+    display: flex;
+    align-items: baseline;
+    min-width: 0;
+}
+
+.song-grid[data-columns="1"] .song-card-text {
+    flex: 1 1 auto;
+    gap: .75rem;
+}
+
+.song-grid[data-columns="1"] .song-title,
+.song-grid[data-columns="1"] .song-artist,
+.song-grid[data-columns="2"] .song-title,
+.song-grid[data-columns="2"] .song-artist {
+    margin-bottom: 0 !important;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.song-grid[data-columns="1"] .song-title {
+    flex: 1 1 42%;
+    font-size: 1rem;
+}
+
+.song-grid[data-columns="1"] .song-artist {
+    flex: 1 1 32%;
+    font-size: .9rem;
+}
+
+.song-grid[data-columns="1"] .song-number {
+    font-size: .8rem;
+}
+
+.song-grid[data-columns="1"] .song-card-meta {
+    flex: 0 0 auto;
+    flex-wrap: nowrap !important;
+    margin-top: 0 !important;
+    justify-content: flex-end;
+}
+
+.song-grid[data-columns="1"] .song-card-meta .badge {
+    max-width: 9.5rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.song-grid[data-columns="2"] .song-card-body {
+    gap: .45rem !important;
+}
+
+.song-grid[data-columns="2"] .song-card-text {
+    flex: 1 1 auto;
+    gap: .5rem;
+}
+
+.song-grid[data-columns="2"] .song-title {
+    flex: 1 1 56%;
+    font-size: 1rem;
+}
+
+.song-grid[data-columns="2"] .song-artist {
+    flex: 1 1 34%;
+    font-size: .9rem;
+}
+
+.song-grid[data-columns="2"] .song-card-meta {
+    flex-wrap: nowrap !important;
+    margin-top: 0 !important;
+}
+
+.song-grid[data-columns="2"] .song-card-meta .badge {
+    max-width: 9rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .stat-badge {
@@ -317,6 +426,29 @@ body {
 
     .app-title {
     font-size: 2rem;
+    }
+
+    .result-controls {
+    align-items: flex-start;
+    flex-direction: column;
+    }
+
+    .song-grid[data-columns="1"] .song-card-body,
+    .song-grid[data-columns="2"] .song-card-body {
+    align-items: stretch;
+    flex-direction: column !important;
+    }
+
+    .song-grid[data-columns="1"] .song-card-text,
+    .song-grid[data-columns="2"] .song-card-text {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: .15rem;
+    }
+
+    .song-grid[data-columns="1"] .song-card-meta {
+    flex-wrap: wrap !important;
+    justify-content: flex-start;
     }
 
     .back-to-top {

--- a/nemupipiano-musiclist-search/css/musiclist-search.css
+++ b/nemupipiano-musiclist-search/css/musiclist-search.css
@@ -208,6 +208,20 @@ body {
     overflow-wrap: anywhere;
 }
 
+.stats-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: .75rem 1rem;
+}
+
+.status-text {
+    flex: 0 1 auto;
+    margin-left: auto;
+    text-align: right;
+}
+
 .song-grid[data-columns="1"] .song-card-body,
 .song-grid[data-columns="2"] .song-card-body {
     padding: .75rem 1rem !important;
@@ -467,6 +481,11 @@ body {
 
     .display-columns {
     display: none;
+    }
+
+    .status-text {
+    margin-left: 0;
+    text-align: left;
     }
 
     .song-grid[data-columns="2"] .song-card-body {

--- a/nemupipiano-musiclist-search/css/musiclist-search.css
+++ b/nemupipiano-musiclist-search/css/musiclist-search.css
@@ -97,21 +97,24 @@ body {
     box-shadow: 0 8px 18px rgba(41, 37, 36, .07);
 }
 
-.search-scope {
+.search-scope,
+.display-columns {
     display: flex;
     flex-wrap: wrap;
     align-items: center;
     gap: .35rem;
 }
 
-.search-scope-label {
+.search-scope-label,
+.display-columns-label {
     color: var(--page-muted);
     font-size: .85rem;
     font-weight: 700;
     margin-right: .15rem;
 }
 
-.search-scope-button {
+.search-scope-button,
+.display-columns-button {
     min-height: 2rem;
     padding: .3rem .75rem;
     border-color: var(--page-line);
@@ -123,13 +126,15 @@ body {
     line-height: 1.2;
 }
 
-.btn-check:checked + .search-scope-button {
+.btn-check:checked + .search-scope-button,
+.btn-check:checked + .display-columns-button {
     border-color: #44403c;
     color: #fff;
     background: #44403c;
 }
 
-.btn-check:focus + .search-scope-button {
+.btn-check:focus + .search-scope-button,
+.btn-check:focus + .display-columns-button {
     box-shadow: 0 0 0 .2rem rgba(68, 64, 60, .18);
 }
 
@@ -248,6 +253,42 @@ body {
     background: #fff;
 }
 
+.back-to-top {
+    position: fixed;
+    right: 1rem;
+    bottom: 4.25rem;
+    z-index: 1070;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 3rem;
+    height: 3rem;
+    border: 1px solid rgba(68, 64, 60, .18);
+    border-radius: 999px;
+    color: #fff;
+    background: #44403c;
+    box-shadow: 0 .75rem 1.5rem rgba(41, 37, 36, .18);
+    font-size: 1.35rem;
+    font-weight: 800;
+    line-height: 1;
+    transition: transform .15s ease, box-shadow .15s ease, background .15s ease;
+}
+
+.back-to-top:hover,
+.back-to-top:focus {
+    background: var(--page-accent);
+    box-shadow: 0 1rem 1.75rem rgba(41, 37, 36, .22);
+    transform: translateY(-2px);
+}
+
+.back-to-top:active {
+    transform: translateY(0);
+}
+
+.back-to-top[hidden] {
+    display: none;
+}
+
 @media (max-width: 575.98px) {
     .app-panel {
     border-radius: 1.1rem;
@@ -276,5 +317,12 @@ body {
 
     .app-title {
     font-size: 2rem;
+    }
+
+    .back-to-top {
+    right: .75rem;
+    bottom: 4rem;
+    width: 2.75rem;
+    height: 2.75rem;
     }
 }

--- a/nemupipiano-musiclist-search/index.html
+++ b/nemupipiano-musiclist-search/index.html
@@ -53,23 +53,25 @@
             <button id="reload" class="btn btn-dark btn-lg" type="button">再読み込み</button>
           </div>
         </div>
-        <div class="search-scope mt-3" role="radiogroup" aria-label="検索対象">
-          <span class="search-scope-label">検索対象</span>
-          <input class="btn-check" type="radio" name="searchScope" id="searchScopeAll" value="all" autocomplete="off" checked>
-          <label class="btn search-scope-button" for="searchScopeAll">すべて</label>
-          <input class="btn-check" type="radio" name="searchScope" id="searchScopeTitle" value="title" autocomplete="off">
-          <label class="btn search-scope-button" for="searchScopeTitle">曲名</label>
-          <input class="btn-check" type="radio" name="searchScope" id="searchScopeArtist" value="artist" autocomplete="off">
-          <label class="btn search-scope-button" for="searchScopeArtist">アーティスト</label>
-        </div>
-        <div class="display-columns mt-2" role="radiogroup" aria-label="表示列">
-          <span class="display-columns-label">表示列</span>
-          <input class="btn-check" type="radio" name="displayColumns" id="displayColumns1" value="1" autocomplete="off">
-          <label class="btn display-columns-button" for="displayColumns1">1列</label>
-          <input class="btn-check" type="radio" name="displayColumns" id="displayColumns2" value="2" autocomplete="off">
-          <label class="btn display-columns-button" for="displayColumns2">2列</label>
-          <input class="btn-check" type="radio" name="displayColumns" id="displayColumns3" value="3" autocomplete="off" checked>
-          <label class="btn display-columns-button" for="displayColumns3">3列</label>
+        <div class="result-controls mt-3">
+          <div class="search-scope" role="radiogroup" aria-label="検索対象">
+            <span class="search-scope-label">検索対象</span>
+            <input class="btn-check" type="radio" name="searchScope" id="searchScopeAll" value="all" autocomplete="off" checked>
+            <label class="btn search-scope-button" for="searchScopeAll">すべて</label>
+            <input class="btn-check" type="radio" name="searchScope" id="searchScopeTitle" value="title" autocomplete="off">
+            <label class="btn search-scope-button" for="searchScopeTitle">曲名</label>
+            <input class="btn-check" type="radio" name="searchScope" id="searchScopeArtist" value="artist" autocomplete="off">
+            <label class="btn search-scope-button" for="searchScopeArtist">アーティスト</label>
+          </div>
+          <div class="display-columns" role="radiogroup" aria-label="表示列">
+            <span class="display-columns-label">表示列</span>
+            <input class="btn-check" type="radio" name="displayColumns" id="displayColumns1" value="1" autocomplete="off">
+            <label class="btn display-columns-button" for="displayColumns1">1列</label>
+            <input class="btn-check" type="radio" name="displayColumns" id="displayColumns2" value="2" autocomplete="off">
+            <label class="btn display-columns-button" for="displayColumns2">2列</label>
+            <input class="btn-check" type="radio" name="displayColumns" id="displayColumns3" value="3" autocomplete="off" checked>
+            <label class="btn display-columns-button" for="displayColumns3">3列</label>
+          </div>
         </div>
 
         <div class="d-flex flex-wrap gap-2 mt-3" id="stats" aria-live="polite"></div>
@@ -475,16 +477,16 @@
       return items.map((song, index) => `
         <div class="col">
           <article class="card song-card h-100" role="button" tabindex="0" data-copy-song="${escapeHtml(song.title)}" data-copy-artist="${escapeHtml(song.artist)}" aria-label="${escapeHtml(song.title)}をリクエスト形式でコピー">
-            <div class="card-body d-flex flex-column gap-2 p-3 p-md-4">
-              <div class="d-flex justify-content-between gap-3 align-items-start">
-                <div class="min-w-0">
+            <div class="card-body song-card-body d-flex flex-column gap-2 p-3 p-md-4">
+              <div class="song-card-header d-flex justify-content-between gap-3 align-items-start">
+                <div class="song-card-text min-w-0">
                   <h2 class="song-title h5 fw-bold mb-1">${escapeHtml(song.title)}</h2>
                   <p class="song-artist mb-0">${escapeHtml(song.artist || "アーティスト未設定")}</p>
                 </div>
-                <span class="text-secondary small flex-shrink-0">#${escapeHtml(song.no || "-")}</span>
+                <span class="song-number text-secondary small flex-shrink-0">#${escapeHtml(song.no || "-")}</span>
               </div>
 
-              <div class="d-flex flex-wrap gap-2 mt-auto">
+              <div class="song-card-meta d-flex flex-wrap gap-2 mt-auto">
                 ${recommended ? `<span class="badge rounded-pill badge-recommend">おすすめ ${index + 1}</span>` : ""}
                 ${song.playable ? `<span class="badge rounded-pill badge-playable">${escapeHtml(song.playable)} 弾ける</span>` : ""}
                 ${song.genre ? `<span class="badge rounded-pill text-bg-light border">${escapeHtml(song.genre)}</span>` : ""}

--- a/nemupipiano-musiclist-search/index.html
+++ b/nemupipiano-musiclist-search/index.html
@@ -74,8 +74,10 @@
           </div>
         </div>
 
-        <div class="d-flex flex-wrap gap-2 mt-3" id="stats" aria-live="polite"></div>
-        <p class="status-text mt-3 mb-0" id="status">読み込み中…</p>
+        <div class="stats-row mt-3">
+          <div class="d-flex flex-wrap gap-2" id="stats" aria-live="polite"></div>
+          <p class="status-text mb-0" id="status">読み込み中…</p>
+        </div>
         <div class="row row-cols-1 row-cols-md-2 row-cols-xl-3 g-3 mt-1 song-grid" id="songs" data-columns="3"></div>
         <div class="empty-box text-center p-4 mt-3" id="empty" hidden>条件に合う曲が見つかりませんでした。</div>
       </section>

--- a/nemupipiano-musiclist-search/index.html
+++ b/nemupipiano-musiclist-search/index.html
@@ -138,7 +138,7 @@
   </div>
 
   <footer class="site-footer fixed-bottom mx-0 bg-black bg-opacity-75 text-center text-white">
-    <p>ver.1.2.0 問題点を見つけたら<a href="https://x.com/bonga_bon_bonga">X(旧Twitter)</a>にご連絡ください。</p>
+    <p>ver.1.3.0 問題点を見つけたら<a href="https://x.com/bonga_bon_bonga">X(旧Twitter)</a>にご連絡ください。</p>
   </footer>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"

--- a/nemupipiano-musiclist-search/index.html
+++ b/nemupipiano-musiclist-search/index.html
@@ -501,14 +501,12 @@
 
     function render() {
       const items = filteredSongs();
-      const playableCount = songs.filter(isPlayable).length;
       const genreCount = new Set(songs.map(song => song.genre).filter(Boolean)).size;
 
       els.stats.innerHTML = `
-        <span class="badge rounded-pill stat-badge px-3 py-2">全<strong>${songs.length}</strong>曲</span>
-        <button class="badge rounded-pill stat-badge stat-filter-button px-3 py-2 ${playableOnly ? "active" : ""}" type="button" data-filter="playable" aria-pressed="${playableOnly}">弾ける曲<strong>${playableCount}</strong>曲</button>
+        <span class="badge rounded-pill stat-badge px-3 py-2">全曲数：<strong>${songs.length}</strong> 表示中：<strong>${items.length}</strong></span>
         <span class="badge rounded-pill stat-badge px-3 py-2">ジャンル<strong>${genreCount}</strong>種</span>
-        <span class="badge rounded-pill stat-badge px-3 py-2">表示中<strong>${items.length}</strong>曲</span>
+        <button class="badge rounded-pill stat-badge stat-filter-button px-3 py-2 ${playableOnly ? "active" : ""}" type="button" data-filter="playable" aria-pressed="${playableOnly}">弾ける曲：<strong>${playableOnly ? "ON" : "OFF"}</strong></button>
       `;
 
       els.empty.hidden = items.length !== 0;

--- a/nemupipiano-musiclist-search/index.html
+++ b/nemupipiano-musiclist-search/index.html
@@ -39,18 +39,18 @@
 
       <section class="tab-panel" id="panel-search" role="tabpanel" aria-labelledby="tab-search">
         <div class="row g-2 g-md-3 align-items-stretch">
-          <div class="col-12 col-md-6">
+          <div class="col-12 col-md-7">
             <label class="visually-hidden" for="search">検索キーワード</label>
             <input id="search" class="form-control form-control-lg" type="search" placeholder="曲名・アーティストで検索" autocomplete="off" />
           </div>
-          <div class="col-12 col-md-4">
+          <div class="col-12 col-md-3">
             <label class="visually-hidden" for="genre">ジャンル</label>
             <select id="genre" class="form-select form-select-lg">
               <option value="">すべてのジャンル</option>
             </select>
           </div>
           <div class="col-12 col-md-2 d-grid">
-            <button id="reload" class="btn btn-dark btn-lg" type="button">再読み込み</button>
+            <button id="reload" class="btn btn-dark btn-lg reload-button" type="button">再読み込み</button>
           </div>
         </div>
         <div class="result-controls mt-3">

--- a/nemupipiano-musiclist-search/index.html
+++ b/nemupipiano-musiclist-search/index.html
@@ -118,7 +118,7 @@
             2. ジャンルを選ぶと、対象ジャンルの曲だけに絞り込めます。<br>
             3. <strong>ランダム表示</strong>タブでは、曲リストからランダムに10曲を表示します。<br>
             4. 曲カードをクリックすると、下記の形式でクリップボードにコピーされます。<br>
-            <span class="d-inline-block mt-2 px-2 py-1 bg-light border rounded text-break">【ぴぴりく】&lt;曲名&gt;／&lt;アーティスト&gt;</span><br>
+            <span class="d-inline-block mt-2 px-2 py-1 bg-light border rounded text-break">【ぴぴりく】&lt;曲番号&gt;.&lt;曲名&gt;／&lt;アーティスト&gt;</span><br>
             5. コピー後は画面上部に、コピーした文字列が2秒ほど表示されます。
           </p>
           <hr>

--- a/nemupipiano-musiclist-search/index.html
+++ b/nemupipiano-musiclist-search/index.html
@@ -62,10 +62,19 @@
           <input class="btn-check" type="radio" name="searchScope" id="searchScopeArtist" value="artist" autocomplete="off">
           <label class="btn search-scope-button" for="searchScopeArtist">アーティスト</label>
         </div>
+        <div class="display-columns mt-2" role="radiogroup" aria-label="表示列">
+          <span class="display-columns-label">表示列</span>
+          <input class="btn-check" type="radio" name="displayColumns" id="displayColumns1" value="1" autocomplete="off">
+          <label class="btn display-columns-button" for="displayColumns1">1列</label>
+          <input class="btn-check" type="radio" name="displayColumns" id="displayColumns2" value="2" autocomplete="off">
+          <label class="btn display-columns-button" for="displayColumns2">2列</label>
+          <input class="btn-check" type="radio" name="displayColumns" id="displayColumns3" value="3" autocomplete="off" checked>
+          <label class="btn display-columns-button" for="displayColumns3">3列</label>
+        </div>
 
         <div class="d-flex flex-wrap gap-2 mt-3" id="stats" aria-live="polite"></div>
         <p class="status-text mt-3 mb-0" id="status">読み込み中…</p>
-        <div class="row row-cols-1 row-cols-md-2 row-cols-xl-3 g-3 mt-1" id="songs"></div>
+        <div class="row row-cols-1 row-cols-md-2 row-cols-xl-3 g-3 mt-1 song-grid" id="songs" data-columns="3"></div>
         <div class="empty-box text-center p-4 mt-3" id="empty" hidden>条件に合う曲が見つかりませんでした。</div>
       </section>
 
@@ -80,7 +89,7 @@
           </div>
         </div>
         <div class="d-flex flex-wrap gap-2 mt-3" id="randomStats" aria-live="polite"></div>
-        <div class="row row-cols-1 row-cols-md-2 row-cols-xl-3 g-3 mt-1" id="randomSongs"></div>
+        <div class="row row-cols-1 row-cols-md-2 row-cols-xl-3 g-3 mt-1 song-grid" id="randomSongs" data-columns="3"></div>
         <div class="empty-box text-center p-4 mt-3" id="randomEmpty" hidden>おすすめできる曲がまだ読み込まれていません。</div>
       </section>
     </section>
@@ -141,6 +150,10 @@
     <p>ver.1.3.0 問題点を見つけたら<a href="https://x.com/bonga_bon_bonga">X(旧Twitter)</a>にご連絡ください。</p>
   </footer>
 
+  <button id="backToTop" class="back-to-top" type="button" aria-label="TOPへ戻る" hidden>
+    <span aria-hidden="true">↑</span>
+  </button>
+
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"
     integrity="sha384-geWF76RCwLtnZ8qwWowPQNguL3RmwHVBC9FhGdlKrxdiJJigb/j/68SIy3Te4Bkz" crossorigin="anonymous"></script>
 
@@ -153,6 +166,7 @@
     const els = {
       search: document.getElementById("search"),
       searchScopes: document.querySelectorAll("[name='searchScope']"),
+      displayColumns: document.querySelectorAll("[name='displayColumns']"),
       genre: document.getElementById("genre"),
       reload: document.getElementById("reload"),
       status: document.getElementById("status"),
@@ -166,12 +180,14 @@
       tabs: document.querySelectorAll("[data-tab]"),
       panels: document.querySelectorAll(".tab-panel"),
       copyToast: document.getElementById("copyToast"),
+      backToTop: document.getElementById("backToTop"),
     };
 
     let songs = [];
     let recommendedSongs = [];
     let musiclistItems = {};
     let playableOnly = false;
+    let displayColumnCount = "3";
 
     // HTMLエスケープを行う関数。& < > " ' をそれぞれ対応するHTMLエンティティに置換する。nullやundefinedも空文字に変換する。
     function escapeHtml(value) {
@@ -439,6 +455,21 @@
       recommendedSongs = source.slice(0, RANDOM_COUNT);
     }
 
+    function gridClassesForColumns(columns) {
+      if (columns === "1") return "row row-cols-1 g-3 mt-1 song-grid";
+      if (columns === "2") return "row row-cols-1 row-cols-md-2 g-3 mt-1 song-grid";
+      return "row row-cols-1 row-cols-md-2 row-cols-xl-3 g-3 mt-1 song-grid";
+    }
+
+    function applyColumnLayout() {
+      const gridClassName = gridClassesForColumns(displayColumnCount);
+
+      [els.songs, els.randomSongs].forEach(grid => {
+        grid.className = gridClassName;
+        grid.dataset.columns = displayColumnCount;
+      });
+    }
+
     function renderSongCards(items, options = {}) {
       const { recommended = false } = options;
       return items.map((song, index) => `
@@ -564,8 +595,18 @@
       });
     }
 
+    function updateBackToTopVisibility() {
+      els.backToTop.hidden = window.scrollY < 320;
+    }
+
     els.search.addEventListener("input", render);
     els.searchScopes.forEach(scope => scope.addEventListener("change", render));
+    els.displayColumns.forEach(column => {
+      column.addEventListener("change", () => {
+        displayColumnCount = column.value;
+        applyColumnLayout();
+      });
+    });
     els.genre.addEventListener("change", render);
     els.stats.addEventListener("click", (event) => {
       const button = event.target.closest("[data-filter='playable']");
@@ -579,6 +620,10 @@
       pickRandomSongs();
       renderRandom();
     });
+    els.backToTop.addEventListener("click", () => {
+      window.scrollTo({ top: 0, behavior: "smooth" });
+    });
+    window.addEventListener("scroll", updateBackToTopVisibility, { passive: true });
 
     document.addEventListener("click", (event) => {
       const card = event.target.closest("[data-copy-song]");
@@ -598,6 +643,8 @@
       tab.addEventListener("click", () => switchTab(tab.dataset.tab));
     });
 
+    applyColumnLayout();
+    updateBackToTopVisibility();
     loadSheet();
   </script>
 </body>

--- a/nemupipiano-musiclist-search/index.html
+++ b/nemupipiano-musiclist-search/index.html
@@ -476,7 +476,7 @@
       const { recommended = false } = options;
       return items.map((song, index) => `
         <div class="col">
-          <article class="card song-card h-100" role="button" tabindex="0" data-copy-song="${escapeHtml(song.title)}" data-copy-artist="${escapeHtml(song.artist)}" aria-label="${escapeHtml(song.title)}をリクエスト形式でコピー">
+          <article class="card song-card h-100" role="button" tabindex="0" data-copy-song="${escapeHtml(song.title)}" data-copy-artist="${escapeHtml(song.artist)}" data-copy-no="${escapeHtml(song.no)}" aria-label="${escapeHtml(song.title)}をリクエスト形式でコピー">
             <div class="card-body song-card-body d-flex flex-column gap-2 p-3 p-md-4">
               <div class="song-card-header d-flex justify-content-between gap-3 align-items-start">
                 <div class="song-card-text min-w-0">
@@ -526,9 +526,11 @@
     }
 
     function requestText(song) {
+      const no = String(song.no || "").trim();
       const title = String(song.title || "").trim();
       const artist = String(song.artist || "").trim();
-      return `【ぴぴりく】${title}／${artist || "アーティスト未設定"}`;
+      const noPrefix = no ? `${no}.` : "";
+      return `【ぴぴりく】${noPrefix}${title}／${artist || "アーティスト未設定"}`;
     }
 
     async function copyToClipboard(text) {
@@ -571,9 +573,10 @@
     }
 
     async function handleCardCopy(card) {
+      const no = card.dataset.copyNo || "";
       const title = card.dataset.copySong || "";
       const artist = card.dataset.copyArtist || "";
-      const text = requestText({ title, artist });
+      const text = requestText({ no, title, artist });
 
       try {
         await copyToClipboard(text);


### PR DESCRIPTION
## PR #18 修正内容まとめ

### 表示列切り替え機能
- 検索結果カードの表示列を `1列 / 2列 / 3列` から選択できるように変更
- 検索結果一覧とランダム表示一覧の両方に表示列設定を反映
- スマホ幅ではレスポンシブにより1列表示となるため、`表示列` 選択項目を非表示化

### カード表示の調整
- 1列表示時はカード内情報をコンパクトに表示
- 2列表示時もカード高さを抑えるように調整
- 1列表示時に右側バッジの有無でアーティスト名の位置がズレないよう、固定カラムレイアウトに変更
- スマホ幅を少し超えた幅でもカード内容が横にはみ出さないよう、狭い画面では縦積み表示に切り替え

### TOPへ戻るボタン
- ページを下にスクロールした際、画面右下に `TOPへ戻る` ボタンを表示
- クリック時にページ最上部へスムーズスクロール

### コピー形式の変更
- カードクリック時にクリップボードへコピーする文面を変更

変更前:

```text
【ぴぴりく】<曲名>／<アーティスト>
```

変更後:

```text
【ぴぴりく】<No>.<曲名>／<アーティスト>
```

例:

```text
【ぴぴりく】100.曲名／アーティスト
```

### ヘッダー説明文のモバイル調整
- スマホ幅の場合、ページ上部の説明文フォントを小さく調整
- 長文が画面幅内で読みやすくなるよう行間も調整

### 統計バッジの表示変更
- `全○○曲` と `表示中○○曲` を1つのバッジに統合

```text
全曲数：915 表示中：915
```

- `弾ける曲154曲` を曲数なしのON/OFF表示に変更

```text
弾ける曲：ON
弾ける曲：OFF
```

- `弾ける曲` バッジを統計バッジ群の一番右へ移動

### 読み込みステータスの位置変更
- `読み込み完了` の表示位置を、統計バッジ行の右側へ移動
- スマホ幅では折り返し時に左寄せになるよう調整

### 検索フォーム幅の調整
- `曲名・アーティストで検索` と `すべてのジャンル` の幅比率を変更
- 変更前: `6 : 4`
- 変更後: `7 : 3`
- `再読み込み` ボタンのフォントを少し小さくし、狭い幅でも改行されにくいよう調整