### PR TITLE
スマホ表示幅の微修正

### DIFF
--- a/nemupipiano-musiclist-search/css/musiclist-search.css
+++ b/nemupipiano-musiclist-search/css/musiclist-search.css
@@ -503,9 +503,9 @@ body {
     .song-grid[data-columns="2"] .song-card-body,
     .song-grid[data-columns="3"] .song-card-body {
     display: grid !important;
-    grid-template-columns: minmax(0, 1.25fr) minmax(0, .85fr) auto;
-    align-items: center;
-    gap: .25rem .55rem !important;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+    gap: .2rem .5rem !important;
     padding: .65rem .75rem !important;
     }
 
@@ -537,27 +537,67 @@ body {
     white-space: nowrap;
     }
 
-    .song-title {
+    .song-title,
+    .song-grid[data-columns="1"] .song-title,
+    .song-grid[data-columns="2"] .song-title,
+    .song-grid[data-columns="3"] .song-title {
+    display: -webkit-box;
+    grid-column: 1;
+    grid-row: 1;
     font-size: 1rem;
     line-height: 1.25;
+    overflow-wrap: anywhere;
+    white-space: normal;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
     }
 
-    .song-artist {
+    .song-artist,
+    .song-grid[data-columns="1"] .song-artist,
+    .song-grid[data-columns="2"] .song-artist,
+    .song-grid[data-columns="3"] .song-artist {
+    grid-column: 1;
+    grid-row: 2;
     font-size: .85rem;
     line-height: 1.25;
     }
 
-    .song-number {
-    align-self: center;
+    .song-number,
+    .song-grid[data-columns="1"] .song-number,
+    .song-grid[data-columns="2"] .song-number,
+    .song-grid[data-columns="3"] .song-number {
+    align-self: start;
+    grid-column: 2;
+    grid-row: 1;
     font-size: .8rem;
     line-height: 1;
+    padding-top: .15rem;
     }
 
     .song-card-meta,
     .song-grid[data-columns="1"] .song-card-meta,
     .song-grid[data-columns="2"] .song-card-meta,
     .song-grid[data-columns="3"] .song-card-meta {
-    display: none !important;
+    display: inline-flex !important;
+    flex-wrap: wrap !important;
+    grid-column: 2;
+    grid-row: 2;
+    justify-content: flex-end;
+    gap: .2rem !important;
+    margin-top: 0 !important;
+    min-width: 0;
+    }
+
+    .song-card-meta .badge,
+    .song-grid[data-columns="1"] .song-card-meta .badge,
+    .song-grid[data-columns="2"] .song-card-meta .badge,
+    .song-grid[data-columns="3"] .song-card-meta .badge {
+    max-width: 5.25rem;
+    overflow: hidden;
+    padding: .2rem .45rem;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: .72rem;
     }
 
     .back-to-top {

--- a/nemupipiano-musiclist-search/index.html
+++ b/nemupipiano-musiclist-search/index.html
@@ -151,7 +151,7 @@
   </div>
 
   <footer class="site-footer fixed-bottom mx-0 bg-black bg-opacity-75 text-center text-white">
-    <p>ver.1.4.0 問題点を見つけたら<a href="https://x.com/bonga_bon_bonga">X(旧Twitter)</a>にご連絡ください。</p>
+    <p>ver.1.4.1 問題点を見つけたら<a href="https://x.com/bonga_bon_bonga">X(旧Twitter)</a>にご連絡ください。</p>
   </footer>
 
   <button id="backToTop" class="back-to-top" type="button" aria-label="TOPへ戻る" hidden>

--- a/nemupipiano-musiclist-search/index.html
+++ b/nemupipiano-musiclist-search/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="../lib/css/bootstrap-reboot.min.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
       integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous">
-  <link rel="stylesheet" href="./css/musiclist-search.css?v=1.4.0" />
+  <link rel="stylesheet" href="./css/musiclist-search.css?v=1.4.1" />
 </head>
 <body>
   <nav class="navbar navbar-expand-md navbar-dark bg-dark fixed-top">


### PR DESCRIPTION
## PR #21: スマホ表示幅の微修正

- PR #20 の1行表示が詰まりすぎていたため、スマホ幅カードを2列・2段構成に変更
- 1段目に `曲名 / No` を表示
- 2段目に `アーティスト / 弾ける・ジャンルのバッジ` を表示
- 曲名は最大2行まで表示できるよう調整
- 行間・項目間の余白をやや詰めた状態で維持
- CSS キャッシュバスターを `1.4.1` に更新