### PR TITLE
スマホ表示微修正その２

### DIFF
--- a/nemupipiano-musiclist-search/css/musiclist-search.css
+++ b/nemupipiano-musiclist-search/css/musiclist-search.css
@@ -480,6 +480,11 @@ body {
     line-height: 1.55;
     }
 
+    .site-footer p {
+    font-size: .75rem;
+    line-height: 1.25;
+    }
+
     .result-controls {
     align-items: flex-start;
     flex-direction: column;

--- a/nemupipiano-musiclist-search/css/musiclist-search.css
+++ b/nemupipiano-musiclist-search/css/musiclist-search.css
@@ -507,6 +507,7 @@ body {
     align-items: start;
     gap: .2rem .5rem !important;
     padding: .65rem .75rem !important;
+    position: relative;
     }
 
     .song-card-header,
@@ -542,11 +543,12 @@ body {
     .song-grid[data-columns="2"] .song-title,
     .song-grid[data-columns="3"] .song-title {
     display: -webkit-box;
-    grid-column: 1;
+    grid-column: 1 / -1;
     grid-row: 1;
     font-size: 1rem;
     line-height: 1.25;
     overflow-wrap: anywhere;
+    padding-right: 3.25rem;
     white-space: normal;
     -webkit-box-orient: vertical;
     -webkit-line-clamp: 2;
@@ -567,11 +569,12 @@ body {
     .song-grid[data-columns="2"] .song-number,
     .song-grid[data-columns="3"] .song-number {
     align-self: start;
-    grid-column: 2;
-    grid-row: 1;
     font-size: .8rem;
     line-height: 1;
+    position: absolute;
     padding-top: .15rem;
+    right: .75rem;
+    top: .65rem;
     }
 
     .song-card-meta,

--- a/nemupipiano-musiclist-search/css/musiclist-search.css
+++ b/nemupipiano-musiclist-search/css/musiclist-search.css
@@ -64,6 +64,18 @@ body {
     border-radius: 1.5rem;
 }
 
+.app-panel.font-size-small {
+    font-size: .9rem;
+}
+
+.app-panel.font-size-medium {
+    font-size: 1rem;
+}
+
+.app-panel.font-size-large {
+    font-size: 1.1rem;
+}
+
 .nav-pills.app-tabs {
     display: flex;
     flex-direction: row;
@@ -372,6 +384,27 @@ body {
     border: 1px solid #bbf7d0;
 }
 
+.setting-options {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: .45rem;
+}
+
+.setting-option-button {
+    min-width: 3.5rem;
+    border-color: var(--page-line);
+    border-radius: .5rem;
+    color: var(--page-muted);
+    background: #f5f5f4;
+    font-weight: 800;
+}
+
+.btn-check:checked + .setting-option-button {
+    border-color: #44403c;
+    color: #fff;
+    background: #44403c;
+}
+
 .empty-box {
     color: var(--page-muted);
     border: 1px dashed var(--page-line);
@@ -379,9 +412,9 @@ body {
     background: #fff;
 }
 
-.back-to-top {
+.back-to-top,
+.settings-button {
     position: fixed;
-    right: 1rem;
     bottom: 4.25rem;
     z-index: 1070;
     display: inline-flex;
@@ -391,23 +424,36 @@ body {
     height: 3rem;
     border: 1px solid rgba(68, 64, 60, .18);
     border-radius: 999px;
+    padding: 0;
     color: #fff;
     background: #44403c;
     box-shadow: 0 .75rem 1.5rem rgba(41, 37, 36, .18);
+    cursor: pointer;
     font-size: 1.35rem;
     font-weight: 800;
     line-height: 1;
     transition: transform .15s ease, box-shadow .15s ease, background .15s ease;
 }
 
+.back-to-top {
+    right: 1rem;
+}
+
+.settings-button {
+    left: 1rem;
+}
+
 .back-to-top:hover,
-.back-to-top:focus {
+.back-to-top:focus,
+.settings-button:hover,
+.settings-button:focus {
     background: var(--page-accent);
     box-shadow: 0 1rem 1.75rem rgba(41, 37, 36, .22);
     transform: translateY(-2px);
 }
 
-.back-to-top:active {
+.back-to-top:active,
+.settings-button:active {
     transform: translateY(0);
 }
 
@@ -608,4 +654,35 @@ body {
     width: 2.75rem;
     height: 2.75rem;
     }
+
+    .settings-button {
+    left: .75rem;
+    bottom: 4rem;
+    width: 2.75rem;
+    height: 2.75rem;
+    }
+}
+
+.app-panel.font-size-small .form-control,
+.app-panel.font-size-small .form-select,
+.app-panel.font-size-small .btn,
+.app-panel.font-size-small .badge,
+.app-panel.font-size-small .song-title,
+.app-panel.font-size-small .song-artist,
+.app-panel.font-size-small .song-number,
+.app-panel.font-size-small .status-text,
+.app-panel.font-size-small .recommend-desc {
+    font-size: .9rem !important;
+}
+
+.app-panel.font-size-large .form-control,
+.app-panel.font-size-large .form-select,
+.app-panel.font-size-large .btn,
+.app-panel.font-size-large .badge,
+.app-panel.font-size-large .song-title,
+.app-panel.font-size-large .song-artist,
+.app-panel.font-size-large .song-number,
+.app-panel.font-size-large .status-text,
+.app-panel.font-size-large .recommend-desc {
+    font-size: 1.1rem !important;
 }

--- a/nemupipiano-musiclist-search/css/musiclist-search.css
+++ b/nemupipiano-musiclist-search/css/musiclist-search.css
@@ -372,12 +372,6 @@ body {
     border: 1px solid #bbf7d0;
 }
 
-.badge-recommend {
-    color: var(--page-accent);
-    background: var(--page-accent-soft);
-    border: 1px solid #fed7aa;
-}
-
 .empty-box {
     color: var(--page-muted);
     border: 1px dashed var(--page-line);

--- a/nemupipiano-musiclist-search/index.html
+++ b/nemupipiano-musiclist-search/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="../lib/css/bootstrap-reboot.min.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
       integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous">
-  <link rel="stylesheet" href="./css/musiclist-search.css?v=1.4.1" />
+  <link rel="stylesheet" href="./css/musiclist-search.css?v=1.4.2" />
 </head>
 <body>
   <nav class="navbar navbar-expand-md navbar-dark bg-dark fixed-top">

--- a/nemupipiano-musiclist-search/index.html
+++ b/nemupipiano-musiclist-search/index.html
@@ -191,6 +191,7 @@
     let recommendedSongs = [];
     let musiclistItems = {};
     let playableOnly = false;
+    let randomPlayableOnly = true;
     let displayColumnCount = "3";
 
     // HTMLエスケープを行う関数。& < > " ' をそれぞれ対応するHTMLエンティティに置換する。nullやundefinedも空文字に変換する。
@@ -445,9 +446,9 @@
     }
 
     function getRecommendSource() {
-      // 「弾ける曲」印がある曲を優先。10曲未満なら全曲からランダムにする。
-      const playableSongs = songs.filter(isPlayable);
-      return playableSongs.length >= RANDOM_COUNT ? playableSongs : songs;
+      if (!randomPlayableOnly) return songs;
+
+      return songs.filter(isPlayable);
     }
 
     function pickRandomSongs() {
@@ -510,10 +511,8 @@
     }
 
     function renderRandom() {
-      const recommendLabel = songs.filter(isPlayable).length >= RANDOM_COUNT ? "弾ける曲から選出" : "全曲から選出";
-
       els.randomStats.innerHTML = `
-        <span class="badge rounded-pill stat-badge px-3 py-2">方式：<strong>${recommendLabel}</strong></span>
+        <button class="badge rounded-pill stat-badge stat-filter-button px-3 py-2 ${randomPlayableOnly ? "active" : ""}" type="button" data-random-filter="playable" aria-pressed="${randomPlayableOnly}">弾ける曲：<strong>${randomPlayableOnly ? "ON" : "OFF"}</strong></button>
       `;
 
       els.randomEmpty.hidden = recommendedSongs.length !== 0;
@@ -614,6 +613,14 @@
 
       playableOnly = !playableOnly;
       render();
+    });
+    els.randomStats.addEventListener("click", (event) => {
+      const button = event.target.closest("[data-random-filter='playable']");
+      if (!button) return;
+
+      randomPlayableOnly = !randomPlayableOnly;
+      pickRandomSongs();
+      renderRandom();
     });
     els.reload.addEventListener("click", loadSheet);
     els.shuffle.addEventListener("click", () => {

--- a/nemupipiano-musiclist-search/index.html
+++ b/nemupipiano-musiclist-search/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="../lib/css/bootstrap-reboot.min.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
       integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous">
-  <link rel="stylesheet" href="./css/musiclist-search.css?v=1.4.2" />
+  <link rel="stylesheet" href="./css/musiclist-search.css?v=1.4.3" />
 </head>
 <body>
   <nav class="navbar navbar-expand-md navbar-dark bg-dark fixed-top">
@@ -23,7 +23,7 @@
       </p>
     </header>
 
-    <section class="app-panel p-3 p-md-4" aria-label="曲リスト">
+    <section class="app-panel font-size-medium p-3 p-md-4" id="appPanel" aria-label="曲リスト">
       <ul class="nav nav-pills app-tabs mb-4" id="songTabs" role="tablist">
         <li class="nav-item" role="presentation">
           <button class="nav-link active" id="tab-search" type="button" role="tab" aria-selected="true" aria-controls="panel-search" data-tab="search">
@@ -138,6 +138,28 @@
     </div>
   </div>
 
+  <div class="modal fade" id="settingsModal" tabindex="-1" aria-labelledby="settingsModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="settingsModalLabel">設定</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <h5>文字の大きさ</h5>
+          <div class="setting-options" role="radiogroup" aria-label="文字の大きさ">
+            <input class="btn-check" type="radio" name="panelFontSize" id="fontSizeSmall" value="small" autocomplete="off">
+            <label class="btn setting-option-button" for="fontSizeSmall">小</label>
+            <input class="btn-check" type="radio" name="panelFontSize" id="fontSizeMedium" value="medium" autocomplete="off" checked>
+            <label class="btn setting-option-button" for="fontSizeMedium">中</label>
+            <input class="btn-check" type="radio" name="panelFontSize" id="fontSizeLarge" value="large" autocomplete="off">
+            <label class="btn setting-option-button" for="fontSizeLarge">大</label>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <div class="copy-toast-container">
     <div id="copyToast" class="toast text-bg-dark border-0" role="status" aria-live="polite" aria-atomic="true" data-bs-delay="2000">
       <div class="d-flex align-items-start">
@@ -151,11 +173,14 @@
   </div>
 
   <footer class="site-footer fixed-bottom mx-0 bg-black bg-opacity-75 text-center text-white">
-    <p>ver.1.4.2 問題点を見つけたら<a href="https://x.com/bonga_bon_bonga">X(旧Twitter)</a>にご連絡ください。</p>
+    <p>ver.1.4.3 問題点を見つけたら<a href="https://x.com/bonga_bon_bonga">X(旧Twitter)</a>にご連絡ください。</p>
   </footer>
 
   <button id="backToTop" class="back-to-top" type="button" aria-label="TOPへ戻る" hidden>
     <span aria-hidden="true">↑</span>
+  </button>
+  <button id="settingsButton" class="settings-button" type="button" aria-label="設定" data-bs-toggle="modal" data-bs-target="#settingsModal">
+    <span aria-hidden="true">&#9881;</span>
   </button>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"
@@ -166,6 +191,7 @@
     const GID = "0";
     const MUSICLIST_JSON_PATH = "./data/musiclist.json";
     const RANDOM_COUNT = 10;
+    const APP_PANEL_FONT_SIZE_KEY = "nemupipiano:appPanelFontSize";
 
     const els = {
       search: document.getElementById("search"),
@@ -185,6 +211,8 @@
       panels: document.querySelectorAll(".tab-panel"),
       copyToast: document.getElementById("copyToast"),
       backToTop: document.getElementById("backToTop"),
+      appPanel: document.getElementById("appPanel"),
+      panelFontSizes: document.querySelectorAll("[name='panelFontSize']"),
     };
 
     let songs = [];
@@ -598,6 +626,16 @@
       els.backToTop.hidden = window.scrollY < 320;
     }
 
+    function applyAppPanelFontSize(size) {
+      const normalized = ["small", "medium", "large"].includes(size) ? size : "medium";
+      els.appPanel.classList.remove("font-size-small", "font-size-medium", "font-size-large");
+      els.appPanel.classList.add(`font-size-${normalized}`);
+      els.panelFontSizes.forEach(option => {
+        option.checked = option.value === normalized;
+      });
+      localStorage.setItem(APP_PANEL_FONT_SIZE_KEY, normalized);
+    }
+
     els.search.addEventListener("input", render);
     els.searchScopes.forEach(scope => scope.addEventListener("change", render));
     els.displayColumns.forEach(column => {
@@ -630,6 +668,9 @@
     els.backToTop.addEventListener("click", () => {
       window.scrollTo({ top: 0, behavior: "smooth" });
     });
+    els.panelFontSizes.forEach(option => {
+      option.addEventListener("change", () => applyAppPanelFontSize(option.value));
+    });
     window.addEventListener("scroll", updateBackToTopVisibility, { passive: true });
 
     document.addEventListener("click", (event) => {
@@ -651,6 +692,7 @@
     });
 
     applyColumnLayout();
+    applyAppPanelFontSize(localStorage.getItem(APP_PANEL_FONT_SIZE_KEY));
     updateBackToTopVisibility();
     loadSheet();
   </script>

--- a/nemupipiano-musiclist-search/index.html
+++ b/nemupipiano-musiclist-search/index.html
@@ -474,9 +474,8 @@
       });
     }
 
-    function renderSongCards(items, options = {}) {
-      const { recommended = false } = options;
-      return items.map((song, index) => `
+    function renderSongCards(items) {
+      return items.map(song => `
         <div class="col">
           <article class="card song-card h-100" role="button" tabindex="0" data-copy-song="${escapeHtml(song.title)}" data-copy-artist="${escapeHtml(song.artist)}" data-copy-no="${escapeHtml(song.no)}" aria-label="${escapeHtml(song.title)}をリクエスト形式でコピー">
             <div class="card-body song-card-body d-flex flex-column gap-2 p-3 p-md-4">
@@ -489,7 +488,6 @@
               </div>
 
               <div class="song-card-meta d-flex flex-wrap gap-2 mt-auto">
-                ${recommended ? `<span class="badge rounded-pill badge-recommend">おすすめ ${index + 1}</span>` : ""}
                 ${song.playable ? `<span class="badge rounded-pill badge-playable">${escapeHtml(song.playable)} 弾ける</span>` : ""}
                 ${song.genre ? `<span class="badge rounded-pill text-bg-light border">${escapeHtml(song.genre)}</span>` : ""}
               </div>
@@ -501,11 +499,9 @@
 
     function render() {
       const items = filteredSongs();
-      const genreCount = new Set(songs.map(song => song.genre).filter(Boolean)).size;
 
       els.stats.innerHTML = `
         <span class="badge rounded-pill stat-badge px-3 py-2">全曲数：<strong>${songs.length}</strong> 表示中：<strong>${items.length}</strong></span>
-        <span class="badge rounded-pill stat-badge px-3 py-2">ジャンル<strong>${genreCount}</strong>種</span>
         <button class="badge rounded-pill stat-badge stat-filter-button px-3 py-2 ${playableOnly ? "active" : ""}" type="button" data-filter="playable" aria-pressed="${playableOnly}">弾ける曲：<strong>${playableOnly ? "ON" : "OFF"}</strong></button>
       `;
 
@@ -517,12 +513,11 @@
       const recommendLabel = songs.filter(isPlayable).length >= RANDOM_COUNT ? "弾ける曲から選出" : "全曲から選出";
 
       els.randomStats.innerHTML = `
-        <span class="badge rounded-pill stat-badge px-3 py-2">おすすめ<strong>${recommendedSongs.length}</strong>曲</span>
         <span class="badge rounded-pill stat-badge px-3 py-2">方式：<strong>${recommendLabel}</strong></span>
       `;
 
       els.randomEmpty.hidden = recommendedSongs.length !== 0;
-      els.randomSongs.innerHTML = renderSongCards(recommendedSongs, { recommended: true });
+      els.randomSongs.innerHTML = renderSongCards(recommendedSongs);
     }
 
     function requestText(song) {

--- a/nemupipiano-musiclist-search/index.html
+++ b/nemupipiano-musiclist-search/index.html
@@ -151,7 +151,7 @@
   </div>
 
   <footer class="site-footer fixed-bottom mx-0 bg-black bg-opacity-75 text-center text-white">
-    <p>ver.1.4.1 問題点を見つけたら<a href="https://x.com/bonga_bon_bonga">X(旧Twitter)</a>にご連絡ください。</p>
+    <p>ver.1.4.2 問題点を見つけたら<a href="https://x.com/bonga_bon_bonga">X(旧Twitter)</a>にご連絡ください。</p>
   </footer>
 
   <button id="backToTop" class="back-to-top" type="button" aria-label="TOPへ戻る" hidden>


### PR DESCRIPTION
## PR #22: スマホ表示微修正その2

- 曲番号をスマホカード右上に固定し、バッジ幅の影響を受けないよう修正
- 曲名の折り返し幅がバッジ幅に影響されないよう、曲名をカード全幅基準に変更
- スマホ幅のみフッター文字サイズを縮小し、折り返しを抑制
- 統計バッジの `ジャンル○種` を削除
- ランダム表示の `おすすめ` バッジを削除
- ランダム表示の `方式：弾ける曲から選出` を `弾ける曲：ON/OFF` ボタン化
- ランダム表示で `弾ける曲のみ / 全曲` を切り替えて再抽選できるよう修正
- 画面左下に `設定` アイコンを追加
- 設定モーダルを追加
- 設定モーダル内に `文字の大きさ 小 / 中 / 大` を追加
- 文字サイズ設定を `.app-panel` 内に適用
- 文字サイズ設定を `localStorage` に保存し、再読み込み後も維持
- CSS キャッシュバスターと表示バージョンを `1.4.3` に更新