### PR TITLE
文字の大きさに関する設定の修正

### DIFF
--- a/nemupipiano-musiclist-search/css/musiclist-search.css
+++ b/nemupipiano-musiclist-search/css/musiclist-search.css
@@ -146,7 +146,6 @@ body {
     border-radius: .45rem;
     color: var(--page-muted);
     background: #f5f5f4;
-    font-size: .875rem;
     font-weight: 800;
     line-height: 1.2;
 }
@@ -390,16 +389,25 @@ body {
     gap: .45rem;
 }
 
-.setting-option-button {
+.setting-option-button,
+.display-columns-button {
     min-width: 3.5rem;
     border-color: var(--page-line);
     border-radius: .5rem;
     color: var(--page-muted);
     background: #f5f5f4;
+    font-size: 1rem;
     font-weight: 800;
 }
 
-.btn-check:checked + .setting-option-button {
+.setting-note {
+    color: var(--page-muted);
+    font-size: .8rem;
+    line-height: 1.45;
+}
+
+.btn-check:checked + .setting-option-button,
+.btn-check:checked + .display-columns-button {
     border-color: #44403c;
     color: #fff;
     background: #44403c;

--- a/nemupipiano-musiclist-search/css/musiclist-search.css
+++ b/nemupipiano-musiclist-search/css/musiclist-search.css
@@ -666,7 +666,6 @@ body {
 .app-panel.font-size-small .form-control,
 .app-panel.font-size-small .form-select,
 .app-panel.font-size-small .btn,
-.app-panel.font-size-small .badge,
 .app-panel.font-size-small .song-title,
 .app-panel.font-size-small .song-artist,
 .app-panel.font-size-small .song-number,
@@ -678,11 +677,22 @@ body {
 .app-panel.font-size-large .form-control,
 .app-panel.font-size-large .form-select,
 .app-panel.font-size-large .btn,
-.app-panel.font-size-large .badge,
 .app-panel.font-size-large .song-title,
 .app-panel.font-size-large .song-artist,
 .app-panel.font-size-large .song-number,
 .app-panel.font-size-large .status-text,
 .app-panel.font-size-large .recommend-desc {
     font-size: 1.1rem !important;
+}
+
+.app-panel.font-size-small .badge {
+    font-size: .72rem !important;
+}
+
+.app-panel.font-size-medium .badge {
+    font-size: .82rem !important;
+}
+
+.app-panel.font-size-large .badge {
+    font-size: .95rem !important;
 }

--- a/nemupipiano-musiclist-search/css/musiclist-search.css
+++ b/nemupipiano-musiclist-search/css/musiclist-search.css
@@ -663,8 +663,6 @@ body {
     }
 }
 
-.app-panel.font-size-small .form-control,
-.app-panel.font-size-small .form-select,
 .app-panel.font-size-small .btn,
 .app-panel.font-size-small .song-title,
 .app-panel.font-size-small .song-artist,
@@ -674,8 +672,6 @@ body {
     font-size: .9rem !important;
 }
 
-.app-panel.font-size-large .form-control,
-.app-panel.font-size-large .form-select,
 .app-panel.font-size-large .btn,
 .app-panel.font-size-large .song-title,
 .app-panel.font-size-large .song-artist,
@@ -683,6 +679,21 @@ body {
 .app-panel.font-size-large .status-text,
 .app-panel.font-size-large .recommend-desc {
     font-size: 1.1rem !important;
+}
+
+.app-panel.font-size-small .form-control,
+.app-panel.font-size-small .form-select {
+    font-size: .95rem !important;
+}
+
+.app-panel.font-size-medium .form-control,
+.app-panel.font-size-medium .form-select {
+    font-size: 1.05rem !important;
+}
+
+.app-panel.font-size-large .form-control,
+.app-panel.font-size-large .form-select {
+    font-size: 1.18rem !important;
 }
 
 .app-panel.font-size-small .badge {

--- a/nemupipiano-musiclist-search/css/musiclist-search.css
+++ b/nemupipiano-musiclist-search/css/musiclist-search.css
@@ -530,10 +530,6 @@ body {
     flex-direction: column;
     }
 
-    .display-columns {
-    display: none;
-    }
-
     .status-text {
     margin-left: 0;
     text-align: left;

--- a/nemupipiano-musiclist-search/css/musiclist-search.css
+++ b/nemupipiano-musiclist-search/css/musiclist-search.css
@@ -664,7 +664,6 @@ body {
 }
 
 .app-panel.font-size-small .btn,
-.app-panel.font-size-small .song-title,
 .app-panel.font-size-small .song-artist,
 .app-panel.font-size-small .song-number,
 .app-panel.font-size-small .status-text,
@@ -673,7 +672,6 @@ body {
 }
 
 .app-panel.font-size-large .btn,
-.app-panel.font-size-large .song-title,
 .app-panel.font-size-large .song-artist,
 .app-panel.font-size-large .song-number,
 .app-panel.font-size-large .status-text,
@@ -694,6 +692,18 @@ body {
 .app-panel.font-size-large .form-control,
 .app-panel.font-size-large .form-select {
     font-size: 1.18rem !important;
+}
+
+.app-panel.font-size-small .song-title {
+    font-size: 1rem !important;
+}
+
+.app-panel.font-size-medium .song-title {
+    font-size: 1.18rem !important;
+}
+
+.app-panel.font-size-large .song-title {
+    font-size: 1.35rem !important;
 }
 
 .app-panel.font-size-small .badge {

--- a/nemupipiano-musiclist-search/index.html
+++ b/nemupipiano-musiclist-search/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="../lib/css/bootstrap-reboot.min.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
       integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous">
-  <link rel="stylesheet" href="./css/musiclist-search.css?v=1.4.4" />
+  <link rel="stylesheet" href="./css/musiclist-search.css?v=1.4.5" />
 </head>
 <body>
   <nav class="navbar navbar-expand-md navbar-dark bg-dark fixed-top">
@@ -173,7 +173,7 @@
   </div>
 
   <footer class="site-footer fixed-bottom mx-0 bg-black bg-opacity-75 text-center text-white">
-    <p>ver.1.4.4 問題点を見つけたら<a href="https://x.com/bonga_bon_bonga">X(旧Twitter)</a>にご連絡ください。</p>
+    <p>ver.1.4.5 問題点を見つけたら<a href="https://x.com/bonga_bon_bonga">X(旧Twitter)</a>にご連絡ください。</p>
   </footer>
 
   <button id="backToTop" class="back-to-top" type="button" aria-label="TOPへ戻る" hidden>

--- a/nemupipiano-musiclist-search/index.html
+++ b/nemupipiano-musiclist-search/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="../lib/css/bootstrap-reboot.min.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
       integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous">
-  <link rel="stylesheet" href="./css/musiclist-search.css?v=1.4.5" />
+  <link rel="stylesheet" href="./css/musiclist-search.css?v=1.4.6" />
 </head>
 <body>
   <nav class="navbar navbar-expand-md navbar-dark bg-dark fixed-top">
@@ -173,7 +173,7 @@
   </div>
 
   <footer class="site-footer fixed-bottom mx-0 bg-black bg-opacity-75 text-center text-white">
-    <p>ver.1.4.5 問題点を見つけたら<a href="https://x.com/bonga_bon_bonga">X(旧Twitter)</a>にご連絡ください。</p>
+    <p>ver.1.4.6 問題点を見つけたら<a href="https://x.com/bonga_bon_bonga">X(旧Twitter)</a>にご連絡ください。</p>
   </footer>
 
   <button id="backToTop" class="back-to-top" type="button" aria-label="TOPへ戻る" hidden>

--- a/nemupipiano-musiclist-search/index.html
+++ b/nemupipiano-musiclist-search/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="../lib/css/bootstrap-reboot.min.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
       integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous">
-  <link rel="stylesheet" href="./css/musiclist-search.css?v=1.4.7" />
+  <link rel="stylesheet" href="./css/musiclist-search.css?v=1.4.8" />
 </head>
 <body>
   <nav class="navbar navbar-expand-md navbar-dark bg-dark fixed-top">
@@ -147,8 +147,8 @@
             <label class="btn setting-option-button" for="fontSizeLarge">大</label>
           </div>
           <hr>
-          <h5>表示列</h5>
-          <div class="display-columns" role="radiogroup" aria-label="表示列">
+          <h5>曲名カードの表示列</h5>
+          <div class="display-columns" role="radiogroup" aria-label="曲名カードの表示列">
             <input class="btn-check" type="radio" name="displayColumns" id="displayColumns1" value="1" autocomplete="off">
             <label class="btn display-columns-button" for="displayColumns1">1列</label>
             <input class="btn-check" type="radio" name="displayColumns" id="displayColumns2" value="2" autocomplete="off">
@@ -156,6 +156,7 @@
             <input class="btn-check" type="radio" name="displayColumns" id="displayColumns3" value="3" autocomplete="off" checked>
             <label class="btn display-columns-button" for="displayColumns3">3列</label>
           </div>
+          <p class="setting-note mt-2 mb-0">※スマホ・タブレット表示の場合、設定した表示列より少なく表示される場合があります</p>
         </div>
       </div>
     </div>
@@ -174,7 +175,7 @@
   </div>
 
   <footer class="site-footer fixed-bottom mx-0 bg-black bg-opacity-75 text-center text-white">
-    <p>ver.1.4.7 問題点を見つけたら<a href="https://x.com/bonga_bon_bonga">X(旧Twitter)</a>にご連絡ください。</p>
+    <p>ver.1.4.8 問題点を見つけたら<a href="https://x.com/bonga_bon_bonga">X(旧Twitter)</a>にご連絡ください。</p>
   </footer>
 
   <button id="backToTop" class="back-to-top" type="button" aria-label="TOPへ戻る" hidden>

--- a/nemupipiano-musiclist-search/index.html
+++ b/nemupipiano-musiclist-search/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="../lib/css/bootstrap-reboot.min.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
       integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous">
-  <link rel="stylesheet" href="./css/musiclist-search.css?v=1.4.6" />
+  <link rel="stylesheet" href="./css/musiclist-search.css?v=1.4.7" />
 </head>
 <body>
   <nav class="navbar navbar-expand-md navbar-dark bg-dark fixed-top">
@@ -62,15 +62,6 @@
             <label class="btn search-scope-button" for="searchScopeTitle">曲名</label>
             <input class="btn-check" type="radio" name="searchScope" id="searchScopeArtist" value="artist" autocomplete="off">
             <label class="btn search-scope-button" for="searchScopeArtist">アーティスト</label>
-          </div>
-          <div class="display-columns" role="radiogroup" aria-label="表示列">
-            <span class="display-columns-label">表示列</span>
-            <input class="btn-check" type="radio" name="displayColumns" id="displayColumns1" value="1" autocomplete="off">
-            <label class="btn display-columns-button" for="displayColumns1">1列</label>
-            <input class="btn-check" type="radio" name="displayColumns" id="displayColumns2" value="2" autocomplete="off">
-            <label class="btn display-columns-button" for="displayColumns2">2列</label>
-            <input class="btn-check" type="radio" name="displayColumns" id="displayColumns3" value="3" autocomplete="off" checked>
-            <label class="btn display-columns-button" for="displayColumns3">3列</label>
           </div>
         </div>
 
@@ -155,6 +146,16 @@
             <input class="btn-check" type="radio" name="panelFontSize" id="fontSizeLarge" value="large" autocomplete="off">
             <label class="btn setting-option-button" for="fontSizeLarge">大</label>
           </div>
+          <hr>
+          <h5>表示列</h5>
+          <div class="display-columns" role="radiogroup" aria-label="表示列">
+            <input class="btn-check" type="radio" name="displayColumns" id="displayColumns1" value="1" autocomplete="off">
+            <label class="btn display-columns-button" for="displayColumns1">1列</label>
+            <input class="btn-check" type="radio" name="displayColumns" id="displayColumns2" value="2" autocomplete="off">
+            <label class="btn display-columns-button" for="displayColumns2">2列</label>
+            <input class="btn-check" type="radio" name="displayColumns" id="displayColumns3" value="3" autocomplete="off" checked>
+            <label class="btn display-columns-button" for="displayColumns3">3列</label>
+          </div>
         </div>
       </div>
     </div>
@@ -173,7 +174,7 @@
   </div>
 
   <footer class="site-footer fixed-bottom mx-0 bg-black bg-opacity-75 text-center text-white">
-    <p>ver.1.4.6 問題点を見つけたら<a href="https://x.com/bonga_bon_bonga">X(旧Twitter)</a>にご連絡ください。</p>
+    <p>ver.1.4.7 問題点を見つけたら<a href="https://x.com/bonga_bon_bonga">X(旧Twitter)</a>にご連絡ください。</p>
   </footer>
 
   <button id="backToTop" class="back-to-top" type="button" aria-label="TOPへ戻る" hidden>
@@ -192,6 +193,11 @@
     const MUSICLIST_JSON_PATH = "./data/musiclist.json";
     const RANDOM_COUNT = 10;
     const APP_PANEL_FONT_SIZE_KEY = "nemupipiano:appPanelFontSize";
+    const ACTIVE_TAB_KEY = "nemupipiano:activeTab";
+    const SEARCH_SCOPE_KEY = "nemupipiano:searchScope";
+    const DISPLAY_COLUMNS_KEY = "nemupipiano:displayColumns";
+    const PLAYABLE_ONLY_KEY = "nemupipiano:playableOnly";
+    const RANDOM_PLAYABLE_ONLY_KEY = "nemupipiano:randomPlayableOnly";
 
     const els = {
       search: document.getElementById("search"),
@@ -610,16 +616,18 @@
     }
 
     function switchTab(tabName) {
+      const normalized = ["search", "random"].includes(tabName) ? tabName : "search";
       els.tabs.forEach(tab => {
-        const active = tab.dataset.tab === tabName;
+        const active = tab.dataset.tab === normalized;
         tab.classList.toggle("active", active);
         tab.setAttribute("aria-selected", String(active));
       });
 
       els.panels.forEach(panel => {
-        const active = panel.id === `panel-${tabName}`;
+        const active = panel.id === `panel-${normalized}`;
         panel.hidden = !active;
       });
+      localStorage.setItem(ACTIVE_TAB_KEY, normalized);
     }
 
     function updateBackToTopVisibility() {
@@ -636,11 +644,31 @@
       localStorage.setItem(APP_PANEL_FONT_SIZE_KEY, normalized);
     }
 
+    function applyRadioValue(options, value, fallback) {
+      const values = [...options].map(option => option.value);
+      const normalized = values.includes(value) ? value : fallback;
+      options.forEach(option => {
+        option.checked = option.value === normalized;
+      });
+      return normalized;
+    }
+
+    function loadSavedBoolean(key, fallback) {
+      const saved = localStorage.getItem(key);
+      if (saved === "true") return true;
+      if (saved === "false") return false;
+      return fallback;
+    }
+
     els.search.addEventListener("input", render);
-    els.searchScopes.forEach(scope => scope.addEventListener("change", render));
+    els.searchScopes.forEach(scope => scope.addEventListener("change", () => {
+      localStorage.setItem(SEARCH_SCOPE_KEY, scope.value);
+      render();
+    }));
     els.displayColumns.forEach(column => {
       column.addEventListener("change", () => {
         displayColumnCount = column.value;
+        localStorage.setItem(DISPLAY_COLUMNS_KEY, displayColumnCount);
         applyColumnLayout();
       });
     });
@@ -650,6 +678,7 @@
       if (!button) return;
 
       playableOnly = !playableOnly;
+      localStorage.setItem(PLAYABLE_ONLY_KEY, String(playableOnly));
       render();
     });
     els.randomStats.addEventListener("click", (event) => {
@@ -657,6 +686,7 @@
       if (!button) return;
 
       randomPlayableOnly = !randomPlayableOnly;
+      localStorage.setItem(RANDOM_PLAYABLE_ONLY_KEY, String(randomPlayableOnly));
       pickRandomSongs();
       renderRandom();
     });
@@ -691,8 +721,13 @@
       tab.addEventListener("click", () => switchTab(tab.dataset.tab));
     });
 
-    applyColumnLayout();
     applyAppPanelFontSize(localStorage.getItem(APP_PANEL_FONT_SIZE_KEY));
+    applyRadioValue(els.searchScopes, localStorage.getItem(SEARCH_SCOPE_KEY), "all");
+    displayColumnCount = applyRadioValue(els.displayColumns, localStorage.getItem(DISPLAY_COLUMNS_KEY), "3");
+    playableOnly = loadSavedBoolean(PLAYABLE_ONLY_KEY, false);
+    randomPlayableOnly = loadSavedBoolean(RANDOM_PLAYABLE_ONLY_KEY, true);
+    applyColumnLayout();
+    switchTab(localStorage.getItem(ACTIVE_TAB_KEY));
     updateBackToTopVisibility();
     loadSheet();
   </script>

--- a/nemupipiano-musiclist-search/index.html
+++ b/nemupipiano-musiclist-search/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="../lib/css/bootstrap-reboot.min.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
       integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous">
-  <link rel="stylesheet" href="./css/musiclist-search.css?v=1.4.3" />
+  <link rel="stylesheet" href="./css/musiclist-search.css?v=1.4.4" />
 </head>
 <body>
   <nav class="navbar navbar-expand-md navbar-dark bg-dark fixed-top">

--- a/nemupipiano-musiclist-search/index.html
+++ b/nemupipiano-musiclist-search/index.html
@@ -173,7 +173,7 @@
   </div>
 
   <footer class="site-footer fixed-bottom mx-0 bg-black bg-opacity-75 text-center text-white">
-    <p>ver.1.4.3 問題点を見つけたら<a href="https://x.com/bonga_bon_bonga">X(旧Twitter)</a>にご連絡ください。</p>
+    <p>ver.1.4.4 問題点を見つけたら<a href="https://x.com/bonga_bon_bonga">X(旧Twitter)</a>にご連絡ください。</p>
   </footer>
 
   <button id="backToTop" class="back-to-top" type="button" aria-label="TOPへ戻る" hidden>


### PR DESCRIPTION
## PR #23: 文字の大きさに関する設定の修正

- 設定モーダル内の文字サイズ設定を追加
  - 小 / 中 / 大 を選択可能
  - `.app-panel` 内の表示に適用
  - `localStorage` に保存し、再読み込み後も維持

- バッジのフォントサイズを修正
  - 小: `.72rem`
  - 中: `.82rem`
  - 大: `.95rem`

- 検索フォーム・ジャンルプルダウンのフォントサイズを修正
  - 小: `.95rem`
  - 中: `1.05rem`
  - 大: `1.18rem`

- 曲名カードの曲名フォントサイズを修正
  - 小: `1rem`
  - 中: `1.18rem`
  - 大: `1.35rem`

- 以下の表示状態を保存・復元できるように修正
  - 検索 / ランダム表示タブ
  - 検索対象
  - 曲名カードの表示列
  - 検索側の弾ける曲 ON/OFF
  - ランダム表示側の弾ける曲 ON/OFF

- `表示列` 設定をメイン画面から設定モーダル内へ移動

- 設定モーダル内の表示列項目を修正
  - 見出しを `曲名カードの表示列` に変更
  - `1列 / 2列 / 3列` ボタンのフォントサイズを文字サイズボタンと統一
  - 注釈を追加  
    `※スマホ・タブレット表示の場合、設定した表示列より少なく表示される場合があります`

- CSS キャッシュバスターと表示バージョンを `1.4.8` に更新