### PR TITLE
検索フォームの改善

### DIFF
--- a/nemupipiano-musiclist-search/css/musiclist-search.css
+++ b/nemupipiano-musiclist-search/css/musiclist-search.css
@@ -109,9 +109,25 @@ body {
     box-shadow: 0 8px 18px rgba(41, 37, 36, .07);
 }
 
-.reload-button {
+.detail-toggle-button {
     font-size: 1rem;
     white-space: nowrap;
+}
+
+.settings-reload-button {
+    font-weight: 800;
+    white-space: nowrap;
+}
+
+.search-details {
+    padding: .875rem;
+    border: 1px solid var(--page-line);
+    border-radius: .85rem;
+    background: #fafaf9;
+}
+
+.search-details[hidden] {
+    display: none;
 }
 
 .result-controls {
@@ -216,8 +232,7 @@ body {
 }
 
 .song-artist,
-.footer-note,
-.status-text {
+.footer-note {
     color: var(--page-muted);
 }
 
@@ -231,12 +246,6 @@ body {
     align-items: center;
     justify-content: space-between;
     gap: .75rem 1rem;
-}
-
-.status-text {
-    flex: 0 1 auto;
-    margin-left: auto;
-    text-align: right;
 }
 
 .song-grid[data-columns="1"] .song-card-body,
@@ -538,11 +547,6 @@ body {
     flex-direction: column;
     }
 
-    .status-text {
-    margin-left: 0;
-    text-align: left;
-    }
-
     .song-card {
     border-radius: .9rem;
     }
@@ -670,7 +674,6 @@ body {
 .app-panel.font-size-small .btn,
 .app-panel.font-size-small .song-artist,
 .app-panel.font-size-small .song-number,
-.app-panel.font-size-small .status-text,
 .app-panel.font-size-small .recommend-desc {
     font-size: .9rem !important;
 }
@@ -678,7 +681,6 @@ body {
 .app-panel.font-size-large .btn,
 .app-panel.font-size-large .song-artist,
 .app-panel.font-size-large .song-number,
-.app-panel.font-size-large .status-text,
 .app-panel.font-size-large .recommend-desc {
     font-size: 1.1rem !important;
 }

--- a/nemupipiano-musiclist-search/css/musiclist-search.css
+++ b/nemupipiano-musiclist-search/css/musiclist-search.css
@@ -205,7 +205,8 @@ html[data-theme="dark"] .form-select {
 }
 
 .search-scope,
-.display-columns {
+.display-columns,
+.playable-filter {
     display: inline-flex;
     flex: 0 0 auto;
     flex-wrap: wrap;
@@ -214,7 +215,8 @@ html[data-theme="dark"] .form-select {
 }
 
 .search-scope-label,
-.display-columns-label {
+.display-columns-label,
+.playable-filter-label {
     color: var(--page-muted);
     font-size: .85rem;
     font-weight: 700;
@@ -459,6 +461,12 @@ html[data-theme="dark"] .form-select {
     color: #15803d;
     background: #f0fdf4;
     border: 1px solid #bbf7d0;
+}
+
+html[data-theme="dark"] .badge-playable {
+    color: #d8b4fe;
+    background: #312e81;
+    border-color: #6d28d9;
 }
 
 .setting-options {

--- a/nemupipiano-musiclist-search/css/musiclist-search.css
+++ b/nemupipiano-musiclist-search/css/musiclist-search.css
@@ -15,25 +15,35 @@
     --page-active: #ffffff;
     --page-shadow: rgba(41, 37, 36, .08);
     --page-focus: rgba(180, 83, 9, .12);
+    --page-button-active: #44403c;
+    --page-button-active-text: #ffffff;
+    --page-filter-active-bg: #ffedd5;
+    --page-filter-active-text: #9a3412;
+    --page-filter-active-border: #fdba74;
 }
 
 html[data-theme="dark"] {
-    --page-bg: #1c1917;
-    --page-text: #f5f5f4;
-    --page-muted: #c7c2bd;
-    --page-accent: #fb923c;
-    --page-accent-soft: #431407;
-    --page-line: #44403c;
-    --page-body: #0f1115;
-    --page-panel: rgba(28, 25, 23, .96);
-    --page-panel-border: rgba(68, 64, 60, .95);
-    --page-control: #1f232b;
-    --page-control-soft: #171a20;
-    --page-button-soft: #292524;
-    --page-card: #1f232b;
-    --page-active: #292524;
-    --page-shadow: rgba(0, 0, 0, .24);
-    --page-focus: rgba(251, 146, 60, .22);
+    --page-bg: #0f0f0f;
+    --page-text: #f1f1f1;
+    --page-muted: #aaa;
+    --page-accent: #3ea6ff;
+    --page-accent-soft: #263850;
+    --page-line: #3f3f3f;
+    --page-body: #0f0f0f;
+    --page-panel: #181818;
+    --page-panel-border: #303030;
+    --page-control: #121212;
+    --page-control-soft: #212121;
+    --page-button-soft: #272727;
+    --page-card: #212121;
+    --page-active: #303030;
+    --page-shadow: rgba(0, 0, 0, .42);
+    --page-focus: rgba(62, 166, 255, .25);
+    --page-button-active: #f1f1f1;
+    --page-button-active-text: #0f0f0f;
+    --page-filter-active-bg: #263850;
+    --page-filter-active-text: #f1f1f1;
+    --page-filter-active-border: #3ea6ff;
 }
 
 body {
@@ -218,16 +228,16 @@ html[data-theme="dark"] .form-select {
     border-color: var(--page-line);
     border-radius: .45rem;
     color: var(--page-muted);
-    background: #f5f5f4;
+    background: var(--page-button-soft);
     font-weight: 800;
     line-height: 1.2;
 }
 
 .btn-check:checked + .search-scope-button,
 .btn-check:checked + .display-columns-button {
-    border-color: #44403c;
-    color: #fff;
-    background: #44403c;
+    border-color: var(--page-button-active);
+    color: var(--page-button-active-text);
+    background: var(--page-button-active);
 }
 
 .btn-check:focus + .search-scope-button,
@@ -414,7 +424,7 @@ html[data-theme="dark"] .form-select {
 
 .stat-badge {
     color: var(--page-muted);
-    background: #fafaf9;
+    background: var(--page-control-soft);
     border: 1px solid var(--page-line);
 }
 
@@ -435,14 +445,14 @@ html[data-theme="dark"] .form-select {
 }
 
 .stat-filter-button.active {
-    color: #9a3412;
-    background: #ffedd5;
-    border-color: #fdba74;
+    color: var(--page-filter-active-text);
+    background: var(--page-filter-active-bg);
+    border-color: var(--page-filter-active-border);
     box-shadow: inset 0 0 0 1px rgba(180, 83, 9, .18);
 }
 
 .stat-filter-button.active strong {
-    color: #9a3412;
+    color: var(--page-filter-active-text);
 }
 
 .badge-playable {
@@ -477,9 +487,9 @@ html[data-theme="dark"] .form-select {
 
 .btn-check:checked + .setting-option-button,
 .btn-check:checked + .display-columns-button {
-    border-color: #44403c;
-    color: #fff;
-    background: #44403c;
+    border-color: var(--page-button-active);
+    color: var(--page-button-active-text);
+    background: var(--page-button-active);
 }
 
 .empty-box {
@@ -506,6 +516,32 @@ html[data-theme="dark"] .btn-close {
 html[data-theme="dark"] .bg-light {
     color: var(--page-text) !important;
     background-color: var(--page-control) !important;
+}
+
+html[data-theme="dark"] .text-bg-light {
+    color: var(--page-text) !important;
+    background-color: var(--page-button-soft) !important;
+    border-color: var(--page-line) !important;
+}
+
+html[data-theme="dark"] .btn-dark {
+    color: var(--page-text);
+    background-color: var(--page-button-soft);
+    border-color: var(--page-button-soft);
+}
+
+html[data-theme="dark"] .btn-dark:hover,
+html[data-theme="dark"] .btn-dark:focus {
+    color: var(--page-text);
+    background-color: #3f3f3f;
+    border-color: #3f3f3f;
+}
+
+html[data-theme="dark"] .btn-dark:disabled {
+    color: #717171;
+    background-color: #272727;
+    border-color: #272727;
+    opacity: 1;
 }
 
 html[data-theme="dark"] .text-secondary {

--- a/nemupipiano-musiclist-search/css/musiclist-search.css
+++ b/nemupipiano-musiclist-search/css/musiclist-search.css
@@ -5,12 +5,41 @@
     --page-accent: #b45309;
     --page-accent-soft: #fff7ed;
     --page-line: #e7e5e4;
+    --page-body: #ffffff;
+    --page-panel: rgba(255, 255, 255, .9);
+    --page-panel-border: rgba(231, 229, 228, .9);
+    --page-control: #ffffff;
+    --page-control-soft: #fafaf9;
+    --page-button-soft: #f5f5f4;
+    --page-card: #ffffff;
+    --page-active: #ffffff;
+    --page-shadow: rgba(41, 37, 36, .08);
+    --page-focus: rgba(180, 83, 9, .12);
+}
+
+html[data-theme="dark"] {
+    --page-bg: #1c1917;
+    --page-text: #f5f5f4;
+    --page-muted: #c7c2bd;
+    --page-accent: #fb923c;
+    --page-accent-soft: #431407;
+    --page-line: #44403c;
+    --page-body: #0f1115;
+    --page-panel: rgba(28, 25, 23, .96);
+    --page-panel-border: rgba(68, 64, 60, .95);
+    --page-control: #1f232b;
+    --page-control-soft: #171a20;
+    --page-button-soft: #292524;
+    --page-card: #1f232b;
+    --page-active: #292524;
+    --page-shadow: rgba(0, 0, 0, .24);
+    --page-focus: rgba(251, 146, 60, .22);
 }
 
 body {
     min-height: 100vh;
     color: var(--page-text);
-    background: #ffffff;
+    background: var(--page-body);
     line-height: 1.7;
     padding-top: 5.75rem;
     padding-bottom: 3.25rem;
@@ -57,9 +86,9 @@ body {
 }
 
 .app-panel {
-    background: rgba(255, 255, 255, .9);
-    border: 1px solid rgba(231, 229, 228, .9);
-    box-shadow: 0 12px 28px rgba(41, 37, 36, .08);
+    background: var(--page-panel);
+    border: 1px solid var(--page-panel-border);
+    box-shadow: 0 12px 28px var(--page-shadow);
     backdrop-filter: blur(10px);
     border-radius: 1.5rem;
 }
@@ -83,7 +112,7 @@ body {
     gap: .5rem;
     padding: .375rem;
     border: 1px solid var(--page-line);
-    background: #fafaf9;
+    background: var(--page-control-soft);
     border-radius: 1rem;
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;
@@ -105,8 +134,8 @@ body {
 
 .nav-pills.app-tabs .nav-link.active {
     color: var(--page-text);
-    background: #fff;
-    box-shadow: 0 8px 18px rgba(41, 37, 36, .07);
+    background: var(--page-active);
+    box-shadow: 0 8px 18px var(--page-shadow);
 }
 
 .detail-toggle-button {
@@ -114,16 +143,44 @@ body {
     white-space: nowrap;
 }
 
+.detail-toggle-button.btn-lg {
+    padding-inline: .7rem;
+}
+
 .settings-reload-button {
     font-weight: 800;
     white-space: nowrap;
+}
+
+.form-control,
+.form-select {
+    color: var(--page-text);
+    background-color: var(--page-control);
+    border-color: var(--page-line);
+}
+
+.form-control::placeholder {
+    color: var(--page-muted);
+    opacity: 1;
+}
+
+.form-control:focus,
+.form-select:focus {
+    color: var(--page-text);
+    background-color: var(--page-control);
+    border-color: var(--page-accent);
+    box-shadow: 0 0 0 .2rem var(--page-focus);
+}
+
+html[data-theme="dark"] .form-select {
+    --bs-form-select-bg-img: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23f5f5f4' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/%3e%3c/svg%3e");
 }
 
 .search-details {
     padding: .875rem;
     border: 1px solid var(--page-line);
     border-radius: .85rem;
-    background: #fafaf9;
+    background: var(--page-control-soft);
 }
 
 .search-details[hidden] {
@@ -179,6 +236,8 @@ body {
 }
 
 .song-card {
+    color: var(--page-text);
+    background: var(--page-card);
     border-color: var(--page-line);
     border-radius: 1.25rem;
     min-height: 100%;
@@ -190,7 +249,7 @@ body {
 .song-card:focus {
     transform: translateY(-2px);
     border-color: rgba(180, 83, 9, .35);
-    box-shadow: 0 .75rem 1.5rem rgba(41, 37, 36, .08);
+    box-shadow: 0 .75rem 1.5rem var(--page-shadow);
     outline: none;
 }
 
@@ -404,9 +463,10 @@ body {
     border-color: var(--page-line);
     border-radius: .5rem;
     color: var(--page-muted);
-    background: #f5f5f4;
+    background: var(--page-button-soft);
     font-size: 1rem;
     font-weight: 800;
+    white-space: nowrap;
 }
 
 .setting-note {
@@ -426,7 +486,30 @@ body {
     color: var(--page-muted);
     border: 1px dashed var(--page-line);
     border-radius: 1rem;
-    background: #fff;
+    background: var(--page-card);
+}
+
+.modal-content {
+    color: var(--page-text);
+    background: var(--page-panel);
+    border-color: var(--page-line);
+}
+
+.modal-header {
+    border-bottom-color: var(--page-line);
+}
+
+html[data-theme="dark"] .btn-close {
+    filter: invert(1) grayscale(100%) brightness(200%);
+}
+
+html[data-theme="dark"] .bg-light {
+    color: var(--page-text) !important;
+    background-color: var(--page-control) !important;
+}
+
+html[data-theme="dark"] .text-secondary {
+    color: var(--page-muted) !important;
 }
 
 .back-to-top,

--- a/nemupipiano-musiclist-search/index.html
+++ b/nemupipiano-musiclist-search/index.html
@@ -60,6 +60,10 @@
             <input class="btn-check" type="radio" name="searchScope" id="searchScopeArtist" value="artist" autocomplete="off">
             <label class="btn search-scope-button" for="searchScopeArtist">アーティスト</label>
           </div>
+          <div class="playable-filter" aria-label="弾ける曲フィルター">
+            <span class="playable-filter-label">弾ける曲</span>
+            <button class="badge rounded-pill stat-badge stat-filter-button px-3 py-2" id="playableFilter" type="button" data-filter="playable" aria-pressed="false">OFF</button>
+          </div>
         </div>
 
         <div class="stats-row mt-3">
@@ -221,6 +225,7 @@
       reload: document.getElementById("reload"),
       searchDetailToggle: document.getElementById("searchDetailToggle"),
       searchDetails: document.getElementById("searchDetails"),
+      playableFilter: document.getElementById("playableFilter"),
       stats: document.getElementById("stats"),
       songs: document.getElementById("songs"),
       empty: document.getElementById("empty"),
@@ -593,8 +598,10 @@
 
       els.stats.innerHTML = `
         <span class="badge rounded-pill stat-badge px-3 py-2">全曲数：<strong>${songs.length}</strong> 表示中：<strong>${items.length}</strong></span>
-        <button class="badge rounded-pill stat-badge stat-filter-button px-3 py-2 ${playableOnly ? "active" : ""}" type="button" data-filter="playable" aria-pressed="${playableOnly}">弾ける曲：<strong>${playableOnly ? "ON" : "OFF"}</strong></button>
       `;
+      els.playableFilter.classList.toggle("active", playableOnly);
+      els.playableFilter.setAttribute("aria-pressed", String(playableOnly));
+      els.playableFilter.textContent = playableOnly ? "ON" : "OFF";
 
       els.empty.hidden = items.length !== 0;
       els.songs.innerHTML = renderSongCards(items);
@@ -750,10 +757,7 @@
       });
     });
     els.genre.addEventListener("change", render);
-    els.stats.addEventListener("click", (event) => {
-      const button = event.target.closest("[data-filter='playable']");
-      if (!button) return;
-
+    els.playableFilter.addEventListener("click", () => {
       playableOnly = !playableOnly;
       localStorage.setItem(PLAYABLE_ONLY_KEY, String(playableOnly));
       render();

--- a/nemupipiano-musiclist-search/index.html
+++ b/nemupipiano-musiclist-search/index.html
@@ -502,6 +502,15 @@
       return document.querySelector("[name='searchScope']:checked")?.value || "all";
     }
 
+    function updateSearchPlaceholder(scope = getSearchScope()) {
+      const placeholders = {
+        all: "曲名・アーティストで検索",
+        title: "曲名で検索",
+        artist: "アーティストで検索",
+      };
+      els.search.placeholder = placeholders[scope] || placeholders.all;
+    }
+
     function searchTargetsForScope(song, scope) {
       const titleTargets = [song.title, ...normalizeStringArray(song.searchWords)];
       const artistTargets = [song.artist, ...normalizeStringArray(song.artistAliases)];
@@ -747,6 +756,7 @@
     els.search.addEventListener("input", render);
     els.searchScopes.forEach(scope => scope.addEventListener("change", () => {
       localStorage.setItem(SEARCH_SCOPE_KEY, scope.value);
+      updateSearchPlaceholder(scope.value);
       render();
     }));
     els.displayColumns.forEach(column => {
@@ -820,7 +830,7 @@
 
     applyTheme(localStorage.getItem(THEME_KEY));
     applyAppPanelFontSize(localStorage.getItem(APP_PANEL_FONT_SIZE_KEY));
-    applyRadioValue(els.searchScopes, localStorage.getItem(SEARCH_SCOPE_KEY), "all");
+    updateSearchPlaceholder(applyRadioValue(els.searchScopes, localStorage.getItem(SEARCH_SCOPE_KEY), "all"));
     displayColumnCount = applyRadioValue(els.displayColumns, localStorage.getItem(DISPLAY_COLUMNS_KEY), "3");
     playableOnly = loadSavedBoolean(PLAYABLE_ONLY_KEY, false);
     randomPlayableOnly = loadSavedBoolean(RANDOM_PLAYABLE_ONLY_KEY, true);

--- a/nemupipiano-musiclist-search/index.html
+++ b/nemupipiano-musiclist-search/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="../lib/css/bootstrap-reboot.min.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
       integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous">
-  <link rel="stylesheet" href="./css/musiclist-search.css?v=1.4.8" />
+  <link rel="stylesheet" href="./css/musiclist-search.css?v=1.4.9" />
 </head>
 <body>
   <nav class="navbar navbar-expand-md navbar-dark bg-dark fixed-top">
@@ -32,18 +32,22 @@
 
       <section class="tab-panel" id="panel-search" role="tabpanel" aria-labelledby="tab-search">
         <div class="row g-2 g-md-3 align-items-stretch">
-          <div class="col-12 col-md-7">
+          <div class="col-12 col-md-10">
             <label class="visually-hidden" for="search">検索キーワード</label>
             <input id="search" class="form-control form-control-lg" type="search" placeholder="曲名・アーティストで検索" autocomplete="off" />
           </div>
-          <div class="col-12 col-md-3">
-            <label class="visually-hidden" for="genre">ジャンル</label>
-            <select id="genre" class="form-select form-select-lg">
-              <option value="">すべてのジャンル</option>
-            </select>
-          </div>
           <div class="col-12 col-md-2 d-grid">
-            <button id="reload" class="btn btn-dark btn-lg reload-button" type="button">再読み込み</button>
+            <button id="searchDetailToggle" class="btn btn-dark btn-lg detail-toggle-button" type="button" aria-expanded="false" aria-controls="searchDetails">▼詳細</button>
+          </div>
+        </div>
+        <div class="search-details mt-3" id="searchDetails" hidden>
+          <div class="row g-2 g-md-3">
+            <div class="col-12 col-md-6">
+              <label class="form-label fw-bold" for="genre">ジャンル</label>
+              <select id="genre" class="form-select form-select-lg">
+                <option value="">すべてのジャンル</option>
+              </select>
+            </div>
           </div>
         </div>
         <div class="result-controls mt-3">
@@ -60,7 +64,6 @@
 
         <div class="stats-row mt-3">
           <div class="d-flex flex-wrap gap-2" id="stats" aria-live="polite"></div>
-          <p class="status-text mb-0" id="status">読み込み中…</p>
         </div>
         <div class="row row-cols-1 row-cols-md-2 row-cols-xl-3 g-3 mt-1 song-grid" id="songs" data-columns="3"></div>
         <div class="empty-box text-center p-4 mt-3" id="empty" hidden>条件に合う曲が見つかりませんでした。</div>
@@ -151,6 +154,10 @@
             <label class="btn display-columns-button" for="displayColumns3">3列</label>
           </div>
           <p class="setting-note mt-2 mb-0">※スマホ・タブレット表示の場合、設定した表示列より少なく表示される場合があります</p>
+          <hr>
+          <div class="d-grid">
+            <button id="reload" class="btn btn-dark settings-reload-button" type="button">再読み込み</button>
+          </div>
         </div>
       </div>
     </div>
@@ -200,7 +207,8 @@
       displayColumns: document.querySelectorAll("[name='displayColumns']"),
       genre: document.getElementById("genre"),
       reload: document.getElementById("reload"),
-      status: document.getElementById("status"),
+      searchDetailToggle: document.getElementById("searchDetailToggle"),
+      searchDetails: document.getElementById("searchDetails"),
       stats: document.getElementById("stats"),
       songs: document.getElementById("songs"),
       empty: document.getElementById("empty"),
@@ -293,7 +301,6 @@
 
     // Google Visualization APIを使ってシートを読み込む。レスポンスはJSONP形式で返されるため、コールバック関数を動的に生成して対応する。
     function loadSheet() {
-      els.status.textContent = "読み込み中…";
       els.reload.disabled = true;
       els.shuffle.disabled = true;
 
@@ -320,10 +327,8 @@
           pickRandomSongs();
           render();
           renderRandom();
-          els.status.textContent = `読み込み完了：${new Date().toLocaleString("ja-JP")}`;
         } catch (error) {
           console.error(error);
-          els.status.textContent = `エラー：${error.message}`;
         } finally {
           els.reload.disabled = false;
           els.shuffle.disabled = false;
@@ -333,7 +338,6 @@
       };
 
       script.onerror = () => {
-        els.status.textContent = "エラー：シートを読み込めませんでした。公開設定を確認してください。";
         els.reload.disabled = false;
         els.shuffle.disabled = false;
         script.remove();
@@ -655,6 +659,12 @@
       return fallback;
     }
 
+    function setSearchDetailsOpen(open) {
+      els.searchDetails.hidden = !open;
+      els.searchDetailToggle.setAttribute("aria-expanded", String(open));
+      els.searchDetailToggle.textContent = open ? "▲詳細" : "▼詳細";
+    }
+
     els.search.addEventListener("input", render);
     els.searchScopes.forEach(scope => scope.addEventListener("change", () => {
       localStorage.setItem(SEARCH_SCOPE_KEY, scope.value);
@@ -684,6 +694,9 @@
       localStorage.setItem(RANDOM_PLAYABLE_ONLY_KEY, String(randomPlayableOnly));
       pickRandomSongs();
       renderRandom();
+    });
+    els.searchDetailToggle.addEventListener("click", () => {
+      setSearchDetailsOpen(els.searchDetails.hidden);
     });
     els.reload.addEventListener("click", loadSheet);
     els.shuffle.addEventListener("click", () => {
@@ -721,6 +734,7 @@
     displayColumnCount = applyRadioValue(els.displayColumns, localStorage.getItem(DISPLAY_COLUMNS_KEY), "3");
     playableOnly = loadSavedBoolean(PLAYABLE_ONLY_KEY, false);
     randomPlayableOnly = loadSavedBoolean(RANDOM_PLAYABLE_ONLY_KEY, true);
+    setSearchDetailsOpen(false);
     applyColumnLayout();
     switchTab(localStorage.getItem(ACTIVE_TAB_KEY));
     updateBackToTopVisibility();

--- a/nemupipiano-musiclist-search/index.html
+++ b/nemupipiano-musiclist-search/index.html
@@ -211,6 +211,7 @@
     const DISPLAY_COLUMNS_KEY = "nemupipiano:displayColumns";
     const PLAYABLE_ONLY_KEY = "nemupipiano:playableOnly";
     const RANDOM_PLAYABLE_ONLY_KEY = "nemupipiano:randomPlayableOnly";
+    const RELOAD_BUTTON_DEFAULT_TEXT = "曲リストを再読み込みする";
 
     const els = {
       search: document.getElementById("search"),
@@ -243,6 +244,7 @@
     let playableOnly = false;
     let randomPlayableOnly = true;
     let displayColumnCount = "3";
+    let reloadFeedbackTimer = null;
 
     // HTMLエスケープを行う関数。& < > " ' をそれぞれ対応するHTMLエンティティに置換する。nullやundefinedも空文字に変換する。
     function escapeHtml(value) {
@@ -312,10 +314,43 @@
       };
     }
 
+    function setReloadButtonState(state) {
+      clearTimeout(reloadFeedbackTimer);
+      reloadFeedbackTimer = null;
+
+      if (state === "loading") {
+        els.reload.disabled = true;
+        els.reload.innerHTML = '<span class="spinner-border spinner-border-sm me-2" aria-hidden="true"></span><span>読み込み中…</span>';
+        return;
+      }
+
+      if (state === "complete") {
+        els.reload.disabled = false;
+        els.reload.textContent = "読み込み完了しました！";
+        reloadFeedbackTimer = setTimeout(() => setReloadButtonState("default"), 2000);
+        return;
+      }
+
+      if (state === "error") {
+        els.reload.disabled = false;
+        els.reload.textContent = "読み込みに失敗しました";
+        reloadFeedbackTimer = setTimeout(() => setReloadButtonState("default"), 2000);
+        return;
+      }
+
+      els.reload.disabled = false;
+      els.reload.textContent = RELOAD_BUTTON_DEFAULT_TEXT;
+    }
+
     // Google Visualization APIを使ってシートを読み込む。レスポンスはJSONP形式で返されるため、コールバック関数を動的に生成して対応する。
-    function loadSheet() {
-      els.reload.disabled = true;
+    function loadSheet({ showReloadFeedback = false } = {}) {
+      if (showReloadFeedback) {
+        setReloadButtonState("loading");
+      } else {
+        els.reload.disabled = true;
+      }
       els.shuffle.disabled = true;
+      let loadSucceeded = false;
 
       const musiclistPromise = loadMusiclist()
         .then(items => ({ items }))
@@ -340,10 +375,15 @@
           pickRandomSongs();
           render();
           renderRandom();
+          loadSucceeded = true;
         } catch (error) {
           console.error(error);
         } finally {
-          els.reload.disabled = false;
+          if (showReloadFeedback) {
+            setReloadButtonState(loadSucceeded ? "complete" : "error");
+          } else {
+            els.reload.disabled = false;
+          }
           els.shuffle.disabled = false;
           script.remove();
           delete window[callbackName];
@@ -351,7 +391,11 @@
       };
 
       script.onerror = () => {
-        els.reload.disabled = false;
+        if (showReloadFeedback) {
+          setReloadButtonState("error");
+        } else {
+          els.reload.disabled = false;
+        }
         els.shuffle.disabled = false;
         script.remove();
         delete window[callbackName];
@@ -726,7 +770,7 @@
     els.searchDetailToggle.addEventListener("click", () => {
       setSearchDetailsOpen(els.searchDetails.hidden);
     });
-    els.reload.addEventListener("click", loadSheet);
+    els.reload.addEventListener("click", () => loadSheet({ showReloadFeedback: true }));
     els.shuffle.addEventListener("click", () => {
       pickRandomSongs();
       renderRandom();

--- a/nemupipiano-musiclist-search/index.html
+++ b/nemupipiano-musiclist-search/index.html
@@ -16,13 +16,6 @@
   </nav>
 
   <main role="main" class="container app-shell">
-    <header class="mb-4">
-      <p class="lead text-secondary mb-0">
-        Googleスプレッドシート「<a href="https://docs.google.com/spreadsheets/d/1Dd-oj59leRwLI-Y1v1hD5tpEgk2yiu4w6DL7adkpr9g/edit?gid=0#gid=0" target="_blank" rel="noopener noreferrer">ピアノ曲リスト</a>」を読み取り、曲のフィルタ検索とランダム表示を行うことが出来ます。<br>
-        リストに曲が無い時は、<a href="https://www.youtube.com/@nemupipi" target="_blank" rel="noopener noreferrer">ねむぴぴ</a>のピアノ配信「ねむぴぴあの」内でリクエスト！
-      </p>
-    </header>
-
     <section class="app-panel font-size-medium p-3 p-md-4" id="appPanel" aria-label="曲リスト">
       <ul class="nav nav-pills app-tabs mb-4" id="songTabs" role="tablist">
         <li class="nav-item" role="presentation">
@@ -100,7 +93,8 @@
         </div>
         <div class="modal-body">
           <p>
-            本ページは、Googleスプレッドシートの「ピアノ曲リスト」を読み取り、Webページ上での曲のフィルタ検索とランダム表示を行うことが出来ます。
+            本ページは、Googleスプレッドシートの「<a href="https://docs.google.com/spreadsheets/d/1Dd-oj59leRwLI-Y1v1hD5tpEgk2yiu4w6DL7adkpr9g/edit?gid=0#gid=0" target="_blank" rel="noopener noreferrer">ピアノ曲リスト</a>」を読み取り、曲のフィルタ検索とランダム表示を行うことが出来ます。<br>
+            リストに曲が無い時は、<a href="https://www.youtube.com/@nemupipi" target="_blank" rel="noopener noreferrer">ねむぴぴ</a>のピアノ配信「ねむぴぴあの」内でリクエスト！
           </p>
           <hr>
           <h5>使い方</h5>
@@ -175,7 +169,7 @@
   </div>
 
   <footer class="site-footer fixed-bottom mx-0 bg-black bg-opacity-75 text-center text-white">
-    <p>ver.1.4.8 問題点を見つけたら<a href="https://x.com/bonga_bon_bonga">X(旧Twitter)</a>にご連絡ください。</p>
+    <p>ver.1.5.0 問題点を見つけたら<a href="https://x.com/bonga_bon_bonga">X(旧Twitter)</a>にご連絡ください。</p>
   </footer>
 
   <button id="backToTop" class="back-to-top" type="button" aria-label="TOPへ戻る" hidden>

--- a/nemupipiano-musiclist-search/index.html
+++ b/nemupipiano-musiclist-search/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="../lib/css/bootstrap-reboot.min.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
       integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous">
-  <link rel="stylesheet" href="./css/musiclist-search.css?v=1.4.9" />
+  <link rel="stylesheet" href="./css/musiclist-search.css?v=1.5.0" />
 </head>
 <body>
   <nav class="navbar navbar-expand-md navbar-dark bg-dark fixed-top">
@@ -32,11 +32,11 @@
 
       <section class="tab-panel" id="panel-search" role="tabpanel" aria-labelledby="tab-search">
         <div class="row g-2 g-md-3 align-items-stretch">
-          <div class="col-12 col-md-10">
+          <div class="col-8 col-md-10">
             <label class="visually-hidden" for="search">検索キーワード</label>
             <input id="search" class="form-control form-control-lg" type="search" placeholder="曲名・アーティストで検索" autocomplete="off" />
           </div>
-          <div class="col-12 col-md-2 d-grid">
+          <div class="col-4 col-md-2 d-grid">
             <button id="searchDetailToggle" class="btn btn-dark btn-lg detail-toggle-button" type="button" aria-expanded="false" aria-controls="searchDetails">▼詳細</button>
           </div>
         </div>
@@ -134,6 +134,16 @@
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <div class="modal-body">
+          <h5>テーマの選択</h5>
+          <div class="setting-options" role="radiogroup" aria-label="テーマの選択">
+            <input class="btn-check" type="radio" name="themeMode" id="themeLight" value="light" autocomplete="off">
+            <label class="btn setting-option-button" for="themeLight">ライト</label>
+            <input class="btn-check" type="radio" name="themeMode" id="themeDark" value="dark" autocomplete="off">
+            <label class="btn setting-option-button" for="themeDark">ダーク</label>
+            <input class="btn-check" type="radio" name="themeMode" id="themeSystem" value="system" autocomplete="off" checked>
+            <label class="btn setting-option-button" for="themeSystem">システム</label>
+          </div>
+          <hr>
           <h5>文字の大きさ</h5>
           <div class="setting-options" role="radiogroup" aria-label="文字の大きさ">
             <input class="btn-check" type="radio" name="panelFontSize" id="fontSizeSmall" value="small" autocomplete="off">
@@ -156,7 +166,7 @@
           <p class="setting-note mt-2 mb-0">※スマホ・タブレット表示の場合、設定した表示列より少なく表示される場合があります</p>
           <hr>
           <div class="d-grid">
-            <button id="reload" class="btn btn-dark settings-reload-button" type="button">再読み込み</button>
+            <button id="reload" class="btn btn-dark settings-reload-button" type="button">曲リストを再読み込みする</button>
           </div>
         </div>
       </div>
@@ -194,6 +204,7 @@
     const GID = "0";
     const MUSICLIST_JSON_PATH = "./data/musiclist.json";
     const RANDOM_COUNT = 10;
+    const THEME_KEY = "nemupipiano:theme";
     const APP_PANEL_FONT_SIZE_KEY = "nemupipiano:appPanelFontSize";
     const ACTIVE_TAB_KEY = "nemupipiano:activeTab";
     const SEARCH_SCOPE_KEY = "nemupipiano:searchScope";
@@ -221,9 +232,11 @@
       copyToast: document.getElementById("copyToast"),
       backToTop: document.getElementById("backToTop"),
       appPanel: document.getElementById("appPanel"),
+      themeModes: document.querySelectorAll("[name='themeMode']"),
       panelFontSizes: document.querySelectorAll("[name='panelFontSize']"),
     };
 
+    const systemThemeQuery = window.matchMedia("(prefers-color-scheme: dark)");
     let songs = [];
     let recommendedSongs = [];
     let musiclistItems = {};
@@ -633,6 +646,21 @@
       els.backToTop.hidden = window.scrollY < 320;
     }
 
+    function resolveTheme(theme) {
+      if (theme === "light" || theme === "dark") return theme;
+      return systemThemeQuery.matches ? "dark" : "light";
+    }
+
+    function applyTheme(theme) {
+      const normalized = ["light", "dark", "system"].includes(theme) ? theme : "system";
+      document.documentElement.dataset.themePreference = normalized;
+      document.documentElement.dataset.theme = resolveTheme(normalized);
+      els.themeModes.forEach(option => {
+        option.checked = option.value === normalized;
+      });
+      localStorage.setItem(THEME_KEY, normalized);
+    }
+
     function applyAppPanelFontSize(size) {
       const normalized = ["small", "medium", "large"].includes(size) ? size : "medium";
       els.appPanel.classList.remove("font-size-small", "font-size-medium", "font-size-large");
@@ -709,6 +737,19 @@
     els.panelFontSizes.forEach(option => {
       option.addEventListener("change", () => applyAppPanelFontSize(option.value));
     });
+    els.themeModes.forEach(option => {
+      option.addEventListener("change", () => applyTheme(option.value));
+    });
+    const handleSystemThemeChange = () => {
+      if (localStorage.getItem(THEME_KEY) === "system") {
+        applyTheme("system");
+      }
+    };
+    if (systemThemeQuery.addEventListener) {
+      systemThemeQuery.addEventListener("change", handleSystemThemeChange);
+    } else if (systemThemeQuery.addListener) {
+      systemThemeQuery.addListener(handleSystemThemeChange);
+    }
     window.addEventListener("scroll", updateBackToTopVisibility, { passive: true });
 
     document.addEventListener("click", (event) => {
@@ -729,6 +770,7 @@
       tab.addEventListener("click", () => switchTab(tab.dataset.tab));
     });
 
+    applyTheme(localStorage.getItem(THEME_KEY));
     applyAppPanelFontSize(localStorage.getItem(APP_PANEL_FONT_SIZE_KEY));
     applyRadioValue(els.searchScopes, localStorage.getItem(SEARCH_SCOPE_KEY), "all");
     displayColumnCount = applyRadioValue(els.displayColumns, localStorage.getItem(DISPLAY_COLUMNS_KEY), "3");


### PR DESCRIPTION
# PR#24 修正内容一覧

## 検索フォーム改善

- 検索フォームから「再読み込み」ボタンを削除
- 検索フォームから「読み込み完了」表示を削除
- 検索フォーム右端に「▼詳細」ボタンを追加
- 「▼詳細」押下時に詳細アコーディオンを開くように修正
- 詳細アコーディオン展開中はボタン表示を「▲詳細」に変更
- 「すべてのジャンル」を検索フォーム直下の詳細アコーディオン内へ移動
- スマホ幅でも検索欄と「詳細」ボタンが1行に収まるよう調整

## 検索対象・フィルタ

- 検索対象の選択状態に応じて検索フォームの placeholder を変更
  - すべて: `曲名・アーティストで検索`
  - 曲名: `曲名で検索`
  - アーティスト: `アーティストで検索`
- 保存済みの検索対象を復元した場合も placeholder が一致するよう対応
- 「弾ける曲」フィルタを統計バッジから「検索対象」の右横へ移動
- 「弾ける曲」はテキスト表示、`ON / OFF` はバッジ表示に変更
- 統計バッジは `全曲数 / 表示中` のみに整理

## 設定モーダル

- 「再読み込み」ボタンを設定モーダル最下部へ移動
- ボタン名を `曲リストを再読み込みする` に変更
- 設定モーダル最上部に「テーマの選択」を追加
- テーマは以下の3種類を選択可能に変更
  - ライト
  - ダーク
  - システム
- テーマ設定を `localStorage` に保存
- 「システム」選択時はOSのカラーモードに追従

## 再読み込みボタン

- 「曲リストを再読み込みする」押下時に読み込み状態を表示
- 読み込み中はスピナーと `読み込み中…` を表示
- 読み込み中はボタンを非活性化して連打を防止
- 読み込み完了後は `読み込み完了しました！` を2秒表示
- 2秒後に `曲リストを再読み込みする` へ戻す
- 読み込み失敗時は `読み込みに失敗しました` を2秒表示

## ダークテーマ調整

- ダークテーマをYouTubeのダークテーマ寄りの黒基調に調整
- 背景、カード、ボタン、チップの色を黒・グレー系に変更
- 選択中ボタンを白背景＋黒文字に調整
- ジャンルバッジや `btn-dark` が白浮きしないよう調整
- `〇 弾ける` バッジをダークテーマ時のみ青紫系に変更