### PR TITLE
お気に入り機能の追加ほか

### DIFF
--- a/nemupipiano-musiclist-search/css/musiclist-search.css
+++ b/nemupipiano-musiclist-search/css/musiclist-search.css
@@ -161,51 +161,6 @@ body {
     padding-inline: .7rem;
 }
 
-.favorite-filter-column {
-    display: flex;
-    align-items: center;
-}
-
-.favorite-filter-button {
-    align-self: center;
-    width: 3.5rem;
-    min-height: 3rem;
-    border-color: transparent;
-    color: var(--page-text);
-    background: transparent;
-    box-shadow: none;
-    font-size: 3.25rem;
-    font-weight: 900;
-    line-height: 1;
-    padding: 0;
-    text-shadow: 0 1px 2px rgba(0, 0, 0, .2);
-}
-
-.favorite-filter-button:hover,
-.favorite-filter-button:focus,
-.favorite-filter-button:active,
-.favorite-filter-button.active:active,
-.favorite-filter-button[aria-pressed="true"]:active {
-    color: var(--page-text);
-    background: transparent !important;
-    border-color: transparent !important;
-    box-shadow: none !important;
-    transform: translateY(-1px);
-}
-
-.favorite-filter-button.active,
-.favorite-filter-button[aria-pressed="true"] {
-    background: transparent !important;
-    border-color: transparent !important;
-    box-shadow: none !important;
-    color: #f59e0b;
-}
-
-html[data-theme="dark"] .favorite-filter-button.active,
-html[data-theme="dark"] .favorite-filter-button[aria-pressed="true"] {
-    color: #facc15;
-}
-
 .settings-reload-button {
     font-weight: 800;
     white-space: nowrap;
@@ -264,7 +219,8 @@ html[data-theme="dark"] .form-select {
 
 .search-scope,
 .display-columns,
-.playable-filter {
+.playable-filter,
+.favorite-filter {
     display: inline-flex;
     flex: 0 0 auto;
     flex-wrap: wrap;
@@ -617,24 +573,6 @@ html[data-theme="dark"] .btn-dark:disabled {
     opacity: 1;
 }
 
-html[data-theme="dark"] .favorite-filter-button,
-html[data-theme="dark"] .favorite-filter-button:hover,
-html[data-theme="dark"] .favorite-filter-button:focus,
-html[data-theme="dark"] .favorite-filter-button:active {
-    color: var(--page-text);
-    background: transparent !important;
-    border-color: transparent !important;
-    box-shadow: none !important;
-}
-
-html[data-theme="dark"] .favorite-filter-button.active,
-html[data-theme="dark"] .favorite-filter-button[aria-pressed="true"] {
-    background: transparent !important;
-    border-color: transparent !important;
-    box-shadow: none !important;
-    color: #facc15;
-}
-
 html[data-theme="dark"] .text-secondary {
     color: var(--page-muted) !important;
 }
@@ -932,19 +870,4 @@ html[data-theme="dark"] .text-secondary {
 
 .app-panel.font-size-large .badge {
     font-size: .95rem !important;
-}
-
-.app-panel.font-size-small .favorite-filter-button {
-    font-size: 2.05rem !important;
-    line-height: 1 !important;
-}
-
-.app-panel.font-size-medium .favorite-filter-button {
-    font-size: 2.35rem !important;
-    line-height: 1 !important;
-}
-
-.app-panel.font-size-large .favorite-filter-button {
-    font-size: 2.65rem !important;
-    line-height: 1 !important;
 }

--- a/nemupipiano-musiclist-search/css/musiclist-search.css
+++ b/nemupipiano-musiclist-search/css/musiclist-search.css
@@ -162,10 +162,26 @@ body {
 }
 
 .favorite-filter-button {
-    font-size: 1.25rem;
-    font-weight: 800;
+    align-self: center;
+    min-height: 3rem;
+    border-color: transparent;
+    color: var(--page-text);
+    background: transparent;
+    box-shadow: none;
+    font-size: 1.85rem;
+    font-weight: 900;
     line-height: 1;
-    padding-inline: .25rem;
+    padding: 0;
+    text-shadow: 0 1px 2px rgba(0, 0, 0, .2);
+}
+
+.favorite-filter-button:hover,
+.favorite-filter-button:focus {
+    color: var(--page-text);
+    background: transparent;
+    border-color: transparent;
+    box-shadow: none;
+    transform: translateY(-1px);
 }
 
 .favorite-filter-button.active,
@@ -179,6 +195,15 @@ html[data-theme="dark"] .favorite-filter-button[aria-pressed="true"] {
 }
 
 .settings-reload-button {
+    font-weight: 800;
+    white-space: nowrap;
+}
+
+.settings-actions {
+    margin-top: 1.25rem;
+}
+
+.settings-clear-favorites-button {
     font-weight: 800;
     white-space: nowrap;
 }
@@ -578,6 +603,20 @@ html[data-theme="dark"] .btn-dark:disabled {
     background-color: #272727;
     border-color: #272727;
     opacity: 1;
+}
+
+html[data-theme="dark"] .favorite-filter-button,
+html[data-theme="dark"] .favorite-filter-button:hover,
+html[data-theme="dark"] .favorite-filter-button:focus {
+    color: var(--page-text);
+    background: transparent;
+    border-color: transparent;
+    box-shadow: none;
+}
+
+html[data-theme="dark"] .favorite-filter-button.active,
+html[data-theme="dark"] .favorite-filter-button[aria-pressed="true"] {
+    color: #ff4e80;
 }
 
 html[data-theme="dark"] .text-secondary {

--- a/nemupipiano-musiclist-search/css/musiclist-search.css
+++ b/nemupipiano-musiclist-search/css/musiclist-search.css
@@ -168,13 +168,13 @@ body {
 
 .favorite-filter-button {
     align-self: center;
-    width: 2.25rem;
+    width: 3.5rem;
     min-height: 3rem;
     border-color: transparent;
     color: var(--page-text);
     background: transparent;
     box-shadow: none;
-    font-size: 1.85rem;
+    font-size: 3.25rem;
     font-weight: 900;
     line-height: 1;
     padding: 0;

--- a/nemupipiano-musiclist-search/css/musiclist-search.css
+++ b/nemupipiano-musiclist-search/css/musiclist-search.css
@@ -161,8 +161,14 @@ body {
     padding-inline: .7rem;
 }
 
+.favorite-filter-column {
+    display: flex;
+    align-items: center;
+}
+
 .favorite-filter-button {
     align-self: center;
+    width: 2.25rem;
     min-height: 3rem;
     border-color: transparent;
     color: var(--page-text);
@@ -176,16 +182,22 @@ body {
 }
 
 .favorite-filter-button:hover,
-.favorite-filter-button:focus {
+.favorite-filter-button:focus,
+.favorite-filter-button:active,
+.favorite-filter-button.active:active,
+.favorite-filter-button[aria-pressed="true"]:active {
     color: var(--page-text);
-    background: transparent;
-    border-color: transparent;
-    box-shadow: none;
+    background: transparent !important;
+    border-color: transparent !important;
+    box-shadow: none !important;
     transform: translateY(-1px);
 }
 
 .favorite-filter-button.active,
 .favorite-filter-button[aria-pressed="true"] {
+    background: transparent !important;
+    border-color: transparent !important;
+    box-shadow: none !important;
     color: #f43f5e;
 }
 
@@ -607,15 +619,19 @@ html[data-theme="dark"] .btn-dark:disabled {
 
 html[data-theme="dark"] .favorite-filter-button,
 html[data-theme="dark"] .favorite-filter-button:hover,
-html[data-theme="dark"] .favorite-filter-button:focus {
+html[data-theme="dark"] .favorite-filter-button:focus,
+html[data-theme="dark"] .favorite-filter-button:active {
     color: var(--page-text);
-    background: transparent;
-    border-color: transparent;
-    box-shadow: none;
+    background: transparent !important;
+    border-color: transparent !important;
+    box-shadow: none !important;
 }
 
 html[data-theme="dark"] .favorite-filter-button.active,
 html[data-theme="dark"] .favorite-filter-button[aria-pressed="true"] {
+    background: transparent !important;
+    border-color: transparent !important;
+    box-shadow: none !important;
     color: #ff4e80;
 }
 

--- a/nemupipiano-musiclist-search/css/musiclist-search.css
+++ b/nemupipiano-musiclist-search/css/musiclist-search.css
@@ -198,12 +198,12 @@ body {
     background: transparent !important;
     border-color: transparent !important;
     box-shadow: none !important;
-    color: #f43f5e;
+    color: #f59e0b;
 }
 
 html[data-theme="dark"] .favorite-filter-button.active,
 html[data-theme="dark"] .favorite-filter-button[aria-pressed="true"] {
-    color: #ff4e80;
+    color: #facc15;
 }
 
 .settings-reload-button {
@@ -632,7 +632,7 @@ html[data-theme="dark"] .favorite-filter-button[aria-pressed="true"] {
     background: transparent !important;
     border-color: transparent !important;
     box-shadow: none !important;
-    color: #ff4e80;
+    color: #facc15;
 }
 
 html[data-theme="dark"] .text-secondary {

--- a/nemupipiano-musiclist-search/css/musiclist-search.css
+++ b/nemupipiano-musiclist-search/css/musiclist-search.css
@@ -20,6 +20,8 @@
     --page-filter-active-bg: #ffedd5;
     --page-filter-active-text: #9a3412;
     --page-filter-active-border: #fdba74;
+    --favorite-card-bg: #fffbeb;
+    --favorite-card-border: #fde68a;
 }
 
 html[data-theme="dark"] {
@@ -44,6 +46,8 @@ html[data-theme="dark"] {
     --page-filter-active-bg: #263850;
     --page-filter-active-text: #f1f1f1;
     --page-filter-active-border: #3ea6ff;
+    --favorite-card-bg: #1f2937;
+    --favorite-card-border: #38bdf8;
 }
 
 body {
@@ -157,6 +161,23 @@ body {
     padding-inline: .7rem;
 }
 
+.favorite-filter-button {
+    font-size: 1.25rem;
+    font-weight: 800;
+    line-height: 1;
+    padding-inline: .25rem;
+}
+
+.favorite-filter-button.active,
+.favorite-filter-button[aria-pressed="true"] {
+    color: #f43f5e;
+}
+
+html[data-theme="dark"] .favorite-filter-button.active,
+html[data-theme="dark"] .favorite-filter-button[aria-pressed="true"] {
+    color: #ff4e80;
+}
+
 .settings-reload-button {
     font-weight: 800;
     white-space: nowrap;
@@ -254,7 +275,14 @@ html[data-theme="dark"] .form-select {
     border-radius: 1.25rem;
     min-height: 100%;
     cursor: pointer;
+    touch-action: manipulation;
+    user-select: none;
     transition: transform .15s ease, box-shadow .15s ease, border-color .15s ease;
+}
+
+.song-card.is-favorite {
+    background: var(--favorite-card-bg);
+    border-color: var(--favorite-card-border);
 }
 
 .song-card:hover,

--- a/nemupipiano-musiclist-search/css/musiclist-search.css
+++ b/nemupipiano-musiclist-search/css/musiclist-search.css
@@ -217,6 +217,14 @@ html[data-theme="dark"] .form-select {
     gap: .5rem 1rem;
 }
 
+.quick-filter-group {
+    display: inline-flex;
+    flex: 0 0 auto;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: .5rem 1rem;
+}
+
 .search-scope,
 .display-columns,
 .playable-filter,
@@ -693,6 +701,16 @@ html[data-theme="dark"] .text-secondary {
     .result-controls {
     align-items: flex-start;
     flex-direction: column;
+    }
+
+    .quick-filter-group {
+    flex-wrap: nowrap;
+    gap: .5rem;
+    max-width: 100%;
+    }
+
+    .quick-filter-group .stat-filter-button {
+    white-space: nowrap;
     }
 
     .song-card {

--- a/nemupipiano-musiclist-search/css/musiclist-search.css
+++ b/nemupipiano-musiclist-search/css/musiclist-search.css
@@ -934,7 +934,17 @@ html[data-theme="dark"] .text-secondary {
     font-size: .95rem !important;
 }
 
-.app-panel .favorite-filter-button {
-    font-size: 3.25rem !important;
+.app-panel.font-size-small .favorite-filter-button {
+    font-size: 2.05rem !important;
+    line-height: 1 !important;
+}
+
+.app-panel.font-size-medium .favorite-filter-button {
+    font-size: 2.35rem !important;
+    line-height: 1 !important;
+}
+
+.app-panel.font-size-large .favorite-filter-button {
+    font-size: 2.65rem !important;
     line-height: 1 !important;
 }

--- a/nemupipiano-musiclist-search/css/musiclist-search.css
+++ b/nemupipiano-musiclist-search/css/musiclist-search.css
@@ -933,3 +933,8 @@ html[data-theme="dark"] .text-secondary {
 .app-panel.font-size-large .badge {
     font-size: .95rem !important;
 }
+
+.app-panel .favorite-filter-button {
+    font-size: 3.25rem !important;
+    line-height: 1 !important;
+}

--- a/nemupipiano-musiclist-search/index.html
+++ b/nemupipiano-musiclist-search/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="../lib/css/bootstrap-reboot.min.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
       integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous">
-  <link rel="stylesheet" href="./css/musiclist-search.css?v=1.6.3" />
+  <link rel="stylesheet" href="./css/musiclist-search.css?v=1.6.4" />
 </head>
 <body>
   <nav class="navbar navbar-expand-md navbar-dark bg-dark fixed-top">
@@ -60,12 +60,14 @@
             <input class="btn-check" type="radio" name="searchScope" id="searchScopeArtist" value="artist" autocomplete="off">
             <label class="btn search-scope-button" for="searchScopeArtist">アーティスト</label>
           </div>
-          <div class="playable-filter" aria-label="弾ける曲フィルター">
-            <span class="playable-filter-label">弾ける曲</span>
-            <button class="badge rounded-pill stat-badge stat-filter-button px-3 py-2" id="playableFilter" type="button" data-filter="playable" aria-pressed="false">OFF</button>
-          </div>
-          <div class="favorite-filter" aria-label="お気に入りフィルター">
-            <button class="badge rounded-pill stat-badge stat-filter-button px-3 py-2" id="favoriteFilter" type="button" aria-pressed="false">☆お気に入りのみ</button>
+          <div class="quick-filter-group">
+            <div class="playable-filter" aria-label="弾ける曲フィルター">
+              <span class="playable-filter-label">弾ける曲</span>
+              <button class="badge rounded-pill stat-badge stat-filter-button px-3 py-2" id="playableFilter" type="button" data-filter="playable" aria-pressed="false">OFF</button>
+            </div>
+            <div class="favorite-filter" aria-label="お気に入りフィルター">
+              <button class="badge rounded-pill stat-badge stat-filter-button px-3 py-2" id="favoriteFilter" type="button" aria-pressed="false">☆お気に入りのみ</button>
+            </div>
           </div>
         </div>
 

--- a/nemupipiano-musiclist-search/index.html
+++ b/nemupipiano-musiclist-search/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="../lib/css/bootstrap-reboot.min.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
       integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous">
-  <link rel="stylesheet" href="./css/musiclist-search.css?v=1.6.0" />
+  <link rel="stylesheet" href="./css/musiclist-search.css?v=1.6.1" />
 </head>
 <body>
   <nav class="navbar navbar-expand-md navbar-dark bg-dark fixed-top">

--- a/nemupipiano-musiclist-search/index.html
+++ b/nemupipiano-musiclist-search/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="../lib/css/bootstrap-reboot.min.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
       integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous">
-  <link rel="stylesheet" href="./css/musiclist-search.css?v=1.6.2" />
+  <link rel="stylesheet" href="./css/musiclist-search.css?v=1.6.3" />
 </head>
 <body>
   <nav class="navbar navbar-expand-md navbar-dark bg-dark fixed-top">
@@ -32,14 +32,11 @@
 
       <section class="tab-panel" id="panel-search" role="tabpanel" aria-labelledby="tab-search">
         <div class="row g-2 g-md-3 align-items-stretch">
-          <div class="col">
+          <div class="col-8 col-md-10">
             <label class="visually-hidden" for="search">検索キーワード</label>
             <input id="search" class="form-control form-control-lg" type="search" placeholder="曲名・アーティストで検索" autocomplete="off" />
           </div>
-          <div class="col-auto favorite-filter-column">
-            <button id="favoriteFilter" class="btn btn-dark btn-lg favorite-filter-button" type="button" aria-label="お気に入りのみ表示" aria-pressed="false">☆</button>
-          </div>
-          <div class="col-auto col-md-2 d-grid">
+          <div class="col-4 col-md-2 d-grid">
             <button id="searchDetailToggle" class="btn btn-dark btn-lg detail-toggle-button" type="button" aria-expanded="false" aria-controls="searchDetails">▼詳細</button>
           </div>
         </div>
@@ -66,6 +63,9 @@
           <div class="playable-filter" aria-label="弾ける曲フィルター">
             <span class="playable-filter-label">弾ける曲</span>
             <button class="badge rounded-pill stat-badge stat-filter-button px-3 py-2" id="playableFilter" type="button" data-filter="playable" aria-pressed="false">OFF</button>
+          </div>
+          <div class="favorite-filter" aria-label="お気に入りフィルター">
+            <button class="badge rounded-pill stat-badge stat-filter-button px-3 py-2" id="favoriteFilter" type="button" aria-pressed="false">☆お気に入りのみ</button>
           </div>
         </div>
 
@@ -372,7 +372,7 @@
       els.favoriteFilter.classList.toggle("active", favoriteOnly);
       els.favoriteFilter.setAttribute("aria-pressed", String(favoriteOnly));
       els.favoriteFilter.setAttribute("aria-label", favoriteOnly ? "お気に入りのみ表示中" : "お気に入りのみ表示");
-      els.favoriteFilter.textContent = favoriteOnly ? "★" : "☆";
+      els.favoriteFilter.textContent = favoriteOnly ? "★お気に入りのみ" : "☆お気に入りのみ";
     }
 
     function clearAllFavorites() {

--- a/nemupipiano-musiclist-search/index.html
+++ b/nemupipiano-musiclist-search/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="../lib/css/bootstrap-reboot.min.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
       integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous">
-  <link rel="stylesheet" href="./css/musiclist-search.css?v=1.6.1" />
+  <link rel="stylesheet" href="./css/musiclist-search.css?v=1.6.2" />
 </head>
 <body>
   <nav class="navbar navbar-expand-md navbar-dark bg-dark fixed-top">

--- a/nemupipiano-musiclist-search/index.html
+++ b/nemupipiano-musiclist-search/index.html
@@ -37,7 +37,7 @@
             <input id="search" class="form-control form-control-lg" type="search" placeholder="曲名・アーティストで検索" autocomplete="off" />
           </div>
           <div class="col-auto favorite-filter-column">
-            <button id="favoriteFilter" class="btn btn-dark btn-lg favorite-filter-button" type="button" aria-label="お気に入りのみ表示" aria-pressed="false">♡</button>
+            <button id="favoriteFilter" class="btn btn-dark btn-lg favorite-filter-button" type="button" aria-label="お気に入りのみ表示" aria-pressed="false">☆</button>
           </div>
           <div class="col-auto col-md-2 d-grid">
             <button id="searchDetailToggle" class="btn btn-dark btn-lg detail-toggle-button" type="button" aria-expanded="false" aria-controls="searchDetails">▼詳細</button>
@@ -372,7 +372,7 @@
       els.favoriteFilter.classList.toggle("active", favoriteOnly);
       els.favoriteFilter.setAttribute("aria-pressed", String(favoriteOnly));
       els.favoriteFilter.setAttribute("aria-label", favoriteOnly ? "お気に入りのみ表示中" : "お気に入りのみ表示");
-      els.favoriteFilter.textContent = favoriteOnly ? "♥" : "♡";
+      els.favoriteFilter.textContent = favoriteOnly ? "★" : "☆";
     }
 
     function clearAllFavorites() {

--- a/nemupipiano-musiclist-search/index.html
+++ b/nemupipiano-musiclist-search/index.html
@@ -195,7 +195,7 @@
   </div>
 
   <footer class="site-footer fixed-bottom mx-0 bg-black bg-opacity-75 text-center text-white">
-    <p>ver.1.6.0 問題点を見つけたら<a href="https://x.com/bonga_bon_bonga">X(旧Twitter)</a>にご連絡ください。</p>
+    <p>ver.1.6.4 問題点を見つけたら<a href="https://x.com/bonga_bon_bonga">X(旧Twitter)</a>にご連絡ください。</p>
   </footer>
 
   <button id="backToTop" class="back-to-top" type="button" aria-label="TOPへ戻る" hidden>

--- a/nemupipiano-musiclist-search/index.html
+++ b/nemupipiano-musiclist-search/index.html
@@ -171,8 +171,8 @@
             <label class="btn display-columns-button" for="displayColumns3">3列</label>
           </div>
           <p class="setting-note mt-2 mb-0">※スマホ・タブレット表示の場合、設定した表示列より少なく表示される場合があります</p>
-          <hr>
-          <div class="d-grid">
+          <div class="settings-actions d-grid gap-2">
+            <button id="clearFavorites" class="btn btn-outline-danger settings-clear-favorites-button" type="button">お気に入りを全解除</button>
             <button id="reload" class="btn btn-dark settings-reload-button" type="button">曲リストを再読み込みする</button>
           </div>
         </div>
@@ -232,6 +232,7 @@
       displayColumns: document.querySelectorAll("[name='displayColumns']"),
       genre: document.getElementById("genre"),
       reload: document.getElementById("reload"),
+      clearFavorites: document.getElementById("clearFavorites"),
       favoriteFilter: document.getElementById("favoriteFilter"),
       searchDetailToggle: document.getElementById("searchDetailToggle"),
       searchDetails: document.getElementById("searchDetails"),
@@ -372,6 +373,23 @@
       els.favoriteFilter.setAttribute("aria-pressed", String(favoriteOnly));
       els.favoriteFilter.setAttribute("aria-label", favoriteOnly ? "お気に入りのみ表示中" : "お気に入りのみ表示");
       els.favoriteFilter.textContent = favoriteOnly ? "♥" : "♡";
+    }
+
+    function clearAllFavorites() {
+      if (favoriteKeys.size === 0) {
+        showCopyToast("お気に入りは登録されていません");
+        return;
+      }
+
+      if (!window.confirm("登録したお気に入りをすべて解除します。よろしいですか？")) return;
+
+      favoriteKeys.clear();
+      saveFavoriteKeys();
+      favoriteOnly = false;
+      localStorage.setItem(FAVORITES_ONLY_KEY, String(favoriteOnly));
+      render();
+      renderRandom();
+      showCopyToast("お気に入りをすべて解除しました");
     }
 
     function setReloadButtonState(state) {
@@ -885,6 +903,7 @@
       localStorage.setItem(FAVORITES_ONLY_KEY, String(favoriteOnly));
       render();
     });
+    els.clearFavorites.addEventListener("click", clearAllFavorites);
     els.randomStats.addEventListener("click", (event) => {
       const button = event.target.closest("[data-random-filter='playable']");
       if (!button) return;

--- a/nemupipiano-musiclist-search/index.html
+++ b/nemupipiano-musiclist-search/index.html
@@ -32,14 +32,14 @@
 
       <section class="tab-panel" id="panel-search" role="tabpanel" aria-labelledby="tab-search">
         <div class="row g-2 g-md-3 align-items-stretch">
-          <div class="col-7 col-md-9">
+          <div class="col">
             <label class="visually-hidden" for="search">検索キーワード</label>
             <input id="search" class="form-control form-control-lg" type="search" placeholder="曲名・アーティストで検索" autocomplete="off" />
           </div>
-          <div class="col-2 col-md-1 d-grid">
+          <div class="col-auto favorite-filter-column">
             <button id="favoriteFilter" class="btn btn-dark btn-lg favorite-filter-button" type="button" aria-label="お気に入りのみ表示" aria-pressed="false">♡</button>
           </div>
-          <div class="col-3 col-md-2 d-grid">
+          <div class="col-auto col-md-2 d-grid">
             <button id="searchDetailToggle" class="btn btn-dark btn-lg detail-toggle-button" type="button" aria-expanded="false" aria-controls="searchDetails">▼詳細</button>
           </div>
         </div>

--- a/nemupipiano-musiclist-search/index.html
+++ b/nemupipiano-musiclist-search/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="../lib/css/bootstrap-reboot.min.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
       integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous">
-  <link rel="stylesheet" href="./css/musiclist-search.css?v=1.5.0" />
+  <link rel="stylesheet" href="./css/musiclist-search.css?v=1.6.0" />
 </head>
 <body>
   <nav class="navbar navbar-expand-md navbar-dark bg-dark fixed-top">
@@ -32,11 +32,14 @@
 
       <section class="tab-panel" id="panel-search" role="tabpanel" aria-labelledby="tab-search">
         <div class="row g-2 g-md-3 align-items-stretch">
-          <div class="col-8 col-md-10">
+          <div class="col-7 col-md-9">
             <label class="visually-hidden" for="search">検索キーワード</label>
             <input id="search" class="form-control form-control-lg" type="search" placeholder="曲名・アーティストで検索" autocomplete="off" />
           </div>
-          <div class="col-4 col-md-2 d-grid">
+          <div class="col-2 col-md-1 d-grid">
+            <button id="favoriteFilter" class="btn btn-dark btn-lg favorite-filter-button" type="button" aria-label="お気に入りのみ表示" aria-pressed="false">♡</button>
+          </div>
+          <div class="col-3 col-md-2 d-grid">
             <button id="searchDetailToggle" class="btn btn-dark btn-lg detail-toggle-button" type="button" aria-expanded="false" aria-controls="searchDetails">▼詳細</button>
           </div>
         </div>
@@ -215,7 +218,13 @@
     const DISPLAY_COLUMNS_KEY = "nemupipiano:displayColumns";
     const PLAYABLE_ONLY_KEY = "nemupipiano:playableOnly";
     const RANDOM_PLAYABLE_ONLY_KEY = "nemupipiano:randomPlayableOnly";
+    const FAVORITES_KEY = "nemupipiano:favorites";
+    const FAVORITES_ONLY_KEY = "nemupipiano:favoritesOnly";
+    const COPY_COUNTS_KEY = "nemupipiano:copyCounts";
+    const COPY_HISTORY_KEY = "nemupipiano:copyHistory";
     const RELOAD_BUTTON_DEFAULT_TEXT = "曲リストを再読み込みする";
+    const LONG_PRESS_MS = 1000;
+    const COPY_HISTORY_LIMIT = 20;
 
     const els = {
       search: document.getElementById("search"),
@@ -223,6 +232,7 @@
       displayColumns: document.querySelectorAll("[name='displayColumns']"),
       genre: document.getElementById("genre"),
       reload: document.getElementById("reload"),
+      favoriteFilter: document.getElementById("favoriteFilter"),
       searchDetailToggle: document.getElementById("searchDetailToggle"),
       searchDetails: document.getElementById("searchDetails"),
       playableFilter: document.getElementById("playableFilter"),
@@ -248,8 +258,15 @@
     let musiclistItems = {};
     let playableOnly = false;
     let randomPlayableOnly = true;
+    let favoriteOnly = false;
+    let favoriteKeys = new Set();
     let displayColumnCount = "3";
     let reloadFeedbackTimer = null;
+    let longPressTimer = null;
+    let longPressHandled = false;
+    let longPressSuppressTimer = null;
+    let longPressStartX = 0;
+    let longPressStartY = 0;
 
     // HTMLエスケープを行う関数。& < > " ' をそれぞれ対応するHTMLエンティティに置換する。nullやundefinedも空文字に変換する。
     function escapeHtml(value) {
@@ -317,6 +334,44 @@
         artistAliases: extra.artistAliases || [],
         tags: extra.tags || [],
       };
+    }
+
+    function readJsonStorage(key, fallback) {
+      try {
+        const raw = localStorage.getItem(key);
+        return raw ? JSON.parse(raw) : fallback;
+      } catch (error) {
+        console.warn(`localStorageの読み込みに失敗しました: ${key}`, error);
+        return fallback;
+      }
+    }
+
+    function writeJsonStorage(key, value) {
+      localStorage.setItem(key, JSON.stringify(value));
+    }
+
+    function favoriteKeyForSong(song) {
+      return `${normalizeCellText(song.title)}|${normalizeCellText(song.artist)}`;
+    }
+
+    function loadFavoriteKeys() {
+      const saved = readJsonStorage(FAVORITES_KEY, []);
+      favoriteKeys = new Set(Array.isArray(saved) ? saved : []);
+    }
+
+    function saveFavoriteKeys() {
+      writeJsonStorage(FAVORITES_KEY, [...favoriteKeys]);
+    }
+
+    function isFavorite(song) {
+      return favoriteKeys.has(favoriteKeyForSong(song));
+    }
+
+    function updateFavoriteFilterButton() {
+      els.favoriteFilter.classList.toggle("active", favoriteOnly);
+      els.favoriteFilter.setAttribute("aria-pressed", String(favoriteOnly));
+      els.favoriteFilter.setAttribute("aria-label", favoriteOnly ? "お気に入りのみ表示中" : "お気に入りのみ表示");
+      els.favoriteFilter.textContent = favoriteOnly ? "♥" : "♡";
     }
 
     function setReloadButtonState(state) {
@@ -538,7 +593,8 @@
         const keywordOk = matchesSearchKeyword(song, keyword, searchScope);
         const genreOk = !genre || song.genre === genre;
         const playableOk = !playableOnly || isPlayable(song);
-        return keywordOk && genreOk && playableOk;
+        const favoriteOk = !favoriteOnly || isFavorite(song);
+        return keywordOk && genreOk && playableOk && favoriteOk;
       });
     }
 
@@ -582,7 +638,7 @@
     function renderSongCards(items) {
       return items.map(song => `
         <div class="col">
-          <article class="card song-card h-100" role="button" tabindex="0" data-copy-song="${escapeHtml(song.title)}" data-copy-artist="${escapeHtml(song.artist)}" data-copy-no="${escapeHtml(song.no)}" aria-label="${escapeHtml(song.title)}をリクエスト形式でコピー">
+          <article class="card song-card h-100 ${isFavorite(song) ? "is-favorite" : ""}" role="button" tabindex="0" data-copy-song="${escapeHtml(song.title)}" data-copy-artist="${escapeHtml(song.artist)}" data-copy-no="${escapeHtml(song.no)}" aria-label="${escapeHtml(song.title)}をリクエスト形式でコピー">
             <div class="card-body song-card-body d-flex flex-column gap-2 p-3 p-md-4">
               <div class="song-card-header d-flex justify-content-between gap-3 align-items-start">
                 <div class="song-card-text min-w-0">
@@ -611,6 +667,7 @@
       els.playableFilter.classList.toggle("active", playableOnly);
       els.playableFilter.setAttribute("aria-pressed", String(playableOnly));
       els.playableFilter.textContent = playableOnly ? "ON" : "OFF";
+      updateFavoriteFilterButton();
 
       els.empty.hidden = items.length !== 0;
       els.songs.innerHTML = renderSongCards(items);
@@ -680,10 +737,59 @@
 
       try {
         await copyToClipboard(text);
+        recordCopyHistory({ no, title, artist, text });
         showCopyToast("クリップボードにコピーしました！", text);
       } catch (error) {
         console.error(error);
         showCopyToast("コピーに失敗しました");
+      }
+    }
+
+    function recordCopyHistory({ no, title, artist, text }) {
+      const key = favoriteKeyForSong({ title, artist });
+      const savedCounts = readJsonStorage(COPY_COUNTS_KEY, {});
+      const counts = savedCounts && !Array.isArray(savedCounts) && typeof savedCounts === "object" ? savedCounts : {};
+      counts[key] = (Number(counts[key]) || 0) + 1;
+      writeJsonStorage(COPY_COUNTS_KEY, counts);
+
+      const savedHistory = readJsonStorage(COPY_HISTORY_KEY, []);
+      const history = Array.isArray(savedHistory) ? savedHistory : [];
+      history.unshift({
+        key,
+        no,
+        title,
+        artist,
+        text,
+        copiedAt: new Date().toISOString(),
+        count: counts[key],
+      });
+      writeJsonStorage(COPY_HISTORY_KEY, history.slice(0, COPY_HISTORY_LIMIT));
+    }
+
+    function toggleFavoriteFromCard(card) {
+      const title = card.dataset.copySong || "";
+      const artist = card.dataset.copyArtist || "";
+      const key = favoriteKeyForSong({ title, artist });
+      const willFavorite = !favoriteKeys.has(key);
+
+      if (willFavorite) {
+        favoriteKeys.add(key);
+      } else {
+        favoriteKeys.delete(key);
+      }
+
+      saveFavoriteKeys();
+      render();
+      renderRandom();
+      showCopyToast(
+        willFavorite ? `${title}をお気に入りにしました！` : `${title}をお気に入りから解除しました`
+      );
+    }
+
+    function clearLongPressTimer() {
+      if (longPressTimer) {
+        clearTimeout(longPressTimer);
+        longPressTimer = null;
       }
     }
 
@@ -772,6 +878,11 @@
       localStorage.setItem(PLAYABLE_ONLY_KEY, String(playableOnly));
       render();
     });
+    els.favoriteFilter.addEventListener("click", () => {
+      favoriteOnly = !favoriteOnly;
+      localStorage.setItem(FAVORITES_ONLY_KEY, String(favoriteOnly));
+      render();
+    });
     els.randomStats.addEventListener("click", (event) => {
       const button = event.target.closest("[data-random-filter='playable']");
       if (!button) return;
@@ -810,9 +921,47 @@
     }
     window.addEventListener("scroll", updateBackToTopVisibility, { passive: true });
 
+    document.addEventListener("pointerdown", (event) => {
+      const card = event.target.closest("[data-copy-song]");
+      if (!card) return;
+
+      clearLongPressTimer();
+      longPressHandled = false;
+      longPressStartX = event.clientX;
+      longPressStartY = event.clientY;
+      longPressTimer = setTimeout(() => {
+        longPressHandled = true;
+        clearTimeout(longPressSuppressTimer);
+        longPressSuppressTimer = setTimeout(() => {
+          longPressHandled = false;
+        }, 800);
+        toggleFavoriteFromCard(card);
+      }, LONG_PRESS_MS);
+    });
+
+    document.addEventListener("pointermove", (event) => {
+      if (!longPressTimer) return;
+      const movedX = Math.abs(event.clientX - longPressStartX);
+      const movedY = Math.abs(event.clientY - longPressStartY);
+      if (movedX > 10 || movedY > 10) {
+        clearLongPressTimer();
+      }
+    });
+
+    ["pointerup", "pointercancel", "pointerleave"].forEach(eventName => {
+      document.addEventListener(eventName, clearLongPressTimer);
+    });
+
     document.addEventListener("click", (event) => {
       const card = event.target.closest("[data-copy-song]");
       if (!card) return;
+      if (longPressHandled) {
+        event.preventDefault();
+        clearTimeout(longPressSuppressTimer);
+        longPressSuppressTimer = null;
+        longPressHandled = false;
+        return;
+      }
       handleCardCopy(card);
     });
 
@@ -834,6 +983,8 @@
     displayColumnCount = applyRadioValue(els.displayColumns, localStorage.getItem(DISPLAY_COLUMNS_KEY), "3");
     playableOnly = loadSavedBoolean(PLAYABLE_ONLY_KEY, false);
     randomPlayableOnly = loadSavedBoolean(RANDOM_PLAYABLE_ONLY_KEY, true);
+    favoriteOnly = loadSavedBoolean(FAVORITES_ONLY_KEY, false);
+    loadFavoriteKeys();
     setSearchDetailsOpen(false);
     applyColumnLayout();
     switchTab(localStorage.getItem(ACTIVE_TAB_KEY));

--- a/nemupipiano-musiclist-search/index.html
+++ b/nemupipiano-musiclist-search/index.html
@@ -190,7 +190,7 @@
   </div>
 
   <footer class="site-footer fixed-bottom mx-0 bg-black bg-opacity-75 text-center text-white">
-    <p>ver.1.5.0 問題点を見つけたら<a href="https://x.com/bonga_bon_bonga">X(旧Twitter)</a>にご連絡ください。</p>
+    <p>ver.1.6.0 問題点を見つけたら<a href="https://x.com/bonga_bon_bonga">X(旧Twitter)</a>にご連絡ください。</p>
   </footer>
 
   <button id="backToTop" class="back-to-top" type="button" aria-label="TOPへ戻る" hidden>

--- a/nemupipiano-musiclist-search/index.html
+++ b/nemupipiano-musiclist-search/index.html
@@ -224,7 +224,7 @@
     const COPY_HISTORY_KEY = "nemupipiano:copyHistory";
     const RELOAD_BUTTON_DEFAULT_TEXT = "曲リストを再読み込みする";
     const LONG_PRESS_MS = 1000;
-    const COPY_HISTORY_LIMIT = 20;
+    const COPY_HISTORY_LIMIT = 500;
 
     const els = {
       search: document.getElementById("search"),
@@ -754,13 +754,15 @@
 
       const savedHistory = readJsonStorage(COPY_HISTORY_KEY, []);
       const history = Array.isArray(savedHistory) ? savedHistory : [];
+      const timestamp = new Date().toISOString();
       history.unshift({
         key,
         no,
         title,
         artist,
         text,
-        copiedAt: new Date().toISOString(),
+        copiedAt: timestamp,
+        timestamp,
         count: counts[key],
       });
       writeJsonStorage(COPY_HISTORY_KEY, history.slice(0, COPY_HISTORY_LIMIT));


### PR DESCRIPTION
# PR#25 修正内容

## お気に入り機能

- 曲名カードを1秒長押しでお気に入り登録・解除できるように追加
- お気に入り状態をLocalStorageに保存
- お気に入り登録済みカードの背景色をテーマ別に変更
  - ライト：薄い黄色
  - ダーク：薄い青系

## お気に入りフィルタ

- 「弾ける曲」の右側にお気に入りフィルタを追加
- OFF時：`☆お気に入りのみ`
- ON時：`★お気に入りのみ`
- スマホ幅でも「弾ける曲」と横並び表示

## コピー履歴

- カード押下によるコピー回数をLocalStorageに保存
- 直近コピー履歴を最大500件まで保存
- 履歴には曲名・アーティスト・タイムスタンプを保存

## 設定

- 設定モーダルに「お気に入りを全解除」ボタンを追加
- 実行前に確認ダイアログを表示

# PR#25 追加修正内容

## スマホ表示の設定モーダル調整

- スマホ幅のみ、設定モーダルに高さ上限を追加
- モーダル本文部分をスクロール表示に変更
- 左下の設定アイコンが「お気に入りを全解除」ボタンに被りにくいよう調整

## 長押し操作の改善

- 曲名カード長押し時に、テキスト選択と競合しにくいよう修正
- カード内テキストの選択を抑制
- iOS Safari等の長押しメニュー表示を抑制

## 処理速度の改善

- お気に入り登録・解除時の再描画処理を軽量化
- 通常表示では全カードを再描画せず、対象カードのみ表示更新するよう修正
