### PR TITLE
Refine mobile settings and favorite toggle

### DIFF
--- a/nemupipiano-musiclist-search/css/musiclist-search.css
+++ b/nemupipiano-musiclist-search/css/musiclist-search.css
@@ -277,8 +277,15 @@ html[data-theme="dark"] .form-select {
     min-height: 100%;
     cursor: pointer;
     touch-action: manipulation;
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
     user-select: none;
     transition: transform .15s ease, box-shadow .15s ease, border-color .15s ease;
+}
+
+.song-card * {
+    -webkit-user-select: none;
+    user-select: none;
 }
 
 .song-card.is-favorite {
@@ -711,6 +718,22 @@ html[data-theme="dark"] .text-secondary {
 
     .quick-filter-group .stat-filter-button {
     white-space: nowrap;
+    }
+
+    #settingsModal .modal-dialog {
+    margin: .75rem 1rem;
+    }
+
+    #settingsModal .modal-content {
+    max-height: calc(100vh - 8.75rem);
+    max-height: calc(100dvh - 8.75rem);
+    overflow: hidden;
+    }
+
+    #settingsModal .modal-body {
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+    padding-bottom: 1rem;
     }
 
     .song-card {

--- a/nemupipiano-musiclist-search/index.html
+++ b/nemupipiano-musiclist-search/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="../lib/css/bootstrap-reboot.min.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
       integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous">
-  <link rel="stylesheet" href="./css/musiclist-search.css?v=1.6.4" />
+  <link rel="stylesheet" href="./css/musiclist-search.css?v=1.6.5" />
 </head>
 <body>
   <nav class="navbar navbar-expand-md navbar-dark bg-dark fixed-top">
@@ -658,7 +658,7 @@
     function renderSongCards(items) {
       return items.map(song => `
         <div class="col">
-          <article class="card song-card h-100 ${isFavorite(song) ? "is-favorite" : ""}" role="button" tabindex="0" data-copy-song="${escapeHtml(song.title)}" data-copy-artist="${escapeHtml(song.artist)}" data-copy-no="${escapeHtml(song.no)}" aria-label="${escapeHtml(song.title)}をリクエスト形式でコピー">
+          <article class="card song-card h-100 ${isFavorite(song) ? "is-favorite" : ""}" role="button" tabindex="0" data-copy-song="${escapeHtml(song.title)}" data-copy-artist="${escapeHtml(song.artist)}" data-copy-no="${escapeHtml(song.no)}" data-favorite-key="${escapeHtml(favoriteKeyForSong(song))}" aria-label="${escapeHtml(song.title)}をリクエスト形式でコピー">
             <div class="card-body song-card-body d-flex flex-column gap-2 p-3 p-md-4">
               <div class="song-card-header d-flex justify-content-between gap-3 align-items-start">
                 <div class="song-card-text min-w-0">
@@ -801,11 +801,23 @@
       }
 
       saveFavoriteKeys();
-      render();
-      renderRandom();
+      if (favoriteOnly) {
+        render();
+        renderRandom();
+      } else {
+        updateFavoriteCards(key, willFavorite);
+      }
       showCopyToast(
         willFavorite ? `${title}をお気に入りにしました！` : `${title}をお気に入りから解除しました`
       );
+    }
+
+    function updateFavoriteCards(key, isFavorited) {
+      document.querySelectorAll("[data-favorite-key]").forEach(card => {
+        if (card.dataset.favoriteKey === key) {
+          card.classList.toggle("is-favorite", isFavorited);
+        }
+      });
     }
 
     function clearLongPressTimer() {
@@ -973,6 +985,18 @@
 
     ["pointerup", "pointercancel", "pointerleave"].forEach(eventName => {
       document.addEventListener(eventName, clearLongPressTimer);
+    });
+
+    document.addEventListener("selectstart", (event) => {
+      if (event.target.closest("[data-copy-song]")) {
+        event.preventDefault();
+      }
+    });
+
+    document.addEventListener("contextmenu", (event) => {
+      if (event.target.closest("[data-copy-song]")) {
+        event.preventDefault();
+      }
     });
 
     document.addEventListener("click", (event) => {


### PR DESCRIPTION
## Summary

- スマホ幅の設定モーダルに高さ上限を追加し、本文部分をスクロール表示に変更
- 設定アイコンが「お気に入りを全解除」ボタンに被りにくいよう調整
- カード長押し時にテキスト選択やiOSの長押しメニューと競合しにくいよう修正
- お気に入り切替時、通常表示では全カード再描画せず対象カードのみ更新するよう軽量化
