### PR TITLE
曲のメタ情報取得の仕組みを実装

### DIFF
--- a/nemupipiano-musiclist-search/data/dictionary/music_metadata.json
+++ b/nemupipiano-musiclist-search/data/dictionary/music_metadata.json
@@ -1,0 +1,19217 @@
+[
+  {
+    "title": "ナイショの話",
+    "artist": "ClariS",
+    "metadata": {
+      "releaseDate": "2012-02-01",
+      "releaseYear": 2012,
+      "decade": "2010年代",
+      "genre": "アニメ",
+      "durationSeconds": 261,
+      "collectionName": "偽物語 劇伴音楽集",
+      "itunesTrackId": 1535798069,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:36:24+09:00"
+  },
+  {
+    "title": "ルパン3世のテーマ",
+    "artist": "大野雄二",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:36:56+09:00"
+  },
+  {
+    "title": "キセキ",
+    "artist": "GReeeeN",
+    "metadata": {
+      "releaseDate": "2008-05-28",
+      "releaseYear": 2008,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 271,
+      "collectionName": "いままでのA面、B面ですと!?",
+      "itunesTrackId": 1440746936,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:36:58+09:00"
+  },
+  {
+    "title": "コネクト",
+    "artist": "ClariS",
+    "metadata": {
+      "releaseDate": "2011-02-02",
+      "releaseYear": 2011,
+      "decade": "2010年代",
+      "genre": "アニメ",
+      "durationSeconds": 272,
+      "collectionName": "コネクト - EP",
+      "itunesTrackId": 1537241619,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:36:59+09:00"
+  },
+  {
+    "title": "レオ",
+    "artist": "優里",
+    "metadata": {
+      "releaseDate": "2022-01-12",
+      "releaseYear": 2022,
+      "decade": "2020年代",
+      "genre": "ロック",
+      "durationSeconds": 239,
+      "collectionName": "壱",
+      "itunesTrackId": 1599543187,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:37:00+09:00"
+  },
+  {
+    "title": "点描の唄",
+    "artist": "Mrs. GREEN APPLE",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:37:02+09:00"
+  },
+  {
+    "title": "千本桜",
+    "artist": "黒うさP",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:37:03+09:00"
+  },
+  {
+    "title": "群青",
+    "artist": "YOASOBI",
+    "metadata": {
+      "releaseDate": "2020-09-01",
+      "releaseYear": 2020,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 248,
+      "collectionName": "群青 - Single",
+      "itunesTrackId": 1528119630,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:37:04+09:00"
+  },
+  {
+    "title": "ドライフラワー",
+    "artist": "優里",
+    "metadata": {
+      "releaseDate": "2020-10-25",
+      "releaseYear": 2020,
+      "decade": "2020年代",
+      "genre": "ロック",
+      "durationSeconds": 286,
+      "collectionName": "ドライフラワー - Single",
+      "itunesTrackId": 1534620183,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:37:06+09:00"
+  },
+  {
+    "title": "春泥棒",
+    "artist": "ヨルシカ",
+    "metadata": {
+      "releaseDate": "2021-01-09",
+      "releaseYear": 2021,
+      "decade": "2020年代",
+      "genre": "ロック",
+      "durationSeconds": 290,
+      "collectionName": "春泥棒 - Single",
+      "itunesTrackId": 1545098596,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:37:07+09:00"
+  },
+  {
+    "title": "DANDAN心惹かれてく",
+    "artist": "FIELD OF VIEW",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:37:09+09:00"
+  },
+  {
+    "title": "夜空",
+    "artist": "音田雅則",
+    "metadata": {
+      "releaseDate": "2022-03-15",
+      "releaseYear": 2022,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 249,
+      "collectionName": "夜空 - Single",
+      "itunesTrackId": 1611322200,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:37:10+09:00"
+  },
+  {
+    "title": "小さな恋の歌",
+    "artist": "MONGOL800",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:37:11+09:00"
+  },
+  {
+    "title": "Rain",
+    "artist": "秦基博",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:37:13+09:00"
+  },
+  {
+    "title": "晩餐歌",
+    "artist": "tuki.",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:37:14+09:00"
+  },
+  {
+    "title": "幾億光年",
+    "artist": "Omoinotake",
+    "metadata": {
+      "releaseDate": "2024-01-24",
+      "releaseYear": 2024,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 277,
+      "collectionName": "幾億光年 - Single",
+      "itunesTrackId": 1725229931,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:37:16+09:00"
+  },
+  {
+    "title": "夜明けと蛍",
+    "artist": "n-buna",
+    "metadata": {
+      "releaseDate": "2015-07-22",
+      "releaseYear": 2015,
+      "decade": "2010年代",
+      "genre": "アニメ",
+      "durationSeconds": 309,
+      "collectionName": "花と水飴、最終電車",
+      "itunesTrackId": 1648869428,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:37:17+09:00"
+  },
+  {
+    "title": "おかえり",
+    "artist": "Tani Yuuki",
+    "metadata": {
+      "releaseDate": "2021-12-08",
+      "releaseYear": 2021,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 226,
+      "collectionName": "Memories",
+      "itunesTrackId": 1596879565,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:37:18+09:00"
+  },
+  {
+    "title": "花に亡霊",
+    "artist": "ヨルシカ",
+    "metadata": {
+      "releaseDate": "2020-04-22",
+      "releaseYear": 2020,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 240,
+      "collectionName": "花に亡霊 - Single",
+      "itunesTrackId": 1506849814,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:37:20+09:00"
+  },
+  {
+    "title": "Soranji",
+    "artist": "Mrs. GREEN APPLE",
+    "metadata": {
+      "releaseDate": "2022-10-18",
+      "releaseYear": 2022,
+      "decade": "2020年代",
+      "genre": "ロック",
+      "durationSeconds": 344,
+      "collectionName": "Soranji - Single",
+      "itunesTrackId": 1648865575,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:37:21+09:00"
+  },
+  {
+    "title": "愛をこめて花束を",
+    "artist": "Superfly",
+    "metadata": {
+      "releaseDate": "2008-02-27",
+      "releaseYear": 2008,
+      "decade": "2000年代",
+      "genre": "ロック",
+      "durationSeconds": 295,
+      "collectionName": "愛をこめて花束を - Single",
+      "itunesTrackId": 273951740,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:37:23+09:00"
+  },
+  {
+    "title": "First love",
+    "artist": "宇多田ヒカル",
+    "metadata": {
+      "releaseDate": "1999-01-01",
+      "releaseYear": 1999,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 259,
+      "collectionName": "First Love - EP",
+      "itunesTrackId": 1445055008,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:37:24+09:00"
+  },
+  {
+    "title": "名探偵コナンのテーマ",
+    "artist": "大野克夫",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:37:26+09:00"
+  },
+  {
+    "title": "花束",
+    "artist": "back number",
+    "metadata": {
+      "releaseDate": "2011-06-22",
+      "releaseYear": 2011,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 286,
+      "collectionName": "花束 - EP",
+      "itunesTrackId": 1451565944,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:37:28+09:00"
+  },
+  {
+    "title": "プロローグ",
+    "artist": "Uru",
+    "metadata": {
+      "releaseDate": "2018-10-30",
+      "releaseYear": 2018,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 302,
+      "collectionName": "プロローグ",
+      "itunesTrackId": 1538102603,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:37:29+09:00"
+  },
+  {
+    "title": "君はロックを聴かない",
+    "artist": "あいみょん",
+    "metadata": {
+      "releaseDate": "2017-07-25",
+      "releaseYear": 2017,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 246,
+      "collectionName": "君はロックを聴かない - EP",
+      "itunesTrackId": 1261937430,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:37:30+09:00"
+  },
+  {
+    "title": "栄光の架け橋",
+    "artist": "ゆず",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:37:32+09:00"
+  },
+  {
+    "title": "ありがとう",
+    "artist": "いきものがかり",
+    "metadata": {
+      "releaseDate": "2010-05-05",
+      "releaseYear": 2010,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 364,
+      "collectionName": "ありがとう - Single",
+      "itunesTrackId": 1536261286,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:37:33+09:00"
+  },
+  {
+    "title": "怪獣の花唄",
+    "artist": "Vaundy",
+    "metadata": {
+      "releaseDate": "2020-05-11",
+      "releaseYear": 2020,
+      "decade": "2020年代",
+      "genre": "ロック",
+      "durationSeconds": 225,
+      "collectionName": "strobo",
+      "itunesTrackId": 1706832137,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:37:35+09:00"
+  },
+  {
+    "title": "3月9日",
+    "artist": "レミオロメン",
+    "metadata": {
+      "releaseDate": "2004-03-09",
+      "releaseYear": 2004,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 263,
+      "collectionName": "3月9日 - Single",
+      "itunesTrackId": 1857509406,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:37:36+09:00"
+  },
+  {
+    "title": "紅蓮華",
+    "artist": "LiSA",
+    "metadata": {
+      "releaseDate": "2019-04-21",
+      "releaseYear": 2019,
+      "decade": "2010年代",
+      "genre": "アニメ",
+      "durationSeconds": 239,
+      "collectionName": "紅蓮華 - EP",
+      "itunesTrackId": 1538286723,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:37:37+09:00"
+  },
+  {
+    "title": "HANABI",
+    "artist": "Mr.Children",
+    "metadata": {
+      "releaseDate": "2008-09-03",
+      "releaseYear": 2008,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 343,
+      "collectionName": "Mr.Children 2005 - 2010 <macro>",
+      "itunesTrackId": 1374993073,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:37:39+09:00"
+  },
+  {
+    "title": "変わらないもの",
+    "artist": "奥華子",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:37:40+09:00"
+  },
+  {
+    "title": "プラネタリウム",
+    "artist": "大塚愛",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:37:41+09:00"
+  },
+  {
+    "title": "晴る",
+    "artist": "ヨルシカ",
+    "metadata": {
+      "releaseDate": "2024-01-05",
+      "releaseYear": 2024,
+      "decade": "2020年代",
+      "genre": "オルタナティブ",
+      "durationSeconds": 271,
+      "collectionName": "晴る - Single",
+      "itunesTrackId": 1721450223,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:37:43+09:00"
+  },
+  {
+    "title": "ひとりごつ",
+    "artist": "トクマルシューゴ",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:37:44+09:00"
+  },
+  {
+    "title": "CHA-LA HEAD-CHA-LA",
+    "artist": "影山ヒロノブ",
+    "metadata": {
+      "releaseDate": "1998-11-18",
+      "releaseYear": 1998,
+      "decade": "1990年代",
+      "genre": "アニメ",
+      "durationSeconds": 275,
+      "collectionName": "影山ヒロノブ POWER LIVE '98",
+      "itunesTrackId": 435413360,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:37:46+09:00"
+  },
+  {
+    "title": "残酷な天使のテーゼ",
+    "artist": "高橋洋子",
+    "metadata": {
+      "releaseDate": "1995-10-25",
+      "releaseYear": 1995,
+      "decade": "1990年代",
+      "genre": "アニメ",
+      "durationSeconds": 246,
+      "collectionName": "残酷な天使のテーゼ - EP",
+      "itunesTrackId": 258926790,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:37:47+09:00"
+  },
+  {
+    "title": "心得",
+    "artist": "Uru",
+    "metadata": {
+      "releaseDate": "2023-05-01",
+      "releaseYear": 2023,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 219,
+      "collectionName": "心得 - Single",
+      "itunesTrackId": 1681691984,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:37:49+09:00"
+  },
+  {
+    "title": "水平線",
+    "artist": "back number",
+    "metadata": {
+      "releaseDate": "2021-08-13",
+      "releaseYear": 2021,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 285,
+      "collectionName": "水平線 - Single",
+      "itunesTrackId": 1579439168,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:37:59+09:00"
+  },
+  {
+    "title": "夢をかなえてドラえもん",
+    "artist": "mao",
+    "metadata": {
+      "releaseDate": "2014-11-19",
+      "releaseYear": 2014,
+      "decade": "2010年代",
+      "genre": "アニメ",
+      "durationSeconds": 249,
+      "collectionName": "テレビ朝日系アニメ「ドラえもん」主題歌 夢をかなえてドラえもん - EP",
+      "itunesTrackId": 938553963,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:38:01+09:00"
+  },
+  {
+    "title": "勇者",
+    "artist": "YOASOBI",
+    "metadata": {
+      "releaseDate": "2023-09-29",
+      "releaseYear": 2023,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 194,
+      "collectionName": "勇者 - Single",
+      "itunesTrackId": 1707001466,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:38:02+09:00"
+  },
+  {
+    "title": "ブルーバード",
+    "artist": "いきものがかり",
+    "metadata": {
+      "releaseDate": "2008-07-09",
+      "releaseYear": 2008,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 218,
+      "collectionName": "My song  Your song",
+      "itunesTrackId": 1536256935,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:38:03+09:00"
+  },
+  {
+    "title": "丸の内サディスティック",
+    "artist": "椎名林檎",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:38:05+09:00"
+  },
+  {
+    "title": "ひぐらしの泣く頃にyou",
+    "artist": "dai",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:38:06+09:00"
+  },
+  {
+    "title": "Story",
+    "artist": "AI",
+    "metadata": {
+      "releaseDate": "2005-05-18",
+      "releaseYear": 2005,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 289,
+      "collectionName": "MIC-AーHOLIC A.I.",
+      "itunesTrackId": 1444118054,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:38:07+09:00"
+  },
+  {
+    "title": "サザンカ",
+    "artist": "SEKAI NO OWARI",
+    "metadata": {
+      "releaseDate": "2018-02-01",
+      "releaseYear": 2018,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 271,
+      "collectionName": "サザンカ - Single",
+      "itunesTrackId": 1338627153,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:38:09+09:00"
+  },
+  {
+    "title": "粉雪",
+    "artist": "レミオロメン",
+    "metadata": {
+      "releaseDate": "2005-11-16",
+      "releaseYear": 2005,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 322,
+      "collectionName": "粉雪 - Single",
+      "itunesTrackId": 1857510109,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:38:10+09:00"
+  },
+  {
+    "title": "虹",
+    "artist": "菅田将暉",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:38:12+09:00"
+  },
+  {
+    "title": "満ちてゆく",
+    "artist": "藤井風",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:38:13+09:00"
+  },
+  {
+    "title": "少女レイ",
+    "artist": "みきとP",
+    "metadata": {
+      "releaseDate": "2018-07-18",
+      "releaseYear": 2018,
+      "decade": "2010年代",
+      "genre": "アニメ",
+      "durationSeconds": 288,
+      "collectionName": "EXIT TUNES PRESENTS Vocaloseasons feat.初音ミク~Summer~",
+      "itunesTrackId": 1408577702,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:38:14+09:00"
+  },
+  {
+    "title": "ふゆびより",
+    "artist": "佐々木恵梨",
+    "metadata": {
+      "releaseDate": "2018-01-24",
+      "releaseYear": 2018,
+      "decade": "2010年代",
+      "genre": "アニメ",
+      "durationSeconds": 278,
+      "collectionName": "ふゆびより(TVアニメ「ゆるキャン△」EDテーマ) - EP",
+      "itunesTrackId": 1329451871,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:38:16+09:00"
+  },
+  {
+    "title": "雪の華",
+    "artist": "中島美嘉",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:38:17+09:00"
+  },
+  {
+    "title": "Butter-Fly",
+    "artist": "和田光司",
+    "metadata": {
+      "releaseDate": "2004-08-01",
+      "releaseYear": 2004,
+      "decade": "2000年代",
+      "genre": "アニメ",
+      "durationSeconds": 258,
+      "collectionName": "Butter-Fly - EP",
+      "itunesTrackId": 520527998,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:38:18+09:00"
+  },
+  {
+    "title": "僕のこと",
+    "artist": "Mrs. GREEN APPLE",
+    "metadata": {
+      "releaseDate": "2018-12-26",
+      "releaseYear": 2018,
+      "decade": "2010年代",
+      "genre": "ロック",
+      "durationSeconds": 322,
+      "collectionName": "僕のこと - EP",
+      "itunesTrackId": 1445145789,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:38:20+09:00"
+  },
+  {
+    "title": "最上級にかわいいの!",
+    "artist": "超ときめき♡宣伝部",
+    "metadata": {
+      "releaseDate": "2024-01-24",
+      "releaseYear": 2024,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 190,
+      "collectionName": "ときめく恋と青春",
+      "itunesTrackId": 1722220691,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:38:21+09:00"
+  },
+  {
+    "title": "subtitle",
+    "artist": "Official髭男dism",
+    "metadata": {
+      "releaseDate": "2022-10-12",
+      "releaseYear": 2022,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 306,
+      "collectionName": "Subtitle - Single",
+      "itunesTrackId": 1648108988,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:38:23+09:00"
+  },
+  {
+    "title": "アイノカタチ",
+    "artist": "MISIA",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:38:24+09:00"
+  },
+  {
+    "title": "糸",
+    "artist": "中島みゆき",
+    "metadata": {
+      "releaseDate": "1992-10-07",
+      "releaseYear": 1992,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 307,
+      "collectionName": "命の別名 - Single",
+      "itunesTrackId": 1654000188,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:38:25+09:00"
+  },
+  {
+    "title": "白い恋人たち",
+    "artist": "桑田佳祐",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:38:27+09:00"
+  },
+  {
+    "title": "明日への扉",
+    "artist": "I WiSH",
+    "metadata": {
+      "releaseDate": "2003-02-14",
+      "releaseYear": 2003,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 294,
+      "collectionName": "THE COMPLETE COLLECTION OF I WiSH",
+      "itunesTrackId": 1537055928,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:38:28+09:00"
+  },
+  {
+    "title": "フリージア",
+    "artist": "Uru",
+    "metadata": {
+      "releaseDate": "2017-02-15",
+      "releaseYear": 2017,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 335,
+      "collectionName": "フリージア - EP",
+      "itunesTrackId": 1535545650,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:38:29+09:00"
+  },
+  {
+    "title": "竈門炭治郎のうた",
+    "artist": "椎名豪featuring中川奈美",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:38:31+09:00"
+  },
+  {
+    "title": "クリスマスソング",
+    "artist": "back number",
+    "metadata": {
+      "releaseDate": "2015-11-18",
+      "releaseYear": 2015,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 341,
+      "collectionName": "クリスマスソング - EP",
+      "itunesTrackId": 1451567627,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:38:32+09:00"
+  },
+  {
+    "title": "いつかのメリークリスマス",
+    "artist": "B'z",
+    "metadata": {
+      "releaseDate": "1992-12-09",
+      "releaseYear": 1992,
+      "decade": "1990年代",
+      "genre": "ロック",
+      "durationSeconds": 334,
+      "collectionName": "FRIENDS",
+      "itunesTrackId": 75353680,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:38:33+09:00"
+  },
+  {
+    "title": "ライラック",
+    "artist": "Mrs. GREEN APPLE",
+    "metadata": {
+      "releaseDate": "2024-04-12",
+      "releaseYear": 2024,
+      "decade": "2020年代",
+      "genre": "ロック",
+      "durationSeconds": 288,
+      "collectionName": "ライラック - Single",
+      "itunesTrackId": 1739088799,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:38:35+09:00"
+  },
+  {
+    "title": "それを愛と呼ぶなら",
+    "artist": "Uru",
+    "metadata": {
+      "releaseDate": "2022-04-24",
+      "releaseYear": 2022,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 295,
+      "collectionName": "それを愛と呼ぶなら - EP",
+      "itunesTrackId": 1618736429,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:38:36+09:00"
+  },
+  {
+    "title": "奏",
+    "artist": "スキマスイッチ",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:38:37+09:00"
+  },
+  {
+    "title": "ガーネット",
+    "artist": "奥華子",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:38:39+09:00"
+  },
+  {
+    "title": "僕が死のうと思ったのは",
+    "artist": "中島美嘉",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:38:40+09:00"
+  },
+  {
+    "title": "アルジャーノン",
+    "artist": "ヨルシカ",
+    "metadata": {
+      "releaseDate": "2023-02-06",
+      "releaseYear": 2023,
+      "decade": "2020年代",
+      "genre": "オルタナティブ",
+      "durationSeconds": 254,
+      "collectionName": "アルジャーノン - Single",
+      "itunesTrackId": 1667187095,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:38:42+09:00"
+  },
+  {
+    "title": "おジャ魔女カーニバル‼",
+    "artist": "MAHO堂",
+    "metadata": {
+      "releaseDate": "2020-11-16",
+      "releaseYear": 2020,
+      "decade": "2020年代",
+      "genre": "アニメ",
+      "durationSeconds": 216,
+      "collectionName": "おジャ魔女どれみ Select Best",
+      "itunesTrackId": 1537920834,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:38:43+09:00"
+  },
+  {
+    "title": "ヒロイン",
+    "artist": "back number",
+    "metadata": {
+      "releaseDate": "2015-01-21",
+      "releaseYear": 2015,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 270,
+      "collectionName": "ヒロイン - EP",
+      "itunesTrackId": 1451566361,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:38:44+09:00"
+  },
+  {
+    "title": "花束の代わりにメロディを",
+    "artist": "清水翔太",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:38:46+09:00"
+  },
+  {
+    "title": "Pretender",
+    "artist": "Official髭男dism",
+    "metadata": {
+      "releaseDate": "2019-04-17",
+      "releaseYear": 2019,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 326,
+      "collectionName": "Pretender - Single",
+      "itunesTrackId": 1459216694,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:38:47+09:00"
+  },
+  {
+    "title": "ハルカ",
+    "artist": "YOASOBI",
+    "metadata": {
+      "releaseDate": "2020-12-18",
+      "releaseYear": 2020,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 244,
+      "collectionName": "ハルカ - Single",
+      "itunesTrackId": 1541851056,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:38:49+09:00"
+  },
+  {
+    "title": "月光",
+    "artist": "鬼束ちひろ",
+    "metadata": {
+      "releaseDate": "2000-08-09",
+      "releaseYear": 2000,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 308,
+      "collectionName": "SINGLES 2000-2003",
+      "itunesTrackId": 1440627637,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:38:50+09:00"
+  },
+  {
+    "title": "innocent world",
+    "artist": "Mr.Children",
+    "metadata": {
+      "releaseDate": "1994-06-01",
+      "releaseYear": 1994,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 345,
+      "collectionName": "innocent world - Single",
+      "itunesTrackId": 1374883461,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:38:51+09:00"
+  },
+  {
+    "title": "蕾",
+    "artist": "コブクロ",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:38:53+09:00"
+  },
+  {
+    "title": "366日",
+    "artist": "HY",
+    "metadata": {
+      "releaseDate": "2008-04-16",
+      "releaseYear": 2008,
+      "decade": "2000年代",
+      "genre": "ロック",
+      "durationSeconds": 353,
+      "collectionName": "HeartY",
+      "itunesTrackId": 297313686,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:38:59+09:00"
+  },
+  {
+    "title": "ロビンソン",
+    "artist": "スピッツ",
+    "metadata": {
+      "releaseDate": "1995-04-05",
+      "releaseYear": 1995,
+      "decade": "1990年代",
+      "genre": "ロック",
+      "durationSeconds": 260,
+      "collectionName": "ハチミツ",
+      "itunesTrackId": 1440746483,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:39:01+09:00"
+  },
+  {
+    "title": "手紙～拝啓十五の君へ～",
+    "artist": "アンジェラ・アキ",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:39:02+09:00"
+  },
+  {
+    "title": "明日への手紙",
+    "artist": "手嶌葵",
+    "metadata": {
+      "releaseDate": "2014-07-23",
+      "releaseYear": 2014,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 292,
+      "collectionName": "Ren'dez-vous",
+      "itunesTrackId": 896503389,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:39:03+09:00"
+  },
+  {
+    "title": "かわいいだけじゃだめですか？",
+    "artist": "CUTIE STREET",
+    "metadata": {
+      "releaseDate": "2024-09-09",
+      "releaseYear": 2024,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 251,
+      "collectionName": "かわいいだけじゃだめですか? - Single",
+      "itunesTrackId": 1804686037,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:39:05+09:00"
+  },
+  {
+    "title": "もしもピアノが弾けたなら",
+    "artist": "西田敏行",
+    "metadata": {
+      "releaseDate": "1981-04-01",
+      "releaseYear": 1981,
+      "decade": "1980年代",
+      "genre": "J-Pop",
+      "durationSeconds": 230,
+      "collectionName": "もしもピアノが弾けたなら / いい夢みろよ BESTタッグ - Single",
+      "itunesTrackId": 1607991583,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:39:06+09:00"
+  },
+  {
+    "title": "カブトムシ",
+    "artist": "aiko",
+    "metadata": {
+      "releaseDate": "1999-11-17",
+      "releaseYear": 1999,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 314,
+      "collectionName": "桜の木の下",
+      "itunesTrackId": 1109978637,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:39:08+09:00"
+  },
+  {
+    "title": "若者たち",
+    "artist": "森山直太朗",
+    "metadata": {
+      "releaseDate": "2014-07-09",
+      "releaseYear": 2014,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 177,
+      "collectionName": "黄金の心",
+      "itunesTrackId": 1442519987,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:39:09+09:00"
+  },
+  {
+    "title": "手紙",
+    "artist": "back number",
+    "metadata": {
+      "releaseDate": "2015-08-12",
+      "releaseYear": 2015,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 270,
+      "collectionName": "手紙 - Single",
+      "itunesTrackId": 1451566889,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:39:10+09:00"
+  },
+  {
+    "title": "SAKURA",
+    "artist": "いきものがかり",
+    "metadata": {
+      "releaseDate": "2006-03-15",
+      "releaseYear": 2006,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 355,
+      "collectionName": "SAKURA - EP",
+      "itunesTrackId": 1536229540,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:39:12+09:00"
+  },
+  {
+    "title": "more than words",
+    "artist": "羊文学",
+    "metadata": {
+      "releaseDate": "2023-09-01",
+      "releaseYear": 2023,
+      "decade": "2020年代",
+      "genre": "ロック",
+      "durationSeconds": 290,
+      "collectionName": "more than words - EP",
+      "itunesTrackId": 1702627144,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:39:13+09:00"
+  },
+  {
+    "title": "ダーリン",
+    "artist": "Mrs. GREEN APPLE",
+    "metadata": {
+      "releaseDate": "2025-01-20",
+      "releaseYear": 2025,
+      "decade": "2020年代",
+      "genre": "ロック",
+      "durationSeconds": 281,
+      "collectionName": "ダーリン - EP",
+      "itunesTrackId": 1790599512,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:39:15+09:00"
+  },
+  {
+    "title": "スパークル",
+    "artist": "RADWIMPS",
+    "metadata": {
+      "releaseDate": "2016-11-23",
+      "releaseYear": 2016,
+      "decade": "2010年代",
+      "genre": "ロック",
+      "durationSeconds": 410,
+      "collectionName": "人間開花",
+      "itunesTrackId": 1518845612,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:39:16+09:00"
+  },
+  {
+    "title": "きらり",
+    "artist": "藤井風",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:39:18+09:00"
+  },
+  {
+    "title": "眠り姫",
+    "artist": "SEKAI NO OWARI",
+    "metadata": {
+      "releaseDate": "2012-05-30",
+      "releaseYear": 2012,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 327,
+      "collectionName": "ENTERTAINMENT",
+      "itunesTrackId": 984426767,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:39:19+09:00"
+  },
+  {
+    "title": "Lemon",
+    "artist": "米津玄師",
+    "metadata": {
+      "releaseDate": "2018-02-12",
+      "releaseYear": 2018,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 256,
+      "collectionName": "Lemon - Single",
+      "itunesTrackId": 1537460612,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:39:20+09:00"
+  },
+  {
+    "title": "カーテンコール",
+    "artist": "優里",
+    "metadata": {
+      "releaseDate": "2024-07-19",
+      "releaseYear": 2024,
+      "decade": "2020年代",
+      "genre": "ロック",
+      "durationSeconds": 243,
+      "collectionName": "カーテンコール - Single",
+      "itunesTrackId": 1754899924,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:39:22+09:00"
+  },
+  {
+    "title": "シルエット",
+    "artist": "KANA-BOON",
+    "metadata": {
+      "releaseDate": "2014-11-26",
+      "releaseYear": 2014,
+      "decade": "2010年代",
+      "genre": "ロック",
+      "durationSeconds": 242,
+      "collectionName": "シルエット - Single",
+      "itunesTrackId": 1536455325,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:39:23+09:00"
+  },
+  {
+    "title": "忘れてください",
+    "artist": "ヨルシカ",
+    "metadata": {
+      "releaseDate": "2026-02-19",
+      "releaseYear": 2026,
+      "decade": "2020年代",
+      "genre": "オルタナティブ",
+      "durationSeconds": 219,
+      "collectionName": "忘れてください - Single",
+      "itunesTrackId": 1755182819,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:39:25+09:00"
+  },
+  {
+    "title": "愛にできることはまだあるかい",
+    "artist": "RADWIMPS",
+    "metadata": {
+      "releaseDate": "2019-07-19",
+      "releaseYear": 2019,
+      "decade": "2010年代",
+      "genre": "ロック",
+      "durationSeconds": 414,
+      "collectionName": "天気の子 (complete version) - EP",
+      "itunesTrackId": 1518516245,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:39:26+09:00"
+  },
+  {
+    "title": "DOWN TOWN",
+    "artist": "シュガーベイブ",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:39:27+09:00"
+  },
+  {
+    "title": "未来予想図Ⅱ",
+    "artist": "DREAMS COME TRUE",
+    "metadata": {
+      "releaseDate": "1989-11-22",
+      "releaseYear": 1989,
+      "decade": "1980年代",
+      "genre": "J-Pop",
+      "durationSeconds": 440,
+      "collectionName": "LOVE GOES ON …",
+      "itunesTrackId": 1536186630,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:39:29+09:00"
+  },
+  {
+    "title": "ナハトムジーク",
+    "artist": "Mrs. GREEN APPLE",
+    "metadata": {
+      "releaseDate": "2024-01-17",
+      "releaseYear": 2024,
+      "decade": "2020年代",
+      "genre": "ロック",
+      "durationSeconds": 263,
+      "collectionName": "ナハトムジーク - Single",
+      "itunesTrackId": 1724293062,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:39:30+09:00"
+  },
+  {
+    "title": "楓",
+    "artist": "スピッツ",
+    "metadata": {
+      "releaseDate": "1998-03-25",
+      "releaseYear": 1998,
+      "decade": "1990年代",
+      "genre": "ロック",
+      "durationSeconds": 326,
+      "collectionName": "フェイクファー",
+      "itunesTrackId": 1440649500,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:39:31+09:00"
+  },
+  {
+    "title": "花は咲く",
+    "artist": "菅野よう子",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:39:33+09:00"
+  },
+  {
+    "title": "なんでもないや",
+    "artist": "RADWIMPS",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:39:34+09:00"
+  },
+  {
+    "title": "再会",
+    "artist": "LiSA×Uru",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:39:36+09:00"
+  },
+  {
+    "title": "グランドエスケープ",
+    "artist": "RADWIMPS",
+    "metadata": {
+      "releaseDate": "2021-11-23",
+      "releaseYear": 2021,
+      "decade": "2020年代",
+      "genre": "ロック",
+      "durationSeconds": 338,
+      "collectionName": "FOREVER DAZE",
+      "itunesTrackId": 1590786969,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:39:37+09:00"
+  },
+  {
+    "title": "カナタハルカ",
+    "artist": "RADWIMPS",
+    "metadata": {
+      "releaseDate": "2022-10-28",
+      "releaseYear": 2022,
+      "decade": "2020年代",
+      "genre": "ロック",
+      "durationSeconds": 356,
+      "collectionName": "すずめの戸締まり",
+      "itunesTrackId": 1651183709,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:39:39+09:00"
+  },
+  {
+    "title": "桜ノ雨",
+    "artist": "halyosy",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:39:40+09:00"
+  },
+  {
+    "title": "弱虫モンブラン",
+    "artist": "DECO*27",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:39:42+09:00"
+  },
+  {
+    "title": "空も飛べるはず",
+    "artist": "スピッツ",
+    "metadata": {
+      "releaseDate": "1994-01-01",
+      "releaseYear": 1994,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 271,
+      "collectionName": "CYCLE HIT 1991-1997 Spitz Complete Single Collection",
+      "itunesTrackId": 1440863470,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:39:43+09:00"
+  },
+  {
+    "title": "忘れじの言の葉",
+    "artist": "未来古代楽団",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:39:44+09:00"
+  },
+  {
+    "title": "サヨナラの意味",
+    "artist": "乃木坂46",
+    "metadata": {
+      "releaseDate": "2016-11-09",
+      "releaseYear": 2016,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 299,
+      "collectionName": "サヨナラの意味 - EP",
+      "itunesTrackId": 1537463069,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:39:46+09:00"
+  },
+  {
+    "title": "MIRACLE SHOPPING",
+    "artist": "田中マイミ",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:39:47+09:00"
+  },
+  {
+    "title": "マツケンサンバⅡ",
+    "artist": "松平健",
+    "metadata": {
+      "releaseDate": "2004-07-07",
+      "releaseYear": 2004,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 297,
+      "collectionName": "マツケン・サンバ Ⅱ",
+      "itunesTrackId": 1805003595,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:39:49+09:00"
+  },
+  {
+    "title": "明日へ",
+    "artist": "MISIA",
+    "metadata": {
+      "releaseDate": "2011-07-27",
+      "releaseYear": 2011,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 284,
+      "collectionName": "SOUL QUEST",
+      "itunesTrackId": 1558067865,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:39:50+09:00"
+  },
+  {
+    "title": "ただ声一つ",
+    "artist": "ロクデナシ",
+    "metadata": {
+      "releaseDate": "2021-12-22",
+      "releaseYear": 2021,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 162,
+      "collectionName": "ただ声一つ - Single",
+      "itunesTrackId": 1599674592,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:40:00+09:00"
+  },
+  {
+    "title": "君の知らない物語",
+    "artist": "Supercell",
+    "metadata": {
+      "releaseDate": "2009-08-12",
+      "releaseYear": 2009,
+      "decade": "2000年代",
+      "genre": "アニメ",
+      "durationSeconds": 344,
+      "collectionName": "歌物語 Special Edition",
+      "itunesTrackId": 1535798235,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:40:01+09:00"
+  },
+  {
+    "title": "夜に駆ける",
+    "artist": "YOASOBI",
+    "metadata": {
+      "releaseDate": "2019-12-15",
+      "releaseYear": 2019,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 261,
+      "collectionName": "夜に駆ける - Single",
+      "itunesTrackId": 1490256995,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:40:03+09:00"
+  },
+  {
+    "title": "青と夏",
+    "artist": "Mrs. GREEN APPLE",
+    "metadata": {
+      "releaseDate": "2018-07-12",
+      "releaseYear": 2018,
+      "decade": "2010年代",
+      "genre": "ロック",
+      "durationSeconds": 271,
+      "collectionName": "青と夏 - EP",
+      "itunesTrackId": 1408505264,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:40:04+09:00"
+  },
+  {
+    "title": "ラブレター",
+    "artist": "YOASOBI",
+    "metadata": {
+      "releaseDate": "2021-08-09",
+      "releaseYear": 2021,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 212,
+      "collectionName": "ラブレター - Single",
+      "itunesTrackId": 1579051058,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:40:06+09:00"
+  },
+  {
+    "title": "たばこ",
+    "artist": "コレサワ",
+    "metadata": {
+      "releaseDate": "2017-03-29",
+      "releaseYear": 2017,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 377,
+      "collectionName": "たばこ - Single",
+      "itunesTrackId": 1215143089,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:40:07+09:00"
+  },
+  {
+    "title": "なごり雪",
+    "artist": "イルカ",
+    "metadata": {
+      "releaseDate": "2021-05-12",
+      "releaseYear": 2021,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 215,
+      "collectionName": "あたしだってLove song!",
+      "itunesTrackId": 1563394275,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:40:08+09:00"
+  },
+  {
+    "title": "群青日和",
+    "artist": "東京事変",
+    "metadata": {
+      "releaseDate": "2004-09-08",
+      "releaseYear": 2004,
+      "decade": "2000年代",
+      "genre": "ロック",
+      "durationSeconds": 213,
+      "collectionName": "群青日和 - Single",
+      "itunesTrackId": 1444396093,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:40:10+09:00"
+  },
+  {
+    "title": "卒業写真",
+    "artist": "荒井由実",
+    "metadata": {
+      "releaseDate": "1975-06-20",
+      "releaseYear": 1975,
+      "decade": "1970年代",
+      "genre": "J-Pop",
+      "durationSeconds": 252,
+      "collectionName": "40周年記念ベストアルバム 日本の恋と、ユーミンと。",
+      "itunesTrackId": 1436021777,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:40:11+09:00"
+  },
+  {
+    "title": "心做し",
+    "artist": "蝶々P feat. GUMI",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:40:13+09:00"
+  },
+  {
+    "title": "上を向いて歩こう",
+    "artist": "坂本九",
+    "metadata": {
+      "releaseDate": "1967-01-01",
+      "releaseYear": 1967,
+      "decade": "1960年代",
+      "genre": "歌謡曲",
+      "durationSeconds": 189,
+      "collectionName": "ベスト9!",
+      "itunesTrackId": 1465042214,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:40:14+09:00"
+  },
+  {
+    "title": "いつかこの涙が",
+    "artist": "Little Glee Monster",
+    "metadata": {
+      "releaseDate": "2018-01-17",
+      "releaseYear": 2018,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 266,
+      "collectionName": "juice",
+      "itunesTrackId": 1538282533,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:40:15+09:00"
+  },
+  {
+    "title": "Best Friend",
+    "artist": "西野カナ",
+    "metadata": {
+      "releaseDate": "2010-02-24",
+      "releaseYear": 2010,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 321,
+      "collectionName": "Best Friend - Single",
+      "itunesTrackId": 1537240311,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:40:17+09:00"
+  },
+  {
+    "title": "ラストソング",
+    "artist": "Official髭男dism",
+    "metadata": {
+      "releaseDate": "2019-10-09",
+      "releaseYear": 2019,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 353,
+      "collectionName": "Traveler",
+      "itunesTrackId": 1479397874,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:40:18+09:00"
+  },
+  {
+    "title": "いのちの歌",
+    "artist": "竹内まりや",
+    "metadata": {
+      "releaseDate": "2014-09-10",
+      "releaseYear": 2014,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 283,
+      "collectionName": "TRAD",
+      "itunesTrackId": 1502568608,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:40:20+09:00"
+  },
+  {
+    "title": "アンパンマンのマーチ",
+    "artist": "ドリーミング",
+    "metadata": {
+      "releaseDate": "2019-12-18",
+      "releaseYear": 2019,
+      "decade": "2010年代",
+      "genre": "アニメ",
+      "durationSeconds": 170,
+      "collectionName": "それいけ!アンパンマン ベストヒット’13",
+      "itunesTrackId": 582615520,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:40:21+09:00"
+  },
+  {
+    "title": "サリシノハラ",
+    "artist": "みきとP",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:40:23+09:00"
+  },
+  {
+    "title": "secret base～君がくれたもの～",
+    "artist": "ZONE",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:40:24+09:00"
+  },
+  {
+    "title": "怪獣",
+    "artist": "サカナクション",
+    "metadata": {
+      "releaseDate": "2025-02-20",
+      "releaseYear": 2025,
+      "decade": "2020年代",
+      "genre": "ロック",
+      "durationSeconds": 253,
+      "collectionName": "怪獣 - Single",
+      "itunesTrackId": 1795905600,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:40:25+09:00"
+  },
+  {
+    "title": "One more time, One more chance",
+    "artist": "山崎まさよし",
+    "metadata": {
+      "releaseDate": "1997-01-22",
+      "releaseYear": 1997,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 332,
+      "collectionName": "YAMAZAKI MASAYOSHI the BEST / BLUE PERIOD -COMPLETE",
+      "itunesTrackId": 1442957649,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:40:27+09:00"
+  },
+  {
+    "title": "rain stops, good-bye",
+    "artist": "におP",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:40:28+09:00"
+  },
+  {
+    "title": "フィナーレ。",
+    "artist": "eill",
+    "metadata": {
+      "releaseDate": "2022-09-07",
+      "releaseYear": 2022,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 242,
+      "collectionName": "プレロマンス / フィナーレ。 - EP",
+      "itunesTrackId": 1638117504,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:40:30+09:00"
+  },
+  {
+    "title": "Bunny Girl",
+    "artist": "AKASAKI",
+    "metadata": {
+      "releaseDate": "2024-10-02",
+      "releaseYear": 2024,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 217,
+      "collectionName": "Bunny Girl - EP",
+      "itunesTrackId": 1769165500,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:40:31+09:00"
+  },
+  {
+    "title": "unravel",
+    "artist": "TK from 凛として時雨",
+    "metadata": {
+      "releaseDate": "2014-07-23",
+      "releaseYear": 2014,
+      "decade": "2010年代",
+      "genre": "ロック",
+      "durationSeconds": 241,
+      "collectionName": "unravel - Single",
+      "itunesTrackId": 1535535911,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:40:32+09:00"
+  },
+  {
+    "title": "正解",
+    "artist": "RADWIMPS",
+    "metadata": {
+      "releaseDate": "2024-01-24",
+      "releaseYear": 2024,
+      "decade": "2020年代",
+      "genre": "ロック",
+      "durationSeconds": 359,
+      "collectionName": "正解 - EP",
+      "itunesTrackId": 1726307099,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:40:34+09:00"
+  },
+  {
+    "title": "新しい恋人達に",
+    "artist": "back number",
+    "metadata": {
+      "releaseDate": "2024-07-15",
+      "releaseYear": 2024,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 287,
+      "collectionName": "新しい恋人達に - Single",
+      "itunesTrackId": 1755670579,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:40:35+09:00"
+  },
+  {
+    "title": "ダンスホール",
+    "artist": "Mrs. GREEN APPLE",
+    "metadata": {
+      "releaseDate": "2022-05-24",
+      "releaseYear": 2022,
+      "decade": "2020年代",
+      "genre": "ロック",
+      "durationSeconds": 203,
+      "collectionName": "ダンスホール - Single",
+      "itunesTrackId": 1623304209,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:40:36+09:00"
+  },
+  {
+    "title": "エルフ",
+    "artist": "Ado",
+    "metadata": {
+      "releaseDate": "2025-01-24",
+      "releaseYear": 2025,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 260,
+      "collectionName": "エルフ - Single",
+      "itunesTrackId": 1789478393,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:40:38+09:00"
+  },
+  {
+    "title": "わたしに花束",
+    "artist": "Ado",
+    "metadata": {
+      "releaseDate": "2025-03-10",
+      "releaseYear": 2025,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 229,
+      "collectionName": "わたしに花束 - Single",
+      "itunesTrackId": 1799216471,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:40:39+09:00"
+  },
+  {
+    "title": "からくりピエロ",
+    "artist": "40mP",
+    "metadata": {
+      "releaseDate": "2011-07-20",
+      "releaseYear": 2011,
+      "decade": "2010年代",
+      "genre": "アニメ",
+      "durationSeconds": 250,
+      "collectionName": "EXIT TUNES PRESENTS Vocaloseasons feat.初音ミク~Autumn~",
+      "itunesTrackId": 1368260334,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:40:41+09:00"
+  },
+  {
+    "title": "テレパシ",
+    "artist": "DECO*27",
+    "metadata": {
+      "releaseDate": "2025-02-22",
+      "releaseYear": 2025,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 138,
+      "collectionName": "テレパシ - Single",
+      "itunesTrackId": 1794967656,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:40:42+09:00"
+  },
+  {
+    "title": "上弦の月",
+    "artist": "黒うさP",
+    "metadata": {
+      "releaseDate": "2013-10-23",
+      "releaseYear": 2013,
+      "decade": "2010年代",
+      "genre": "アニメ",
+      "durationSeconds": 237,
+      "collectionName": "EXIT TUNES PRESENTS Vocalofantasy feat.初音ミク",
+      "itunesTrackId": 985156335,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:40:43+09:00"
+  },
+  {
+    "title": "タイムパラドックス",
+    "artist": "Vaundy",
+    "metadata": {
+      "releaseDate": "2024-01-07",
+      "releaseYear": 2024,
+      "decade": "2020年代",
+      "genre": "ロック",
+      "durationSeconds": 227,
+      "collectionName": "タイムパラドックス - Single",
+      "itunesTrackId": 1721130445,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:40:45+09:00"
+  },
+  {
+    "title": "アイドル",
+    "artist": "YOASOBI",
+    "metadata": {
+      "releaseDate": "2023-04-12",
+      "releaseYear": 2023,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 213,
+      "collectionName": "アイドル - Single",
+      "itunesTrackId": 1679278167,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:40:46+09:00"
+  },
+  {
+    "title": "シャルル",
+    "artist": "バルーン",
+    "metadata": {
+      "releaseDate": "2016-10-12",
+      "releaseYear": 2016,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 234,
+      "collectionName": "Corridor",
+      "itunesTrackId": 1271271759,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:41:00+09:00"
+  },
+  {
+    "title": "マリーゴールド",
+    "artist": "あいみょん",
+    "metadata": {
+      "releaseDate": "2018-07-18",
+      "releaseYear": 2018,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 308,
+      "collectionName": "マリーゴールド - Single",
+      "itunesTrackId": 1402042897,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:41:01+09:00"
+  },
+  {
+    "title": "だから僕は音楽を辞めた",
+    "artist": "ヨルシカ",
+    "metadata": {
+      "releaseDate": "2019-04-10",
+      "releaseYear": 2019,
+      "decade": "2010年代",
+      "genre": "ロック",
+      "durationSeconds": 243,
+      "collectionName": "だから僕は音楽を辞めた",
+      "itunesTrackId": 1648877323,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:41:02+09:00"
+  },
+  {
+    "title": "美しい鰭",
+    "artist": "スピッツ",
+    "metadata": {
+      "releaseDate": "2023-04-10",
+      "releaseYear": 2023,
+      "decade": "2020年代",
+      "genre": "ロック",
+      "durationSeconds": 212,
+      "collectionName": "美しい鰭 - Single",
+      "itunesTrackId": 1680093755,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:41:04+09:00"
+  },
+  {
+    "title": "君の銀の庭",
+    "artist": "Kalafina",
+    "metadata": {
+      "releaseDate": "2013-11-06",
+      "releaseYear": 2013,
+      "decade": "2010年代",
+      "genre": "アニメ",
+      "durationSeconds": 306,
+      "collectionName": "THE BEST “Blue”",
+      "itunesTrackId": 1537252415,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:41:05+09:00"
+  },
+  {
+    "title": "僕らまた",
+    "artist": "SG",
+    "metadata": {
+      "releaseDate": "2021-04-04",
+      "releaseYear": 2021,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 197,
+      "collectionName": "僕らまた - Single",
+      "itunesTrackId": 1561507415,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:41:07+09:00"
+  },
+  {
+    "title": "さくら",
+    "artist": "森山直太朗",
+    "metadata": {
+      "releaseDate": "2002-10-02",
+      "releaseYear": 2002,
+      "decade": "2000年代",
+      "genre": "ポップ",
+      "durationSeconds": 269,
+      "collectionName": "乾いた唄は魚の餌にちょうどいい",
+      "itunesTrackId": 1444128277,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:41:08+09:00"
+  },
+  {
+    "title": "メリクリ",
+    "artist": "BoA",
+    "metadata": {
+      "releaseDate": "2004-12-01",
+      "releaseYear": 2004,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 332,
+      "collectionName": "BEST OF SOUL",
+      "itunesTrackId": 200715360,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:41:09+09:00"
+  },
+  {
+    "title": "ロウワー",
+    "artist": "ぬゆり",
+    "metadata": {
+      "releaseDate": "2021-11-09",
+      "releaseYear": 2021,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 230,
+      "collectionName": "ロウワー - Single",
+      "itunesTrackId": 1592499103,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:41:11+09:00"
+  },
+  {
+    "title": "コロブチカ/テトリス",
+    "artist": "作曲者不詳/柊マグネタイト",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:41:12+09:00"
+  },
+  {
+    "title": "BOW AND ARROW",
+    "artist": "米津玄師",
+    "metadata": {
+      "releaseDate": "2025-01-27",
+      "releaseYear": 2025,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 176,
+      "collectionName": "BOW AND ARROW - Single",
+      "itunesTrackId": 1790607807,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:41:14+09:00"
+  },
+  {
+    "title": "真っ白",
+    "artist": "藤井風",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:41:15+09:00"
+  },
+  {
+    "title": "春愁",
+    "artist": "Mrs. GREEN APPLE",
+    "metadata": {
+      "releaseDate": "2018-02-14",
+      "releaseYear": 2018,
+      "decade": "2010年代",
+      "genre": "ロック",
+      "durationSeconds": 184,
+      "collectionName": "Love me, Love you - EP",
+      "itunesTrackId": 1441018143,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:41:16+09:00"
+  },
+  {
+    "title": "ひまわりの約束",
+    "artist": "秦基博",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:41:18+09:00"
+  },
+  {
+    "title": "猫",
+    "artist": "DISH//",
+    "metadata": {
+      "releaseDate": "2017-08-15",
+      "releaseYear": 2017,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 276,
+      "collectionName": "僕たちがやりました (Special Edition) - EP",
+      "itunesTrackId": 1537750439,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:41:19+09:00"
+  },
+  {
+    "title": "向日葵",
+    "artist": "Ado",
+    "metadata": {
+      "releaseDate": "2023-07-11",
+      "releaseYear": 2023,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 260,
+      "collectionName": "向日葵 - Single",
+      "itunesTrackId": 1694654875,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:41:21+09:00"
+  },
+  {
+    "title": "ただ君に晴れ",
+    "artist": "ヨルシカ",
+    "metadata": {
+      "releaseDate": "2018-05-09",
+      "releaseYear": 2018,
+      "decade": "2010年代",
+      "genre": "ロック",
+      "durationSeconds": 199,
+      "collectionName": "負け犬にアンコールはいらない",
+      "itunesTrackId": 1648876333,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:41:22+09:00"
+  },
+  {
+    "title": "チェリー",
+    "artist": "スピッツ",
+    "metadata": {
+      "releaseDate": "1996-01-01",
+      "releaseYear": 1996,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 261,
+      "collectionName": "CYCLE HIT 1991-1997 Spitz Complete Single Collection",
+      "itunesTrackId": 1440863574,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:41:23+09:00"
+  },
+  {
+    "title": "回る空うさぎ",
+    "artist": "Orangestar",
+    "metadata": {
+      "releaseDate": "2017-01-18",
+      "releaseYear": 2017,
+      "decade": "2010年代",
+      "genre": "アニメ",
+      "durationSeconds": 174,
+      "collectionName": "SEASIDE SOLILOQUIES",
+      "itunesTrackId": 1194947577,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:41:25+09:00"
+  },
+  {
+    "title": "会いたい",
+    "artist": "いきものがかり",
+    "metadata": {
+      "releaseDate": "2025-04-23",
+      "releaseYear": 2025,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 363,
+      "collectionName": "会いたい - EP",
+      "itunesTrackId": 1774642946,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:41:26+09:00"
+  },
+  {
+    "title": "へび",
+    "artist": "ヨルシカ",
+    "metadata": {
+      "releaseDate": "2025-01-17",
+      "releaseYear": 2025,
+      "decade": "2020年代",
+      "genre": "オルタナティブ",
+      "durationSeconds": 256,
+      "collectionName": "へび - Single",
+      "itunesTrackId": 1787471129,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:41:27+09:00"
+  },
+  {
+    "title": "真生活",
+    "artist": "案山子",
+    "metadata": {
+      "releaseDate": "2019-12-01",
+      "releaseYear": 2019,
+      "decade": "2010年代",
+      "genre": "アニメ",
+      "durationSeconds": 247,
+      "collectionName": "rouge",
+      "itunesTrackId": 1493377521,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:41:29+09:00"
+  },
+  {
+    "title": "remember",
+    "artist": "Uru",
+    "metadata": {
+      "releaseDate": "2018-09-26",
+      "releaseYear": 2018,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 349,
+      "collectionName": "remember",
+      "itunesTrackId": 1535549717,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:41:30+09:00"
+  },
+  {
+    "title": "勇気100%",
+    "artist": "光GENJI",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:41:31+09:00"
+  },
+  {
+    "title": "若者のすべて",
+    "artist": "フジファブリック",
+    "metadata": {
+      "releaseDate": "2004-11-15",
+      "releaseYear": 2004,
+      "decade": "2000年代",
+      "genre": "ロック",
+      "durationSeconds": 297,
+      "collectionName": "SINGLES 2004-2009",
+      "itunesTrackId": 1440725618,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:41:33+09:00"
+  },
+  {
+    "title": "はいよろこんで",
+    "artist": "こっちのけんと",
+    "metadata": {
+      "releaseDate": "2024-05-27",
+      "releaseYear": 2024,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 162,
+      "collectionName": "はいよろこんで - Single",
+      "itunesTrackId": 1745488818,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:41:34+09:00"
+  },
+  {
+    "title": "元気を出して",
+    "artist": "竹内まりや",
+    "metadata": {
+      "releaseDate": "1984-02-14",
+      "releaseYear": 1984,
+      "decade": "1980年代",
+      "genre": "J-Pop",
+      "durationSeconds": 285,
+      "collectionName": "Expressions (MOON Version)",
+      "itunesTrackId": 1541673401,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:41:36+09:00"
+  },
+  {
+    "title": "Anytime Anywhere",
+    "artist": "milet",
+    "metadata": {
+      "releaseDate": "2023-09-29",
+      "releaseYear": 2023,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 230,
+      "collectionName": "Anytime Anywhere - Single",
+      "itunesTrackId": 1708333825,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:41:37+09:00"
+  },
+  {
+    "title": "Get Wild",
+    "artist": "TM NETWORK",
+    "metadata": {
+      "releaseDate": "1987-04-08",
+      "releaseYear": 1987,
+      "decade": "1980年代",
+      "genre": "J-Pop",
+      "durationSeconds": 240,
+      "collectionName": "TM NETWORK ORIGINAL SINGLES 1984-1999",
+      "itunesTrackId": 1536875508,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:41:38+09:00"
+  },
+  {
+    "title": "天国",
+    "artist": "Mrs. GREEN APPLE",
+    "metadata": {
+      "releaseDate": "2025-05-02",
+      "releaseYear": 2025,
+      "decade": "2020年代",
+      "genre": "ロック",
+      "durationSeconds": 324,
+      "collectionName": "天国 - Single",
+      "itunesTrackId": 1810410952,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:41:40+09:00"
+  },
+  {
+    "title": "ウィーアー！",
+    "artist": "きただにひろし",
+    "metadata": {
+      "releaseDate": "1999-11-20",
+      "releaseYear": 1999,
+      "decade": "1990年代",
+      "genre": "アニメ",
+      "durationSeconds": 242,
+      "collectionName": "ウィーアー! (TVアニメ『ONE PIECE』オープニングテーマ) - Single",
+      "itunesTrackId": 1770907052,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:41:41+09:00"
+  },
+  {
+    "title": "可愛くてごめん",
+    "artist": "HoneyWorks",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:41:43+09:00"
+  },
+  {
+    "title": "ハロ／ハワユ",
+    "artist": "ナノウ",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:41:44+09:00"
+  },
+  {
+    "title": "雨とカプチーノ",
+    "artist": "ヨルシカ",
+    "metadata": {
+      "releaseDate": "2019-08-02",
+      "releaseYear": 2019,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 270,
+      "collectionName": "エルマ",
+      "itunesTrackId": 1474062330,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:41:46+09:00"
+  },
+  {
+    "title": "ENDLESS RAIN",
+    "artist": "X JAPAN",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:41:47+09:00"
+  },
+  {
+    "title": "繋いだ手から",
+    "artist": "back number",
+    "metadata": {
+      "releaseDate": "2014-03-19",
+      "releaseYear": 2014,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 283,
+      "collectionName": "繋いだ手から - EP",
+      "itunesTrackId": 1451566928,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:41:48+09:00"
+  },
+  {
+    "title": "クスシキ",
+    "artist": "Mrs. GREEN APPLE",
+    "metadata": {
+      "releaseDate": "2025-04-05",
+      "releaseYear": 2025,
+      "decade": "2020年代",
+      "genre": "ロック",
+      "durationSeconds": 188,
+      "collectionName": "クスシキ - Single",
+      "itunesTrackId": 1804230388,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:41:50+09:00"
+  },
+  {
+    "title": "RAIN",
+    "artist": "SEKAI NO OWARI",
+    "metadata": {
+      "releaseDate": "2017-07-05",
+      "releaseYear": 2017,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 307,
+      "collectionName": "RAIN - Single",
+      "itunesTrackId": 1248216996,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:41:51+09:00"
+  },
+  {
+    "title": "StaRt",
+    "artist": "Mrs. GREEN APPLE",
+    "metadata": {
+      "releaseDate": "2015-07-01",
+      "releaseYear": 2015,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 211,
+      "collectionName": "Variety - EP",
+      "itunesTrackId": 1440745441,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:42:00+09:00"
+  },
+  {
+    "title": "青のすみか",
+    "artist": "キタニタツヤ",
+    "metadata": {
+      "releaseDate": "2023-07-07",
+      "releaseYear": 2023,
+      "decade": "2020年代",
+      "genre": "オルタナティブ",
+      "durationSeconds": 196,
+      "collectionName": "青のすみか - Single",
+      "itunesTrackId": 1692289314,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:42:01+09:00"
+  },
+  {
+    "title": "Yesterday Once More",
+    "artist": "カーペンターズ",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:42:02+09:00"
+  },
+  {
+    "title": "GET BACK",
+    "artist": "ゆず",
+    "metadata": {
+      "releaseDate": "2025-05-21",
+      "releaseYear": 2025,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 150,
+      "collectionName": "GET BACK - Single",
+      "itunesTrackId": 1810615468,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:42:04+09:00"
+  },
+  {
+    "title": "RPG",
+    "artist": "SEKAI NO OWARI",
+    "metadata": {
+      "releaseDate": "2013-05-01",
+      "releaseYear": 2013,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 291,
+      "collectionName": "Tree",
+      "itunesTrackId": 955796477,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:42:05+09:00"
+  },
+  {
+    "title": "アイネクライネ",
+    "artist": "米津玄師",
+    "metadata": {
+      "releaseDate": "2014-04-23",
+      "releaseYear": 2014,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 288,
+      "collectionName": "YANKEE",
+      "itunesTrackId": 1440792118,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:42:07+09:00"
+  },
+  {
+    "title": "コウを追いかけて",
+    "artist": "坂本秀一",
+    "metadata": {
+      "releaseDate": "2016-11-18",
+      "releaseYear": 2016,
+      "decade": "2010年代",
+      "genre": "サウンドトラック",
+      "durationSeconds": 116,
+      "collectionName": "「溺れるナイフ」オリジナル・サウンドトラック",
+      "itunesTrackId": 1171317144,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:42:08+09:00"
+  },
+  {
+    "title": "さわって・変わって",
+    "artist": "スピッツ",
+    "metadata": {
+      "releaseDate": "2001-12-12",
+      "releaseYear": 2001,
+      "decade": "2000年代",
+      "genre": "ロック",
+      "durationSeconds": 219,
+      "collectionName": "三日月ロック",
+      "itunesTrackId": 1440618811,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:42:09+09:00"
+  },
+  {
+    "title": "ずっと2人で…",
+    "artist": "GLAY",
+    "metadata": {
+      "releaseDate": "1995-03-01",
+      "releaseYear": 1995,
+      "decade": "1990年代",
+      "genre": "ロック",
+      "durationSeconds": 417,
+      "collectionName": "SPEED POP",
+      "itunesTrackId": 989824416,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:42:11+09:00"
+  },
+  {
+    "title": "レイニーブルー",
+    "artist": "徳永英明",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:42:12+09:00"
+  },
+  {
+    "title": "春の歌",
+    "artist": "スピッツ",
+    "metadata": {
+      "releaseDate": "2005-01-12",
+      "releaseYear": 2005,
+      "decade": "2000年代",
+      "genre": "ロック",
+      "durationSeconds": 282,
+      "collectionName": "スーベニア",
+      "itunesTrackId": 1440738537,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:42:14+09:00"
+  },
+  {
+    "title": "帝国のマーチ(The Imperial March)",
+    "artist": "ジョン・ウィリアムズ",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:42:15+09:00"
+  },
+  {
+    "title": "暴れん坊将軍のテーマ",
+    "artist": "菊池俊輔",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:42:16+09:00"
+  },
+  {
+    "title": "Dear",
+    "artist": "Mrs. GREEN APPLE",
+    "metadata": {
+      "releaseDate": "2024-05-20",
+      "releaseYear": 2024,
+      "decade": "2020年代",
+      "genre": "ロック",
+      "durationSeconds": 311,
+      "collectionName": "Dear - Single",
+      "itunesTrackId": 1745507749,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:42:18+09:00"
+  },
+  {
+    "title": "遥か",
+    "artist": "スピッツ",
+    "metadata": {
+      "releaseDate": "2006-03-25",
+      "releaseYear": 2006,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 261,
+      "collectionName": "CYCLE HIT 1997-2005 Spitz Complete Single Collection",
+      "itunesTrackId": 1440893440,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:42:19+09:00"
+  },
+  {
+    "title": "ツバサ",
+    "artist": "アンダーグラフ",
+    "metadata": {
+      "releaseDate": "2004-09-22",
+      "releaseYear": 2004,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 269,
+      "collectionName": "ゼロへの調和",
+      "itunesTrackId": 219640354,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:42:21+09:00"
+  },
+  {
+    "title": "抜錨",
+    "artist": "ナナホシ管弦楽団",
+    "metadata": {
+      "releaseDate": "2017-11-12",
+      "releaseYear": 2017,
+      "decade": "2010年代",
+      "genre": "アニメ",
+      "durationSeconds": 204,
+      "collectionName": "パワード・ワード・ワールド",
+      "itunesTrackId": 1641741688,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:42:22+09:00"
+  },
+  {
+    "title": "デイ・ドリーム・ビリーバー",
+    "artist": "ザ・モンキーズ / ザ・タイマーズ",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:42:23+09:00"
+  },
+  {
+    "title": "Realize",
+    "artist": "玉置成実",
+    "metadata": {
+      "releaseDate": "2003-07-24",
+      "releaseYear": 2003,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 284,
+      "collectionName": "Believe / Realize BESTタッグ - Single",
+      "itunesTrackId": 1611160767,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:42:25+09:00"
+  },
+  {
+    "title": "瑠璃色の地球",
+    "artist": "松田聖子",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:42:26+09:00"
+  },
+  {
+    "title": "て",
+    "artist": "上野大樹",
+    "metadata": {
+      "releaseDate": "2020-12-02",
+      "releaseYear": 2020,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 146,
+      "collectionName": "瀬と瀬",
+      "itunesTrackId": 1540215947,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:42:27+09:00"
+  },
+  {
+    "title": "花になって",
+    "artist": "緑黄色社会",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:42:29+09:00"
+  },
+  {
+    "title": "花束を君に",
+    "artist": "宇多田ヒカル",
+    "metadata": {
+      "releaseDate": "2016-04-15",
+      "releaseYear": 2016,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 278,
+      "collectionName": "Fantôme",
+      "itunesTrackId": 1428767877,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:42:30+09:00"
+  },
+  {
+    "title": "花",
+    "artist": "中孝介 / 森山直太朗(Self Cover)",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:42:31+09:00"
+  },
+  {
+    "title": "花",
+    "artist": "ORANGE RANGE",
+    "metadata": {
+      "releaseDate": "2004-10-20",
+      "releaseYear": 2004,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 255,
+      "collectionName": "ALL the SINGLES",
+      "itunesTrackId": 1537418568,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:42:33+09:00"
+  },
+  {
+    "title": "花占い",
+    "artist": "Vaundy",
+    "metadata": {
+      "releaseDate": "2021-07-05",
+      "releaseYear": 2021,
+      "decade": "2020年代",
+      "genre": "ロック",
+      "durationSeconds": 208,
+      "collectionName": "花占い - Single",
+      "itunesTrackId": 1706829372,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:42:34+09:00"
+  },
+  {
+    "title": "花",
+    "artist": "樹原涼子",
+    "metadata": {
+      "releaseDate": "2004-04-01",
+      "releaseYear": 2004,
+      "decade": "2000年代",
+      "genre": "ヴォーカル",
+      "durationSeconds": 230,
+      "collectionName": "The Four Seasons -spring- 約束 - EP",
+      "itunesTrackId": 1757563911,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:42:36+09:00"
+  },
+  {
+    "title": "花の名",
+    "artist": "BUMP OF CHICKEN",
+    "metadata": {
+      "releaseDate": "2007-10-24",
+      "releaseYear": 2007,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 362,
+      "collectionName": "花の名 - Single",
+      "itunesTrackId": 1461735360,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:42:37+09:00"
+  },
+  {
+    "title": "花の塔",
+    "artist": "さユり",
+    "metadata": {
+      "releaseDate": "2022-07-03",
+      "releaseYear": 2022,
+      "decade": "2020年代",
+      "genre": "ロック",
+      "durationSeconds": 276,
+      "collectionName": "花の塔 - Single",
+      "itunesTrackId": 1630061094,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:42:38+09:00"
+  },
+  {
+    "title": "桜坂",
+    "artist": "福山雅治",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:42:40+09:00"
+  },
+  {
+    "title": "ひまわり",
+    "artist": "福山雅治",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:42:41+09:00"
+  },
+  {
+    "title": "帰ろう",
+    "artist": "藤井風",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:42:43+09:00"
+  },
+  {
+    "title": "ケセラセラ",
+    "artist": "Mrs. GREEN APPLE",
+    "metadata": {
+      "releaseDate": "2023-04-25",
+      "releaseYear": 2023,
+      "decade": "2020年代",
+      "genre": "ロック",
+      "durationSeconds": 273,
+      "collectionName": "ケセラセラ - Single",
+      "itunesTrackId": 1681600508,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:42:44+09:00"
+  },
+  {
+    "title": "コーヒールンバ",
+    "artist": "ウーゴ・ブランコ",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:42:46+09:00"
+  },
+  {
+    "title": "コーヒーとシロップ",
+    "artist": "Official髭男dism",
+    "metadata": {
+      "releaseDate": "2016-06-15",
+      "releaseYear": 2016,
+      "decade": "2010年代",
+      "genre": "ロック",
+      "durationSeconds": 225,
+      "collectionName": "MAN IN THE MIRROR",
+      "itunesTrackId": 1103745757,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:42:47+09:00"
+  },
+  {
+    "title": "一杯のコーヒーから",
+    "artist": "霧島昇とミス・コロムビア",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:42:48+09:00"
+  },
+  {
+    "title": "God knows...",
+    "artist": "涼宮ハルヒ(CV.平野 綾)",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:42:50+09:00"
+  },
+  {
+    "title": "コーヒーハウスにて",
+    "artist": "相曽晴日",
+    "metadata": {
+      "releaseDate": "1982-01-01",
+      "releaseYear": 1982,
+      "decade": "1980年代",
+      "genre": "J-Pop",
+      "durationSeconds": 238,
+      "collectionName": "トワイライトの風",
+      "itunesTrackId": 75027723,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:42:51+09:00"
+  },
+  {
+    "title": "ベンチとコーヒー",
+    "artist": "BUMP OF CHICKEN",
+    "metadata": {
+      "releaseDate": "2002-02-20",
+      "releaseYear": 2002,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 372,
+      "collectionName": "jupiter",
+      "itunesTrackId": 1464634463,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:42:53+09:00"
+  },
+  {
+    "title": "コーヒーショップで",
+    "artist": "あべ静江",
+    "metadata": {
+      "releaseDate": "1973-05-25",
+      "releaseYear": 1973,
+      "decade": "1970年代",
+      "genre": "歌謡曲",
+      "durationSeconds": 186,
+      "collectionName": "みずいろの手紙/コーヒーショップで",
+      "itunesTrackId": 1648093446,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:42:54+09:00"
+  },
+  {
+    "title": "Coffee",
+    "artist": "Mrs. GREEN APPLE",
+    "metadata": {
+      "releaseDate": "2018-04-17",
+      "releaseYear": 2018,
+      "decade": "2010年代",
+      "genre": "ロック",
+      "durationSeconds": 279,
+      "collectionName": "ENSEMBLE",
+      "itunesTrackId": 1360524272,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:42:55+09:00"
+  },
+  {
+    "title": "MELODY",
+    "artist": "福山雅治",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:42:57+09:00"
+  },
+  {
+    "title": "時代",
+    "artist": "中島みゆき",
+    "metadata": {
+      "releaseDate": "1993-12-01",
+      "releaseYear": 1993,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 274,
+      "collectionName": "時代/最後の女神 - Single",
+      "itunesTrackId": 1653991584,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:42:58+09:00"
+  },
+  {
+    "title": "新時代",
+    "artist": "Ado",
+    "metadata": {
+      "releaseDate": "2022-06-08",
+      "releaseYear": 2022,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 227,
+      "collectionName": "ウタの歌 ONE PIECE FILM RED",
+      "itunesTrackId": 1636446946,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:43:00+09:00"
+  },
+  {
+    "title": "少年時代",
+    "artist": "井上陽水",
+    "metadata": {
+      "releaseDate": "1990-09-21",
+      "releaseYear": 1990,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 201,
+      "collectionName": "少年時代 - Single",
+      "itunesTrackId": 284457304,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:43:01+09:00"
+  },
+  {
+    "title": "川の流れのように",
+    "artist": "美空ひばり",
+    "metadata": {
+      "releaseDate": "1989-01-01",
+      "releaseYear": 1989,
+      "decade": "1980年代",
+      "genre": "歌謡曲",
+      "durationSeconds": 296,
+      "collectionName": "美空ひばり プレミアムパッケージ「Best 70+1 Songs」",
+      "itunesTrackId": 280271444,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:43:02+09:00"
+  },
+  {
+    "title": "神田川",
+    "artist": "かぐや姫",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:43:04+09:00"
+  },
+  {
+    "title": "神っぽいな",
+    "artist": "ピノキオピー",
+    "metadata": {
+      "releaseDate": "2021-09-19",
+      "releaseYear": 2021,
+      "decade": "2020年代",
+      "genre": "エレクトロニック",
+      "durationSeconds": 204,
+      "collectionName": "神っぽいな - Single",
+      "itunesTrackId": 1585951058,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:43:05+09:00"
+  },
+  {
+    "title": "Love Song",
+    "artist": "Uru",
+    "metadata": {
+      "releaseDate": "2021-08-05",
+      "releaseYear": 2021,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 286,
+      "collectionName": "Love Song - EP",
+      "itunesTrackId": 1577551340,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:43:07+09:00"
+  },
+  {
+    "title": "水の星へ愛をこめて",
+    "artist": "森口博子",
+    "metadata": {
+      "releaseDate": "1985-08-07",
+      "releaseYear": 1985,
+      "decade": "1980年代",
+      "genre": "J-Pop",
+      "durationSeconds": 222,
+      "collectionName": "水の星へ愛をこめて - Single",
+      "itunesTrackId": 1688399963,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:43:08+09:00"
+  },
+  {
+    "title": "翔べ！ガンダム",
+    "artist": "池田鴻",
+    "metadata": {
+      "releaseDate": "1979-04-21",
+      "releaseYear": 1979,
+      "decade": "1970年代",
+      "genre": "アニメ",
+      "durationSeconds": 166,
+      "collectionName": "翔べ!ガンダム/永遠にアムロ - Single",
+      "itunesTrackId": 1244019603,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:43:09+09:00"
+  },
+  {
+    "title": "哀 戦士",
+    "artist": "井上大輔",
+    "metadata": {
+      "releaseDate": "1981-07-05",
+      "releaseYear": 1981,
+      "decade": "1980年代",
+      "genre": "アニメ",
+      "durationSeconds": 231,
+      "collectionName": "哀 戦士/風にひとりで - Single",
+      "itunesTrackId": 1244019088,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:43:11+09:00"
+  },
+  {
+    "title": "Plazma",
+    "artist": "米津玄師",
+    "metadata": {
+      "releaseDate": "2025-01-20",
+      "releaseYear": 2025,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 181,
+      "collectionName": "Plazma - Single",
+      "itunesTrackId": 1789465887,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:43:12+09:00"
+  },
+  {
+    "title": "渡月橋 ～君 想ふ～",
+    "artist": "倉木麻衣",
+    "metadata": {
+      "releaseDate": "2017-04-12",
+      "releaseYear": 2017,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 248,
+      "collectionName": "渡月橋 ~君 想ふ~ - Single",
+      "itunesTrackId": 1226258283,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:43:14+09:00"
+  },
+  {
+    "title": "名もなき詩",
+    "artist": "Mr.Children",
+    "metadata": {
+      "releaseDate": "1996-02-05",
+      "releaseYear": 1996,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 329,
+      "collectionName": "名もなき詩 - Single",
+      "itunesTrackId": 1374910673,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:43:15+09:00"
+  },
+  {
+    "title": "終わりなき旅",
+    "artist": "Mr.Children",
+    "metadata": {
+      "releaseDate": "1998-10-21",
+      "releaseYear": 1998,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 425,
+      "collectionName": "終わりなき旅 - Single",
+      "itunesTrackId": 1374906674,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:43:16+09:00"
+  },
+  {
+    "title": "しるし",
+    "artist": "Mr.Children",
+    "metadata": {
+      "releaseDate": "2006-11-15",
+      "releaseYear": 2006,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 432,
+      "collectionName": "しるし - Single",
+      "itunesTrackId": 1374876230,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:43:18+09:00"
+  },
+  {
+    "title": "強風オールバック",
+    "artist": "ゆこぴ",
+    "metadata": {
+      "releaseDate": "2023-11-29",
+      "releaseYear": 2023,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 137,
+      "collectionName": "アルバム1号",
+      "itunesTrackId": 1715782987,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:43:19+09:00"
+  },
+  {
+    "title": "愛が灯る",
+    "artist": "ロクデナシ",
+    "metadata": {
+      "releaseDate": "2023-02-15",
+      "releaseYear": 2023,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 199,
+      "collectionName": "愛が灯る - Single",
+      "itunesTrackId": 1668706884,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:43:20+09:00"
+  },
+  {
+    "title": "七つの海を渡る風のように",
+    "artist": "愛内里菜&三枝夕夏",
+    "metadata": {
+      "releaseDate": "2008-03-26",
+      "releaseYear": 2008,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 237,
+      "collectionName": "For you...3 ~春・旅立ち~",
+      "itunesTrackId": 276284384,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:43:22+09:00"
+  },
+  {
+    "title": "炎",
+    "artist": "LiSA",
+    "metadata": {
+      "releaseDate": "2020-10-12",
+      "releaseYear": 2020,
+      "decade": "2020年代",
+      "genre": "アニメ",
+      "durationSeconds": 274,
+      "collectionName": "炎 - EP",
+      "itunesTrackId": 1531847485,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:43:23+09:00"
+  },
+  {
+    "title": "月夜の悪戯の魔法",
+    "artist": "BREAKERZ",
+    "metadata": {
+      "releaseDate": "2011-04-27",
+      "releaseYear": 2011,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 289,
+      "collectionName": "月夜の悪戯の魔法/CLIMBER×CLIMBER - Single",
+      "itunesTrackId": 463446005,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:43:25+09:00"
+  },
+  {
+    "title": "PLAYERS",
+    "artist": "YOASOBI",
+    "metadata": {
+      "releaseDate": "2025-03-21",
+      "releaseYear": 2025,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 201,
+      "collectionName": "PLAYERS - Single",
+      "itunesTrackId": 1802134777,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:43:26+09:00"
+  },
+  {
+    "title": "Watch me!",
+    "artist": "YOASOBI",
+    "metadata": {
+      "releaseDate": "2025-05-18",
+      "releaseYear": 2025,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 186,
+      "collectionName": "Watch me! - Single",
+      "itunesTrackId": 1813364855,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:43:27+09:00"
+  },
+  {
+    "title": "もう少しだけ",
+    "artist": "YOASOBI",
+    "metadata": {
+      "releaseDate": "2021-05-10",
+      "releaseYear": 2021,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 220,
+      "collectionName": "もう少しだけ - Single",
+      "itunesTrackId": 1564444512,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:43:29+09:00"
+  },
+  {
+    "title": "夏祭り",
+    "artist": "JITTERIN'JINN(原曲) / Whiteberry(Cover)",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:43:30+09:00"
+  },
+  {
+    "title": "雲は白リンゴは赤",
+    "artist": "aiko",
+    "metadata": {
+      "releaseDate": "2006-07-12",
+      "releaseYear": 2006,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 251,
+      "collectionName": "雲は白リンゴは赤 - EP",
+      "itunesTrackId": 1499600312,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:43:31+09:00"
+  },
+  {
+    "title": "ナツノハナ",
+    "artist": "JUJU",
+    "metadata": {
+      "releaseDate": "2007-08-08",
+      "releaseYear": 2007,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 337,
+      "collectionName": "Wonderful Life",
+      "itunesTrackId": 1535497507,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:43:33+09:00"
+  },
+  {
+    "title": "夏色",
+    "artist": "ゆず",
+    "metadata": {
+      "releaseDate": "1998-06-03",
+      "releaseYear": 1998,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 203,
+      "collectionName": "ゆず一家",
+      "itunesTrackId": 422250979,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:43:34+09:00"
+  },
+  {
+    "title": "Summer",
+    "artist": "久石譲",
+    "metadata": {
+      "releaseDate": "1999-05-26",
+      "releaseYear": 1999,
+      "decade": "1990年代",
+      "genre": "サウンドトラック",
+      "durationSeconds": 386,
+      "collectionName": "菊次郎の夏 (オリジナル・サウンドトラック)",
+      "itunesTrackId": 1498700482,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:43:36+09:00"
+  },
+  {
+    "title": "旅立ちの日に",
+    "artist": "小嶋登、坂本浩美",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:43:37+09:00"
+  },
+  {
+    "title": "渚のアデリーヌ",
+    "artist": "リチャード・クレイダーマン",
+    "metadata": {
+      "releaseDate": "1977-01-01",
+      "releaseYear": 1977,
+      "decade": "1970年代",
+      "genre": "クラシック",
+      "durationSeconds": 158,
+      "collectionName": "ピアノ ピアノ! ピアノ!!",
+      "itunesTrackId": 855011119,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:43:38+09:00"
+  },
+  {
+    "title": "River flows in you",
+    "artist": "イルマ",
+    "metadata": {
+      "releaseDate": "2001-11-27",
+      "releaseYear": 2001,
+      "decade": "2000年代",
+      "genre": "ニューエイジ",
+      "durationSeconds": 189,
+      "collectionName": "Yiruma 2nd Album 'First Love' (The Original & the Very First Recording)",
+      "itunesTrackId": 1436677761,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:43:40+09:00"
+  },
+  {
+    "title": "My Heart Will Go On",
+    "artist": "セリーヌ・ディオン",
+    "metadata": {
+      "releaseDate": "1997-11-14",
+      "releaseYear": 1997,
+      "decade": "1990年代",
+      "genre": "ポップ",
+      "durationSeconds": 283,
+      "collectionName": "I AM: CELINE DION (Original Motion Picture Soundtrack)",
+      "itunesTrackId": 1745568934,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:43:41+09:00"
+  },
+  {
+    "title": "let it be",
+    "artist": "ビートルズ",
+    "metadata": {
+      "releaseDate": "2003-11-17",
+      "releaseYear": 2003,
+      "decade": "2000年代",
+      "genre": "ロック",
+      "durationSeconds": 235,
+      "collectionName": "Let It Be... Naked",
+      "itunesTrackId": 1441132706,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:43:43+09:00"
+  },
+  {
+    "title": "翼をください",
+    "artist": "村井邦彦",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:43:44+09:00"
+  },
+  {
+    "title": "戦場のメリークリスマス",
+    "artist": "坂本龍一",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:43:46+09:00"
+  },
+  {
+    "title": "The Rose",
+    "artist": "ベット・ミドラー",
+    "metadata": {
+      "releaseDate": "1979-01-01",
+      "releaseYear": 1979,
+      "decade": "1970年代",
+      "genre": "サウンドトラック",
+      "durationSeconds": 221,
+      "collectionName": "The Rose (The Original Soundtrack Recording)",
+      "itunesTrackId": 740212490,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:43:47+09:00"
+  },
+  {
+    "title": "アメイジング・グレイス",
+    "artist": "ジョン・ニュートン",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:43:48+09:00"
+  },
+  {
+    "title": "天城越え",
+    "artist": "石川さゆり",
+    "metadata": {
+      "releaseDate": "1986-07-21",
+      "releaseYear": 1986,
+      "decade": "1980年代",
+      "genre": "演歌",
+      "durationSeconds": 293,
+      "collectionName": "名唱コレクション 石川さゆり 時代の粋を唄う",
+      "itunesTrackId": 1860988958,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:43:50+09:00"
+  },
+  {
+    "title": "二人セゾン",
+    "artist": "欅坂46",
+    "metadata": {
+      "releaseDate": "2016-11-30",
+      "releaseYear": 2016,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 289,
+      "collectionName": "永遠より長い一瞬 ~あの頃、確かに存在した私たち~(Complete Edition)",
+      "itunesTrackId": 1533414469,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:43:51+09:00"
+  },
+  {
+    "title": "硝子の少年",
+    "artist": "KinKi Kids",
+    "metadata": {
+      "releaseDate": "1997-07-21",
+      "releaseYear": 1997,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 279,
+      "collectionName": "B album",
+      "itunesTrackId": 1810378623,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:43:53+09:00"
+  },
+  {
+    "title": "Time goes by",
+    "artist": "Every Little Thing",
+    "metadata": {
+      "releaseDate": "1998-02-11",
+      "releaseYear": 1998,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 312,
+      "collectionName": "Time goes by - Single",
+      "itunesTrackId": 1014864272,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:43:54+09:00"
+  },
+  {
+    "title": "スノーマジックファンタジー",
+    "artist": "SEKAI NO OWARI",
+    "metadata": {
+      "releaseDate": "2014-01-22",
+      "releaseYear": 2014,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 316,
+      "collectionName": "Tree",
+      "itunesTrackId": 955796395,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:43:55+09:00"
+  },
+  {
+    "title": "純恋歌",
+    "artist": "湘南乃風",
+    "metadata": {
+      "releaseDate": "2006-03-08",
+      "releaseYear": 2006,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 431,
+      "collectionName": "純恋歌 - Single",
+      "itunesTrackId": 1508422678,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:43:57+09:00"
+  },
+  {
+    "title": "夏の終わり",
+    "artist": "森山直太朗",
+    "metadata": {
+      "releaseDate": "2003-08-20",
+      "releaseYear": 2003,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 347,
+      "collectionName": "傑作撰 2001~2005",
+      "itunesTrackId": 1444129023,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:43:58+09:00"
+  },
+  {
+    "title": "このまま君だけを奪い去りたい",
+    "artist": "DEEN",
+    "metadata": {
+      "releaseDate": "1998-03-18",
+      "releaseYear": 1998,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 279,
+      "collectionName": "DEEN SINGLES+1",
+      "itunesTrackId": 75717512,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:44:00+09:00"
+  },
+  {
+    "title": "涙のイエスタデー",
+    "artist": "GARNET CROW",
+    "metadata": {
+      "releaseDate": "2007-07-04",
+      "releaseYear": 2007,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 280,
+      "collectionName": "REQUEST BEST",
+      "itunesTrackId": 719990540,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:44:01+09:00"
+  },
+  {
+    "title": "energy flow",
+    "artist": "坂本龍一",
+    "metadata": {
+      "releaseDate": "1998-09-26",
+      "releaseYear": 1998,
+      "decade": "1990年代",
+      "genre": "ポップ",
+      "durationSeconds": 273,
+      "collectionName": "BTTB -20th Anniversary Edition-",
+      "itunesTrackId": 1434825534,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:44:03+09:00"
+  },
+  {
+    "title": "きらきら星",
+    "artist": "ジャン・フィリップ・ラモー",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:44:04+09:00"
+  },
+  {
+    "title": "7月7日、晴れ",
+    "artist": "DREAMS COME TRUE",
+    "metadata": {
+      "releaseDate": "1996-04-01",
+      "releaseYear": 1996,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 254,
+      "collectionName": "7月7日、晴れ サウンドトラック",
+      "itunesTrackId": 1536207088,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:44:05+09:00"
+  },
+  {
+    "title": "渚にまつわるエトセトラ",
+    "artist": "PUFFY",
+    "metadata": {
+      "releaseDate": "1997-01-01",
+      "releaseYear": 1997,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 233,
+      "collectionName": "30th Anniversary",
+      "itunesTrackId": 6763519747,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:44:07+09:00"
+  },
+  {
+    "title": "渚",
+    "artist": "スピッツ",
+    "metadata": {
+      "releaseDate": "1996-09-09",
+      "releaseYear": 1996,
+      "decade": "1990年代",
+      "genre": "ロック",
+      "durationSeconds": 288,
+      "collectionName": "インディゴ地平線",
+      "itunesTrackId": 1440746845,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:44:08+09:00"
+  },
+  {
+    "title": "残響散歌",
+    "artist": "Aimer",
+    "metadata": {
+      "releaseDate": "2021-12-06",
+      "releaseYear": 2021,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 185,
+      "collectionName": "残響散歌 / 朝が来る - EP",
+      "itunesTrackId": 1594814706,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:44:09+09:00"
+  },
+  {
+    "title": "夏の魔物",
+    "artist": "スピッツ",
+    "metadata": {
+      "releaseDate": "1991-03-25",
+      "releaseYear": 1991,
+      "decade": "1990年代",
+      "genre": "ロック",
+      "durationSeconds": 191,
+      "collectionName": "スピッツ",
+      "itunesTrackId": 1443091269,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:44:11+09:00"
+  },
+  {
+    "title": "魔法の絨毯",
+    "artist": "川崎鷹也",
+    "metadata": {
+      "releaseDate": "2018-03-14",
+      "releaseYear": 2018,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 209,
+      "collectionName": "I believe in you",
+      "itunesTrackId": 1573810335,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:44:12+09:00"
+  },
+  {
+    "title": "わたしの一番かわいいところ",
+    "artist": "FRUITS ZIPPER",
+    "metadata": {
+      "releaseDate": "2022-04-29",
+      "releaseYear": 2022,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 261,
+      "collectionName": "NEW KAWAII",
+      "itunesTrackId": 1807963404,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:44:14+09:00"
+  },
+  {
+    "title": "たなばたさま",
+    "artist": "下総皖一",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:44:15+09:00"
+  },
+  {
+    "title": "シングル・アゲイン",
+    "artist": "竹内まりや",
+    "metadata": {
+      "releaseDate": "1989-09-12",
+      "releaseYear": 1989,
+      "decade": "1980年代",
+      "genre": "J-Pop",
+      "durationSeconds": 265,
+      "collectionName": "Expressions (MOON Version)",
+      "itunesTrackId": 1541673406,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:44:17+09:00"
+  },
+  {
+    "title": "毎日がスペシャル",
+    "artist": "竹内まりや",
+    "metadata": {
+      "releaseDate": "2001-08-22",
+      "releaseYear": 2001,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 301,
+      "collectionName": "Bon Appetit!",
+      "itunesTrackId": 257400711,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:44:18+09:00"
+  },
+  {
+    "title": "うさぎ",
+    "artist": "作曲者不詳",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:44:19+09:00"
+  },
+  {
+    "title": "祝福",
+    "artist": "YOASOBI",
+    "metadata": {
+      "releaseDate": "2022-10-01",
+      "releaseYear": 2022,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 196,
+      "collectionName": "祝福 - Single",
+      "itunesTrackId": 1645308331,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:44:21+09:00"
+  },
+  {
+    "title": "いぬのおまわりさん",
+    "artist": "大中恩",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:44:22+09:00"
+  },
+  {
+    "title": "新宝島",
+    "artist": "サカナクション",
+    "metadata": {
+      "releaseDate": "2015-09-30",
+      "releaseYear": 2015,
+      "decade": "2010年代",
+      "genre": "ロック",
+      "durationSeconds": 306,
+      "collectionName": "新宝島 - EP",
+      "itunesTrackId": 1039793121,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:44:24+09:00"
+  },
+  {
+    "title": "ありがとう",
+    "artist": "大橋卓弥",
+    "metadata": {
+      "releaseDate": "2008-04-02",
+      "releaseYear": 2008,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 299,
+      "collectionName": "Drunk Monkeys",
+      "itunesTrackId": 1443163958,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:44:25+09:00"
+  },
+  {
+    "title": "ありがとう",
+    "artist": "井上陽水奥田民生",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:44:26+09:00"
+  },
+  {
+    "title": "青春ライン",
+    "artist": "いきものがかり",
+    "metadata": {
+      "releaseDate": "2007-08-08",
+      "releaseYear": 2007,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 239,
+      "collectionName": "夏空グラフィティ/青春ライン - EP",
+      "itunesTrackId": 1536232596,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:44:28+09:00"
+  },
+  {
+    "title": "天体観測",
+    "artist": "BUMP OF CHICKEN",
+    "metadata": {
+      "releaseDate": "2001-03-14",
+      "releaseYear": 2001,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 264,
+      "collectionName": "天体観測 - Single",
+      "itunesTrackId": 1465863819,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:44:29+09:00"
+  },
+  {
+    "title": "貴方の側に。",
+    "artist": "りりあ。",
+    "metadata": {
+      "releaseDate": "2023-07-06",
+      "releaseYear": 2023,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 242,
+      "collectionName": "貴方の側に。 - Single",
+      "itunesTrackId": 1690736863,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:44:31+09:00"
+  },
+  {
+    "title": "打上花火",
+    "artist": "DAOKO×米津玄師",
+    "metadata": {
+      "releaseDate": "2017-08-16",
+      "releaseYear": 2017,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 289,
+      "collectionName": "打上花火 - Single",
+      "itunesTrackId": 1263790415,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:44:32+09:00"
+  },
+  {
+    "title": "海",
+    "artist": "文部省唱歌(作詞、作曲不詳)",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:44:33+09:00"
+  },
+  {
+    "title": "久遠 ～光と波の記憶～",
+    "artist": "松枝賀子、江口貴勅",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:44:35+09:00"
+  },
+  {
+    "title": "恋しさと せつなさと 心強さと",
+    "artist": "篠原涼子",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:44:36+09:00"
+  },
+  {
+    "title": "恋",
+    "artist": "星野源",
+    "metadata": {
+      "releaseDate": "2016-10-05",
+      "releaseYear": 2016,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 253,
+      "collectionName": "恋 - EP",
+      "itunesTrackId": 1156375396,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:44:38+09:00"
+  },
+  {
+    "title": "世界は恋に落ちている",
+    "artist": "CHiCO with HoneyWorks",
+    "metadata": {
+      "releaseDate": "2014-08-06",
+      "releaseYear": 2014,
+      "decade": "2010年代",
+      "genre": "アニメ",
+      "durationSeconds": 311,
+      "collectionName": "世界は恋に落ちている - EP",
+      "itunesTrackId": 1537331532,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:44:39+09:00"
+  },
+  {
+    "title": "あなたに",
+    "artist": "MONGOL800",
+    "metadata": {
+      "releaseDate": "2001-09-16",
+      "releaseYear": 2001,
+      "decade": "2000年代",
+      "genre": "オルタナティブ",
+      "durationSeconds": 196,
+      "collectionName": "MESSAGE",
+      "itunesTrackId": 273169324,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:44:40+09:00"
+  },
+  {
+    "title": "ユアーズ",
+    "artist": "菅田将暉",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:44:42+09:00"
+  },
+  {
+    "title": "Cry Baby",
+    "artist": "Official髭男dism",
+    "metadata": {
+      "releaseDate": "2021-05-07",
+      "releaseYear": 2021,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 240,
+      "collectionName": "Cry Baby - Single",
+      "itunesTrackId": 1563683060,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:44:43+09:00"
+  },
+  {
+    "title": "Snow halation",
+    "artist": "μ's",
+    "metadata": {
+      "releaseDate": "2010-12-22",
+      "releaseYear": 2010,
+      "decade": "2010年代",
+      "genre": "アニメ",
+      "durationSeconds": 259,
+      "collectionName": "Snow halation - EP",
+      "itunesTrackId": 1891050046,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:44:44+09:00"
+  },
+  {
+    "title": "SWEET MEMORIES",
+    "artist": "松田聖子",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:44:46+09:00"
+  },
+  {
+    "title": "わたがし",
+    "artist": "back number",
+    "metadata": {
+      "releaseDate": "2012-07-18",
+      "releaseYear": 2012,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 262,
+      "collectionName": "わたがし - EP",
+      "itunesTrackId": 1451567084,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:44:47+09:00"
+  },
+  {
+    "title": "115万キロのフィルム",
+    "artist": "Official髭男dism",
+    "metadata": {
+      "releaseDate": "2018-04-11",
+      "releaseYear": 2018,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 325,
+      "collectionName": "エスカパレード",
+      "itunesTrackId": 1394013614,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:44:49+09:00"
+  },
+  {
+    "title": "I LOVE...",
+    "artist": "Official髭男dism",
+    "metadata": {
+      "releaseDate": "2020-02-12",
+      "releaseYear": 2020,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 282,
+      "collectionName": "I LOVE... - Single",
+      "itunesTrackId": 1492963535,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:44:50+09:00"
+  },
+  {
+    "title": "ミックスナッツ",
+    "artist": "Official髭男dism",
+    "metadata": {
+      "releaseDate": "2022-04-15",
+      "releaseYear": 2022,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 213,
+      "collectionName": "ミックスナッツ - Single",
+      "itunesTrackId": 1616586639,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:44:51+09:00"
+  },
+  {
+    "title": "灰色と青",
+    "artist": "米津玄師、菅田将暉",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:44:53+09:00"
+  },
+  {
+    "title": "それがあなたの幸せとしても",
+    "artist": "Heavenz",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:44:54+09:00"
+  },
+  {
+    "title": "うたかた花火",
+    "artist": "Supercell",
+    "metadata": {
+      "releaseDate": "2011-03-16",
+      "releaseYear": 2011,
+      "decade": "2010年代",
+      "genre": "アニメ",
+      "durationSeconds": 362,
+      "collectionName": "うたかた花火/星が瞬くこんな夜に",
+      "itunesTrackId": 1537420032,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:44:56+09:00"
+  },
+  {
+    "title": "ロミオとシンデレラ",
+    "artist": "doriko",
+    "metadata": {
+      "releaseDate": "2009-08-19",
+      "releaseYear": 2009,
+      "decade": "2000年代",
+      "genre": "アニメ",
+      "durationSeconds": 281,
+      "collectionName": "ロミオとシンデレラ - Single",
+      "itunesTrackId": 1648263854,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:44:57+09:00"
+  },
+  {
+    "title": "ドーナツホール",
+    "artist": "ハチ",
+    "metadata": {
+      "releaseDate": "2015-11-13",
+      "releaseYear": 2015,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 205,
+      "collectionName": "ドーナツホール - Single",
+      "itunesTrackId": 1056062119,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:45:00+09:00"
+  },
+  {
+    "title": "深海少女",
+    "artist": "ゆうゆ",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:45:01+09:00"
+  },
+  {
+    "title": "ホシアイ",
+    "artist": "レフティーモンスターP",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:45:03+09:00"
+  },
+  {
+    "title": "宇宙戦艦ヤマト",
+    "artist": "ささきいさお",
+    "metadata": {
+      "releaseDate": "2016-09-28",
+      "releaseYear": 2016,
+      "decade": "2010年代",
+      "genre": "アニメ",
+      "durationSeconds": 135,
+      "collectionName": "MOMENT 〜今の向こうの今を〜",
+      "itunesTrackId": 1162564855,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:45:04+09:00"
+  },
+  {
+    "title": "銀河鉄道999",
+    "artist": "ゴダイゴ",
+    "metadata": {
+      "releaseDate": "1979-07-01",
+      "releaseYear": 1979,
+      "decade": "1970年代",
+      "genre": "J-Pop",
+      "durationSeconds": 209,
+      "collectionName": "GODIEGO GREAT BEST VOL.1 -Japanese Version-",
+      "itunesTrackId": 477643022,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:45:05+09:00"
+  },
+  {
+    "title": "わんだふるぷりきゅあ！evolution!!",
+    "artist": "吉武千颯",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:45:07+09:00"
+  },
+  {
+    "title": "Over the Rainbow(虹の彼方に)",
+    "artist": "ハロルド・アーレン",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:45:08+09:00"
+  },
+  {
+    "title": "あー夏休み",
+    "artist": "TUBE",
+    "metadata": {
+      "releaseDate": "1989-12-21",
+      "releaseYear": 1989,
+      "decade": "1980年代",
+      "genre": "J-Pop",
+      "durationSeconds": 285,
+      "collectionName": "N・A・T・S・U",
+      "itunesTrackId": 1535482212,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:45:10+09:00"
+  },
+  {
+    "title": "島唄",
+    "artist": "THE BOOM",
+    "metadata": {
+      "releaseDate": "1989-01-01",
+      "releaseYear": 1989,
+      "decade": "1980年代",
+      "genre": "J-Pop",
+      "durationSeconds": 303,
+      "collectionName": "思春期",
+      "itunesTrackId": 1536709036,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:45:11+09:00"
+  },
+  {
+    "title": "僕らの夏の夢",
+    "artist": "山下達郎",
+    "metadata": {
+      "releaseDate": "2008-03-12",
+      "releaseYear": 2008,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 306,
+      "collectionName": "Ray Of Hope",
+      "itunesTrackId": 458559023,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:45:12+09:00"
+  },
+  {
+    "title": "深い森",
+    "artist": "Do As Infinity",
+    "metadata": {
+      "releaseDate": "2001-06-27",
+      "releaseYear": 2001,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 245,
+      "collectionName": "Deep Forest",
+      "itunesTrackId": 75621413,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:45:14+09:00"
+  },
+  {
+    "title": "高嶺の花子さん",
+    "artist": "back number",
+    "metadata": {
+      "releaseDate": "2013-01-01",
+      "releaseYear": 2013,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 295,
+      "collectionName": "高嶺の花子さん - EP",
+      "itunesTrackId": 1451566891,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:45:16+09:00"
+  },
+  {
+    "title": "全力少年",
+    "artist": "スキマスイッチ",
+    "metadata": {
+      "releaseDate": "2005-04-20",
+      "releaseYear": 2005,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 274,
+      "collectionName": "グレイテスト・ヒッツ",
+      "itunesTrackId": 1440897282,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:45:17+09:00"
+  },
+  {
+    "title": "君がくれた夏",
+    "artist": "家入レオ",
+    "metadata": {
+      "releaseDate": "2015-08-19",
+      "releaseYear": 2015,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 258,
+      "collectionName": "君がくれた夏 - Single",
+      "itunesTrackId": 1026711118,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:45:18+09:00"
+  },
+  {
+    "title": "ミツバチ",
+    "artist": "遊助",
+    "metadata": {
+      "releaseDate": "2010-07-28",
+      "releaseYear": 2010,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 251,
+      "collectionName": "ミツバチ - EP",
+      "itunesTrackId": 1537420007,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:45:20+09:00"
+  },
+  {
+    "title": "負けないで",
+    "artist": "ZARD",
+    "metadata": {
+      "releaseDate": "1993-01-27",
+      "releaseYear": 1993,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 225,
+      "collectionName": "ZARD BEST The  Single  Collection  ～軌跡～",
+      "itunesTrackId": 76095814,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:45:21+09:00"
+  },
+  {
+    "title": "M",
+    "artist": "浜崎あゆみ",
+    "metadata": {
+      "releaseDate": "2000-12-13",
+      "releaseYear": 2000,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 271,
+      "collectionName": "A COMPLETE ~ALL SINGLES~",
+      "itunesTrackId": 289403701,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:45:23+09:00"
+  },
+  {
+    "title": "M",
+    "artist": "プリンセス プリンセス",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:45:24+09:00"
+  },
+  {
+    "title": "Driver's High",
+    "artist": "L'Arc～en～Ciel",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:45:26+09:00"
+  },
+  {
+    "title": "アイスクリーム シンドローム",
+    "artist": "スキマスイッチ",
+    "metadata": {
+      "releaseDate": "2010-07-07",
+      "releaseYear": 2010,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 295,
+      "collectionName": "アイスクリーム シンドローム - EP",
+      "itunesTrackId": 1444886346,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:45:27+09:00"
+  },
+  {
+    "title": "君は天然色",
+    "artist": "大滝詠一",
+    "metadata": {
+      "releaseDate": "1981-03-21",
+      "releaseYear": 1981,
+      "decade": "1980年代",
+      "genre": "J-Pop",
+      "durationSeconds": 307,
+      "collectionName": "A LONG VACATION",
+      "itunesTrackId": 1556260400,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:45:28+09:00"
+  },
+  {
+    "title": "チューリングラブ",
+    "artist": "ナナヲアカリ",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:45:30+09:00"
+  },
+  {
+    "title": "Diamonds",
+    "artist": "プリンセス プリンセス",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:45:31+09:00"
+  },
+  {
+    "title": "月光浴",
+    "artist": "柴田淳",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:45:33+09:00"
+  },
+  {
+    "title": "地上の星",
+    "artist": "中島みゆき",
+    "metadata": {
+      "releaseDate": "2000-07-19",
+      "releaseYear": 2000,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 311,
+      "collectionName": "地上の星 / ヘッドライト・テールライト - Single",
+      "itunesTrackId": 107232909,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:45:34+09:00"
+  },
+  {
+    "title": "Myra",
+    "artist": "Tani Yuuki",
+    "metadata": {
+      "releaseDate": "2020-05-16",
+      "releaseYear": 2020,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 255,
+      "collectionName": "Myra - Single",
+      "itunesTrackId": 1521618651,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:45:35+09:00"
+  },
+  {
+    "title": "W/X/Y",
+    "artist": "Tani Yuuki",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:45:37+09:00"
+  },
+  {
+    "title": "サクラキミワタシ",
+    "artist": "tuki.",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:45:38+09:00"
+  },
+  {
+    "title": "白日",
+    "artist": "King Gnu",
+    "metadata": {
+      "releaseDate": "2019-02-22",
+      "releaseYear": 2019,
+      "decade": "2010年代",
+      "genre": "オルタナティブ",
+      "durationSeconds": 275,
+      "collectionName": "白日 - Single",
+      "itunesTrackId": 1536027148,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:45:40+09:00"
+  },
+  {
+    "title": "にじ",
+    "artist": "中川ひろたか",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:45:41+09:00"
+  },
+  {
+    "title": "虹",
+    "artist": "手嶌葵",
+    "metadata": {
+      "releaseDate": "2008-06-04",
+      "releaseYear": 2008,
+      "decade": "2000年代",
+      "genre": "ヴォーカル",
+      "durationSeconds": 321,
+      "collectionName": "虹の歌集",
+      "itunesTrackId": 313439447,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:45:42+09:00"
+  },
+  {
+    "title": "虹",
+    "artist": "Aqua Timez",
+    "metadata": {
+      "releaseDate": "2005-01-01",
+      "releaseYear": 2005,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 339,
+      "collectionName": "10th Anniversary Best RED",
+      "itunesTrackId": 1536313320,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:45:44+09:00"
+  },
+  {
+    "title": "虹",
+    "artist": "福山雅治",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:45:47+09:00"
+  },
+  {
+    "title": "虹",
+    "artist": "高橋優",
+    "metadata": {
+      "releaseDate": "2017-07-26",
+      "releaseYear": 2017,
+      "decade": "2010年代",
+      "genre": "ロック",
+      "durationSeconds": 356,
+      "collectionName": "虹/シンプル - EP",
+      "itunesTrackId": 1256541190,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:45:48+09:00"
+  },
+  {
+    "title": "虹",
+    "artist": "二宮和也",
+    "metadata": {
+      "releaseDate": "2007-07-11",
+      "releaseYear": 2007,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 265,
+      "collectionName": "ウラ嵐BEST 1999-2007",
+      "itunesTrackId": 1573383059,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:45:59+09:00"
+  },
+  {
+    "title": "虹",
+    "artist": "ゆず",
+    "metadata": {
+      "releaseDate": "2009-09-02",
+      "releaseYear": 2009,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 327,
+      "collectionName": "虹 - Single",
+      "itunesTrackId": 425580467,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:46:00+09:00"
+  },
+  {
+    "title": "虹",
+    "artist": "コブクロ",
+    "metadata": {
+      "releaseDate": "2007-06-13",
+      "releaseYear": 2007,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 306,
+      "collectionName": "ALL TIME BEST 1998-2018",
+      "itunesTrackId": 1441818340,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:46:02+09:00"
+  },
+  {
+    "title": "虹色の心",
+    "artist": "リチャード・クレイダーマン",
+    "metadata": {
+      "releaseDate": "1982-01-01",
+      "releaseYear": 1982,
+      "decade": "1980年代",
+      "genre": "イージーリスニング",
+      "durationSeconds": 219,
+      "collectionName": "栄光の軌跡",
+      "itunesTrackId": 279405347,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:46:03+09:00"
+  },
+  {
+    "title": "ベテルギウス",
+    "artist": "優里",
+    "metadata": {
+      "releaseDate": "2021-11-04",
+      "releaseYear": 2021,
+      "decade": "2020年代",
+      "genre": "ロック",
+      "durationSeconds": 230,
+      "collectionName": "ベテルギウス - Single",
+      "itunesTrackId": 1589915077,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:46:04+09:00"
+  },
+  {
+    "title": "あの夢をなぞって",
+    "artist": "YOASOBI",
+    "metadata": {
+      "releaseDate": "2020-01-18",
+      "releaseYear": 2020,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 243,
+      "collectionName": "あの夢をなぞって - Single",
+      "itunesTrackId": 1494399118,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:46:06+09:00"
+  },
+  {
+    "title": "サヨナラ",
+    "artist": "GAO",
+    "metadata": {
+      "releaseDate": "1992-04-21",
+      "releaseYear": 1992,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 235,
+      "collectionName": "サヨナラ",
+      "itunesTrackId": 1594810011,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:46:07+09:00"
+  },
+  {
+    "title": "どんぐりころころ",
+    "artist": "梁田貞",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:46:09+09:00"
+  },
+  {
+    "title": "森の小さなレストラン",
+    "artist": "手嶌葵",
+    "metadata": {
+      "releaseDate": "2023-04-12",
+      "releaseYear": 2023,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 153,
+      "collectionName": "森の小さなレストラン - Single",
+      "itunesTrackId": 1678898357,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:46:10+09:00"
+  },
+  {
+    "title": "ドラえもん",
+    "artist": "星野源",
+    "metadata": {
+      "releaseDate": "2018-02-28",
+      "releaseYear": 2018,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 240,
+      "collectionName": "ドラえもん - EP",
+      "itunesTrackId": 1348205599,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:46:12+09:00"
+  },
+  {
+    "title": "YUME日和",
+    "artist": "島谷ひとみ",
+    "metadata": {
+      "releaseDate": "2003-11-06",
+      "releaseYear": 2003,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 244,
+      "collectionName": "Delicious!~The Best of Hitomi Shimatani~",
+      "itunesTrackId": 1128272549,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:46:13+09:00"
+  },
+  {
+    "title": "ボクノート",
+    "artist": "スキマスイッチ",
+    "metadata": {
+      "releaseDate": "2003-01-01",
+      "releaseYear": 2003,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 337,
+      "collectionName": "夕風ブレンド",
+      "itunesTrackId": 1442953655,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:46:14+09:00"
+  },
+  {
+    "title": "また会える日まで",
+    "artist": "ゆず",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:46:16+09:00"
+  },
+  {
+    "title": "ぼくドラえもん",
+    "artist": "大山のぶ代、こおろぎ'73",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:46:17+09:00"
+  },
+  {
+    "title": "少年期",
+    "artist": "武田鉄矢",
+    "metadata": {
+      "releaseDate": "1991-01-01",
+      "releaseYear": 1991,
+      "decade": "1990年代",
+      "genre": "歌謡曲",
+      "durationSeconds": 192,
+      "collectionName": "ドラえもん 映画主題歌集+挿入歌",
+      "itunesTrackId": 1440790935,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:46:19+09:00"
+  },
+  {
+    "title": "スター・ウォーズ メインテーマ",
+    "artist": "ジョン・ウィリアムズ",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:46:20+09:00"
+  },
+  {
+    "title": "ヘドウィグのテーマ",
+    "artist": "ジョン・ウィリアムズ",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:46:22+09:00"
+  },
+  {
+    "title": "レイダース・マーチ",
+    "artist": "ジョン・ウィリアムズ",
+    "metadata": {
+      "releaseDate": "2008-01-01",
+      "releaseYear": 2008,
+      "decade": "2000年代",
+      "genre": "サウンドトラック",
+      "durationSeconds": 306,
+      "collectionName": "インディ・ジョーンズ/クリスタル・スカルの王国 (オリジナル・サウンドトラック)",
+      "itunesTrackId": 1400941657,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:46:23+09:00"
+  },
+  {
+    "title": "スーパーマンのテーマ",
+    "artist": "ジョン・ウィリアムズ",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:46:24+09:00"
+  },
+  {
+    "title": "ミッションインポッシブルのテーマ",
+    "artist": "ラロ・シフリン",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:46:26+09:00"
+  },
+  {
+    "title": "バック・トゥ・ザ・フューチャーのテーマ",
+    "artist": "アラン・シルヴェストリ",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:46:27+09:00"
+  },
+  {
+    "title": "ロッキーのテーマ",
+    "artist": "ビル・コンティ",
+    "metadata": {
+      "releaseDate": "1982-01-01",
+      "releaseYear": 1982,
+      "decade": "1980年代",
+      "genre": "インストゥルメンタル",
+      "durationSeconds": 170,
+      "collectionName": "Full 70s",
+      "itunesTrackId": 1847500253,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:46:29+09:00"
+  },
+  {
+    "title": "ゴーストバスターズ",
+    "artist": "レイ・パーカー・ジュニア",
+    "metadata": {
+      "releaseDate": "1984-05-01",
+      "releaseYear": 1984,
+      "decade": "1980年代",
+      "genre": "サウンドトラック",
+      "durationSeconds": 239,
+      "collectionName": "Pure... Movies",
+      "itunesTrackId": 404853969,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:46:30+09:00"
+  },
+  {
+    "title": "80日間世界一周",
+    "artist": "ビクター・ヤング",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:46:32+09:00"
+  },
+  {
+    "title": "フォレストガンプのテーマ",
+    "artist": "アラン・シルヴェストリ",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:46:33+09:00"
+  },
+  {
+    "title": "月のワルツ",
+    "artist": "諫山実生",
+    "metadata": {
+      "releaseDate": "2004-11-01",
+      "releaseYear": 2004,
+      "decade": "2000年代",
+      "genre": "ポップ",
+      "durationSeconds": 283,
+      "collectionName": "月のワルツ - Single",
+      "itunesTrackId": 720409377,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:46:35+09:00"
+  },
+  {
+    "title": "TRUE LOVE",
+    "artist": "藤井フミヤ",
+    "metadata": {
+      "releaseDate": "1993-11-10",
+      "releaseYear": 1993,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 233,
+      "collectionName": "エンジェル",
+      "itunesTrackId": 260699478,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:46:36+09:00"
+  },
+  {
+    "title": "I LOVE YOU",
+    "artist": "尾崎豊",
+    "metadata": {
+      "releaseDate": "2013-11-27",
+      "releaseYear": 2013,
+      "decade": "2010年代",
+      "genre": "ロック",
+      "durationSeconds": 260,
+      "collectionName": "ALL TIME BEST",
+      "itunesTrackId": 1537531003,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:46:37+09:00"
+  },
+  {
+    "title": "Everything",
+    "artist": "MISIA",
+    "metadata": {
+      "releaseDate": "2000-10-25",
+      "releaseYear": 2000,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 420,
+      "collectionName": "Everything - EP",
+      "itunesTrackId": 1536002900,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:46:39+09:00"
+  },
+  {
+    "title": "OH MY LITTLE GIRL",
+    "artist": "尾崎豊",
+    "metadata": {
+      "releaseDate": "1983-12-01",
+      "releaseYear": 1983,
+      "decade": "1980年代",
+      "genre": "ロック",
+      "durationSeconds": 276,
+      "collectionName": "WEDNESDAY〜LOVE SONG BEST OF YUTAKA OZAKI",
+      "itunesTrackId": 1537395820,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:46:59+09:00"
+  },
+  {
+    "title": "オレンジ",
+    "artist": "SMAP",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:47:01+09:00"
+  },
+  {
+    "title": "アンドロメダ",
+    "artist": "aiko",
+    "metadata": {
+      "releaseDate": "2003-08-06",
+      "releaseYear": 2003,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 289,
+      "collectionName": "アンドロメダ - EP",
+      "itunesTrackId": 1499476930,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:47:02+09:00"
+  },
+  {
+    "title": "LOVE LOVE LOVE",
+    "artist": "DREAMS COME TRUE",
+    "metadata": {
+      "releaseDate": "1995-07-24",
+      "releaseYear": 1995,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 204,
+      "collectionName": "愛していると言ってくれ オリジナル・サウンドトラック",
+      "itunesTrackId": 1536204693,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:47:04+09:00"
+  },
+  {
+    "title": "守ってあげたい",
+    "artist": "松任谷由実",
+    "metadata": {
+      "releaseDate": "1981-06-21",
+      "releaseYear": 1981,
+      "decade": "1980年代",
+      "genre": "J-Pop",
+      "durationSeconds": 267,
+      "collectionName": "守ってあげたい - Single",
+      "itunesTrackId": 1436008910,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:47:05+09:00"
+  },
+  {
+    "title": "風のように",
+    "artist": "S.E.N.S.",
+    "metadata": {
+      "releaseDate": "1988-01-01",
+      "releaseYear": 1988,
+      "decade": "1980年代",
+      "genre": "J-Pop",
+      "durationSeconds": 305,
+      "collectionName": "GOLDEN☆BEST  S.E.N.S.〜Singles Collection",
+      "itunesTrackId": 1536735711,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:47:06+09:00"
+  },
+  {
+    "title": "かたち あるもの",
+    "artist": "柴咲コウ",
+    "metadata": {
+      "releaseDate": "2004-08-11",
+      "releaseYear": 2004,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 256,
+      "collectionName": "KO SHIBASAKI ALL TIME BEST 詩",
+      "itunesTrackId": 1440903667,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:47:08+09:00"
+  },
+  {
+    "title": "オーケストラ",
+    "artist": "BiSH",
+    "metadata": {
+      "releaseDate": "2016-10-05",
+      "releaseYear": 2016,
+      "decade": "2010年代",
+      "genre": "ロック",
+      "durationSeconds": 342,
+      "collectionName": "KiLLER BiSH",
+      "itunesTrackId": 1147516283,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:47:09+09:00"
+  },
+  {
+    "title": "まちがいさがし",
+    "artist": "菅田将暉",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:47:11+09:00"
+  },
+  {
+    "title": "君に届け",
+    "artist": "flumpool",
+    "metadata": {
+      "releaseDate": "2010-09-29",
+      "releaseYear": 2010,
+      "decade": "2010年代",
+      "genre": "ロック",
+      "durationSeconds": 325,
+      "collectionName": "君に届け - Single",
+      "itunesTrackId": 1838916920,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:47:12+09:00"
+  },
+  {
+    "title": "BELIEVE",
+    "artist": "杉本竜一",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:47:14+09:00"
+  },
+  {
+    "title": "マイ バラード",
+    "artist": "松井孝夫",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:47:15+09:00"
+  },
+  {
+    "title": "証",
+    "artist": "flumpool",
+    "metadata": {
+      "releaseDate": "2011-09-07",
+      "releaseYear": 2011,
+      "decade": "2010年代",
+      "genre": "ロック",
+      "durationSeconds": 320,
+      "collectionName": "証 - EP",
+      "itunesTrackId": 1838917016,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:47:16+09:00"
+  },
+  {
+    "title": "南風",
+    "artist": "レミオロメン",
+    "metadata": {
+      "releaseDate": "2005-02-09",
+      "releaseYear": 2005,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 242,
+      "collectionName": "南風 - Single",
+      "itunesTrackId": 1857509722,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:47:18+09:00"
+  },
+  {
+    "title": "二人のアカボシ",
+    "artist": "キンモクセイ",
+    "metadata": {
+      "releaseDate": "2001-02-27",
+      "releaseYear": 2001,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 340,
+      "collectionName": "ベスト・コンディション〜kinmokusei single collection〜",
+      "itunesTrackId": 1535996759,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:47:19+09:00"
+  },
+  {
+    "title": "キンモクセイ",
+    "artist": "オレンジスパイニクラブ",
+    "metadata": {
+      "releaseDate": "2019-01-20",
+      "releaseYear": 2019,
+      "decade": "2010年代",
+      "genre": "ロック",
+      "durationSeconds": 232,
+      "collectionName": "イラつくときはいつだって",
+      "itunesTrackId": 1559717561,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:47:21+09:00"
+  },
+  {
+    "title": "カワキヲアメク",
+    "artist": "美波",
+    "metadata": {
+      "releaseDate": "2019-01-30",
+      "releaseYear": 2019,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 252,
+      "collectionName": "カワキヲアメク - EP",
+      "itunesTrackId": 1725802551,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:47:22+09:00"
+  },
+  {
+    "title": "あんたなんて。",
+    "artist": "りりあ。",
+    "metadata": {
+      "releaseDate": "2024-10-13",
+      "releaseYear": 2024,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 242,
+      "collectionName": "あんたなんて。 - Single",
+      "itunesTrackId": 1770727505,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:47:23+09:00"
+  },
+  {
+    "title": "なんでもないよ、",
+    "artist": "マカロニえんぴつ",
+    "metadata": {
+      "releaseDate": "2021-11-03",
+      "releaseYear": 2021,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 219,
+      "collectionName": "なんでもないよ、 - Single",
+      "itunesTrackId": 1591370660,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:47:25+09:00"
+  },
+  {
+    "title": "Eyes On Me",
+    "artist": "Superfly",
+    "metadata": {
+      "releaseDate": "2010-12-15",
+      "releaseYear": 2010,
+      "decade": "2010年代",
+      "genre": "ロック",
+      "durationSeconds": 273,
+      "collectionName": "Mind Travel",
+      "itunesTrackId": 440112862,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:47:26+09:00"
+  },
+  {
+    "title": "AM11:00",
+    "artist": "HY",
+    "metadata": {
+      "releaseDate": "2000-01-01",
+      "releaseYear": 2000,
+      "decade": "2000年代",
+      "genre": "ロック",
+      "durationSeconds": 319,
+      "collectionName": "Street Story",
+      "itunesTrackId": 297287194,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:47:27+09:00"
+  },
+  {
+    "title": "黒毛和牛上塩タン焼680円",
+    "artist": "大塚愛",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:47:29+09:00"
+  },
+  {
+    "title": "夜空ノムコウ",
+    "artist": "SMAP",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:47:30+09:00"
+  },
+  {
+    "title": "想い出がいっぱい",
+    "artist": "H2O",
+    "metadata": {
+      "releaseDate": "1983-03-25",
+      "releaseYear": 1983,
+      "decade": "1980年代",
+      "genre": "J-Pop",
+      "durationSeconds": 242,
+      "collectionName": "想い出がいっぱい - Single",
+      "itunesTrackId": 1825777193,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:47:32+09:00"
+  },
+  {
+    "title": "Your Best Friend",
+    "artist": "倉木麻衣",
+    "metadata": {
+      "releaseDate": "2011-10-19",
+      "releaseYear": 2011,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 353,
+      "collectionName": "Your Best Friend - Single",
+      "itunesTrackId": 470147829,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:47:33+09:00"
+  },
+  {
+    "title": "めざせポケモンマスター",
+    "artist": "松本梨香",
+    "metadata": {
+      "releaseDate": "1997-06-28",
+      "releaseYear": 1997,
+      "decade": "1990年代",
+      "genre": "アニメ",
+      "durationSeconds": 252,
+      "collectionName": "ポケモンTVアニメ主題歌 BEST OF BEST 1997-2012",
+      "itunesTrackId": 583838497,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:47:35+09:00"
+  },
+  {
+    "title": "乙女どもよ。",
+    "artist": "CHiCO with HoneyWorks",
+    "metadata": {
+      "releaseDate": "2019-07-27",
+      "releaseYear": 2019,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 252,
+      "collectionName": "瞬く世界にiを揺らせ",
+      "itunesTrackId": 1530015502,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:47:36+09:00"
+  },
+  {
+    "title": "パリは燃えているか",
+    "artist": "加古隆",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:47:38+09:00"
+  },
+  {
+    "title": "木蘭の涙",
+    "artist": "スターダストレビュー",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:47:39+09:00"
+  },
+  {
+    "title": "夏の決心",
+    "artist": "大江千里",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:47:40+09:00"
+  },
+  {
+    "title": "未来へ",
+    "artist": "Kiroro",
+    "metadata": {
+      "releaseDate": "1998-06-24",
+      "releaseYear": 1998,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 330,
+      "collectionName": "キロロのいちばんイイ歌あつめました",
+      "itunesTrackId": 156209828,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:47:42+09:00"
+  },
+  {
+    "title": "Sunny Day Sunday",
+    "artist": "センチメンタル・バス",
+    "metadata": {
+      "releaseDate": "1999-08-04",
+      "releaseYear": 1999,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 154,
+      "collectionName": "Sunny Day Sunday - Single",
+      "itunesTrackId": 1537228599,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:47:43+09:00"
+  },
+  {
+    "title": "Over Drive",
+    "artist": "JUDY AND MARY",
+    "metadata": {
+      "releaseDate": "1995-06-19",
+      "releaseYear": 1995,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 259,
+      "collectionName": "MIRACLE DIVING",
+      "itunesTrackId": 1536206508,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:47:45+09:00"
+  },
+  {
+    "title": "ミュージック・アワー",
+    "artist": "ポルノグラフィティ",
+    "metadata": {
+      "releaseDate": "2000-07-12",
+      "releaseYear": 2000,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 276,
+      "collectionName": "PORNO GRAFFITTI BEST RED'S",
+      "itunesTrackId": 1537232075,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:47:46+09:00"
+  },
+  {
+    "title": "HOT LIMIT",
+    "artist": "T.M.Revolution",
+    "metadata": {
+      "releaseDate": "1998-06-24",
+      "releaseYear": 1998,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 221,
+      "collectionName": "1000000000000",
+      "itunesTrackId": 1536230428,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:47:47+09:00"
+  },
+  {
+    "title": "奥寺先輩のテーマ",
+    "artist": "RADWIMPS",
+    "metadata": {
+      "releaseDate": "2016-08-24",
+      "releaseYear": 2016,
+      "decade": "2010年代",
+      "genre": "ロック",
+      "durationSeconds": 126,
+      "collectionName": "君の名は。",
+      "itunesTrackId": 1440719636,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:47:49+09:00"
+  },
+  {
+    "title": "ガラモン・ソング",
+    "artist": "蓜島邦明",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:47:59+09:00"
+  },
+  {
+    "title": "Same Blue",
+    "artist": "Official髭男dism",
+    "metadata": {
+      "releaseDate": "2024-10-02",
+      "releaseYear": 2024,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 238,
+      "collectionName": "Same Blue - Single",
+      "itunesTrackId": 1768218701,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:48:01+09:00"
+  },
+  {
+    "title": "サザエさん一家",
+    "artist": "宇野ゆう子",
+    "metadata": {
+      "releaseDate": "1992-09-23",
+      "releaseYear": 1992,
+      "decade": "1990年代",
+      "genre": "ポップ",
+      "durationSeconds": 208,
+      "collectionName": "サザエさん - EP",
+      "itunesTrackId": 829758742,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:48:02+09:00"
+  },
+  {
+    "title": "サザエさん",
+    "artist": "宇野ゆう子",
+    "metadata": {
+      "releaseDate": "1992-09-23",
+      "releaseYear": 1992,
+      "decade": "1990年代",
+      "genre": "ポップ",
+      "durationSeconds": 180,
+      "collectionName": "サザエさん - EP",
+      "itunesTrackId": 829758740,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:48:04+09:00"
+  },
+  {
+    "title": "サマータイム ブルース",
+    "artist": "渡辺美里",
+    "metadata": {
+      "releaseDate": "1990-07-07",
+      "releaseYear": 1990,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 320,
+      "collectionName": "美里うたGolden BEST",
+      "itunesTrackId": 1536269708,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:48:05+09:00"
+  },
+  {
+    "title": "I'm a mess",
+    "artist": "MY FIRST STORY",
+    "metadata": {
+      "releaseDate": "2021-07-14",
+      "releaseYear": 2021,
+      "decade": "2020年代",
+      "genre": "ロック",
+      "durationSeconds": 249,
+      "collectionName": "告白 - Confession - Single",
+      "itunesTrackId": 1571628539,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:48:06+09:00"
+  },
+  {
+    "title": "ワインレッドの心",
+    "artist": "安全地帯",
+    "metadata": {
+      "releaseDate": "1983-11-25",
+      "releaseYear": 1983,
+      "decade": "1980年代",
+      "genre": "ロック",
+      "durationSeconds": 251,
+      "collectionName": "安全地帯Ⅱ",
+      "itunesTrackId": 1443380310,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:48:08+09:00"
+  },
+  {
+    "title": "カイト",
+    "artist": "嵐",
+    "metadata": {
+      "releaseDate": "2020-11-03",
+      "releaseYear": 2020,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 283,
+      "collectionName": "This is 嵐",
+      "itunesTrackId": 1541306821,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:48:09+09:00"
+  },
+  {
+    "title": "世界に一つだけの花",
+    "artist": "SMAP",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:48:11+09:00"
+  },
+  {
+    "title": "Hello, Again ～昔からある場所～",
+    "artist": "MY LITTLE LOVER",
+    "metadata": {
+      "releaseDate": "2015-11-25",
+      "releaseYear": 2015,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 311,
+      "collectionName": "re:evergreen",
+      "itunesTrackId": 1050899149,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:48:12+09:00"
+  },
+  {
+    "title": "星座になれたら",
+    "artist": "結束バンド",
+    "metadata": {
+      "releaseDate": "2022-12-25",
+      "releaseYear": 2022,
+      "decade": "2020年代",
+      "genre": "アニメ",
+      "durationSeconds": 258,
+      "collectionName": "星座になれたら - Single",
+      "itunesTrackId": 1657316198,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:48:13+09:00"
+  },
+  {
+    "title": "You Raise Me Up",
+    "artist": "Secret Garden",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:48:15+09:00"
+  },
+  {
+    "title": "花火",
+    "artist": "aiko",
+    "metadata": {
+      "releaseDate": "1999-08-04",
+      "releaseYear": 1999,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 279,
+      "collectionName": "桜の木の下",
+      "itunesTrackId": 1109978628,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:48:16+09:00"
+  },
+  {
+    "title": "Top of the World",
+    "artist": "カーペンターズ",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:48:18+09:00"
+  },
+  {
+    "title": "青春の輝き(I Need to Be in Love)",
+    "artist": "カーペンターズ",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:48:19+09:00"
+  },
+  {
+    "title": "Sing",
+    "artist": "カーペンターズ",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:48:20+09:00"
+  },
+  {
+    "title": "365日の紙飛行機",
+    "artist": "AKB48",
+    "metadata": {
+      "releaseDate": "2015-12-09",
+      "releaseYear": 2015,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 282,
+      "collectionName": "唇にBe My Baby (Type A) - EP",
+      "itunesTrackId": 1062460737,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:48:22+09:00"
+  },
+  {
+    "title": "CRUCIFY MY LOVE",
+    "artist": "X JAPAN",
+    "metadata": {
+      "releaseDate": "1996-08-26",
+      "releaseYear": 1996,
+      "decade": "1990年代",
+      "genre": "ロック",
+      "durationSeconds": 276,
+      "collectionName": "DAHLIA",
+      "itunesTrackId": 1886166660,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:48:23+09:00"
+  },
+  {
+    "title": "紅",
+    "artist": "X JAPAN",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:48:25+09:00"
+  },
+  {
+    "title": "金魚花火",
+    "artist": "大塚愛",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:48:26+09:00"
+  },
+  {
+    "title": "天使のくれた奇跡",
+    "artist": "Libera",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:48:27+09:00"
+  },
+  {
+    "title": "唱",
+    "artist": "Ado",
+    "metadata": {
+      "releaseDate": "2023-09-06",
+      "releaseYear": 2023,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 190,
+      "collectionName": "唱 - Single",
+      "itunesTrackId": 1704093812,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:48:29+09:00"
+  },
+  {
+    "title": "うっせぇわ",
+    "artist": "Ado",
+    "metadata": {
+      "releaseDate": "2020-10-23",
+      "releaseYear": 2020,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 205,
+      "collectionName": "うっせぇわ - Single",
+      "itunesTrackId": 1535123742,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:48:30+09:00"
+  },
+  {
+    "title": "ドラえもんのうた",
+    "artist": "大杉久美子",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:48:32+09:00"
+  },
+  {
+    "title": "倍倍FIGHT!",
+    "artist": "CANDY TUNE",
+    "metadata": {
+      "releaseDate": "2024-04-24",
+      "releaseYear": 2024,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 254,
+      "collectionName": "倍倍FIGHT! - Single",
+      "itunesTrackId": 1807721854,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:48:33+09:00"
+  },
+  {
+    "title": "恋のメガラバ",
+    "artist": "マキシマム ザ ホルモン",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:48:34+09:00"
+  },
+  {
+    "title": "決意の朝に",
+    "artist": "Aqua Timez",
+    "metadata": {
+      "releaseDate": "2005-01-01",
+      "releaseYear": 2005,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 303,
+      "collectionName": "The BEST of Aqua Timez",
+      "itunesTrackId": 1536259381,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:48:36+09:00"
+  },
+  {
+    "title": "Violet Snow",
+    "artist": "結城アイラ",
+    "metadata": {
+      "releaseDate": "2020-03-25",
+      "releaseYear": 2020,
+      "decade": "2020年代",
+      "genre": "アニメ",
+      "durationSeconds": 273,
+      "collectionName": "Leading role",
+      "itunesTrackId": 1498022230,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:48:37+09:00"
+  },
+  {
+    "title": "みちしるべ",
+    "artist": "茅原実里",
+    "metadata": {
+      "releaseDate": "2018-01-31",
+      "releaseYear": 2018,
+      "decade": "2010年代",
+      "genre": "アニメ",
+      "durationSeconds": 286,
+      "collectionName": "SPIRAL",
+      "itunesTrackId": 1486799616,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:48:39+09:00"
+  },
+  {
+    "title": "WILL",
+    "artist": "TRUE",
+    "metadata": {
+      "releaseDate": "2020-09-16",
+      "releaseYear": 2020,
+      "decade": "2020年代",
+      "genre": "アニメ",
+      "durationSeconds": 332,
+      "collectionName": "コトバアソビ",
+      "itunesTrackId": 1579813840,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:48:40+09:00"
+  },
+  {
+    "title": "KissHug",
+    "artist": "aiko",
+    "metadata": {
+      "releaseDate": "2008-07-23",
+      "releaseYear": 2008,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 363,
+      "collectionName": "KissHug - EP",
+      "itunesTrackId": 1499615822,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:48:41+09:00"
+  },
+  {
+    "title": "相思相愛",
+    "artist": "aiko",
+    "metadata": {
+      "releaseDate": "2024-04-12",
+      "releaseYear": 2024,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 261,
+      "collectionName": "相思相愛 - Single",
+      "itunesTrackId": 1737707213,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:48:43+09:00"
+  },
+  {
+    "title": "Zoltraak",
+    "artist": "Evan Call",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:48:44+09:00"
+  },
+  {
+    "title": "怪獣のバラード",
+    "artist": "東海林修",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:48:45+09:00"
+  },
+  {
+    "title": "愛のメモリー",
+    "artist": "松崎しげる",
+    "metadata": {
+      "releaseDate": "1988-05-11",
+      "releaseYear": 1988,
+      "decade": "1980年代",
+      "genre": "ポップ",
+      "durationSeconds": 300,
+      "collectionName": "Time",
+      "itunesTrackId": 720409949,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:48:47+09:00"
+  },
+  {
+    "title": "I Don't Want to Set the World on Fire",
+    "artist": "The Ink Spots",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:48:48+09:00"
+  },
+  {
+    "title": "銀色飛行船",
+    "artist": "Supercell",
+    "metadata": {
+      "releaseDate": "2012-12-12",
+      "releaseYear": 2012,
+      "decade": "2010年代",
+      "genre": "アニメ",
+      "durationSeconds": 425,
+      "collectionName": "銀色飛行船 - EP",
+      "itunesTrackId": 1537455821,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:48:50+09:00"
+  },
+  {
+    "title": "雨に唄えば(Singin' in the Rain)",
+    "artist": "ナシオ・ハーブ・ブラウン",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:48:51+09:00"
+  },
+  {
+    "title": "ハナミズキ",
+    "artist": "一青窈",
+    "metadata": {
+      "releaseDate": "2004-02-11",
+      "releaseYear": 2004,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 326,
+      "collectionName": "ハナミズキ - Single",
+      "itunesTrackId": 157155289,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:48:53+09:00"
+  },
+  {
+    "title": "明日へ",
+    "artist": "富岡博志",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:48:54+09:00"
+  },
+  {
+    "title": "荒城の月",
+    "artist": "滝廉太郎",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:48:56+09:00"
+  },
+  {
+    "title": "花",
+    "artist": "滝廉太郎",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:48:59+09:00"
+  },
+  {
+    "title": "さくらんぼ",
+    "artist": "大塚愛",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:49:01+09:00"
+  },
+  {
+    "title": "夕焼小焼",
+    "artist": "草川信",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:49:02+09:00"
+  },
+  {
+    "title": "故郷",
+    "artist": "岡野貞一",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:49:04+09:00"
+  },
+  {
+    "title": "おもちゃのチャチャチャ",
+    "artist": "越部信義",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:49:05+09:00"
+  },
+  {
+    "title": "魂のルフラン",
+    "artist": "高橋洋子",
+    "metadata": {
+      "releaseDate": "1997-02-21",
+      "releaseYear": 1997,
+      "decade": "1990年代",
+      "genre": "アニメ",
+      "durationSeconds": 314,
+      "collectionName": "魂のルフラン/THANATOS-IF I CAN'T BE YOURS - EP",
+      "itunesTrackId": 258926443,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:49:07+09:00"
+  },
+  {
+    "title": "歩いて帰ろう",
+    "artist": "斉藤和義",
+    "metadata": {
+      "releaseDate": "1995-02-01",
+      "releaseYear": 1995,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 210,
+      "collectionName": "WONDERFUL FISH",
+      "itunesTrackId": 1281427312,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:49:08+09:00"
+  },
+  {
+    "title": "give it back",
+    "artist": "Cö shu Nie",
+    "metadata": {
+      "releaseDate": "2021-01-22",
+      "releaseYear": 2021,
+      "decade": "2020年代",
+      "genre": "ロック",
+      "durationSeconds": 212,
+      "collectionName": "give it back - Single",
+      "itunesTrackId": 1545881892,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:49:09+09:00"
+  },
+  {
+    "title": "廻廻奇譚",
+    "artist": "Eve",
+    "metadata": {
+      "releaseDate": "2020-10-03",
+      "releaseYear": 2020,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 219,
+      "collectionName": "廻廻奇譚 - Single",
+      "itunesTrackId": 1533208085,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:49:11+09:00"
+  },
+  {
+    "title": "夏の終りのハーモニー",
+    "artist": "井上陽水・安全地帯",
+    "metadata": {
+      "releaseDate": "2017-05-31",
+      "releaseYear": 2017,
+      "decade": "2010年代",
+      "genre": "歌謡曲",
+      "durationSeconds": 267,
+      "collectionName": "ALL TIME BEST",
+      "itunesTrackId": 1440895683,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:49:12+09:00"
+  },
+  {
+    "title": "赤とんぼ",
+    "artist": "山田耕筰",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:49:13+09:00"
+  },
+  {
+    "title": "シーズン・イン・ザ・サン",
+    "artist": "TUBE",
+    "metadata": {
+      "releaseDate": "1986-01-01",
+      "releaseYear": 1986,
+      "decade": "1980年代",
+      "genre": "J-Pop",
+      "durationSeconds": 242,
+      "collectionName": "THE SEASON IN THE SUN",
+      "itunesTrackId": 1535481261,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:49:15+09:00"
+  },
+  {
+    "title": "サマータイムシンデレラ",
+    "artist": "緑黄色社会",
+    "metadata": {
+      "releaseDate": "2023-07-24",
+      "releaseYear": 2023,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 229,
+      "collectionName": "サマータイムシンデレラ - EP",
+      "itunesTrackId": 1697302630,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:49:16+09:00"
+  },
+  {
+    "title": "めぐりあい",
+    "artist": "井上大輔",
+    "metadata": {
+      "releaseDate": "1982-01-01",
+      "releaseYear": 1982,
+      "decade": "1980年代",
+      "genre": "アニメ",
+      "durationSeconds": 264,
+      "collectionName": "めぐりあい - Single",
+      "itunesTrackId": 1244018758,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:49:18+09:00"
+  },
+  {
+    "title": "檄！帝国華撃団",
+    "artist": "真宮寺さくら（横山智佐）＆帝国歌劇団",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:49:19+09:00"
+  },
+  {
+    "title": "ZOO",
+    "artist": "川村かおり / ECHOES(Self Cover)",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:49:20+09:00"
+  },
+  {
+    "title": "ゆずれない願い",
+    "artist": "田村直美",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:49:22+09:00"
+  },
+  {
+    "title": "フォニイ",
+    "artist": "ツミキ",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:49:23+09:00"
+  },
+  {
+    "title": "パプリカ",
+    "artist": "Foorin",
+    "metadata": {
+      "releaseDate": "2018-08-13",
+      "releaseYear": 2018,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 208,
+      "collectionName": "パプリカ - Single",
+      "itunesTrackId": 1537765262,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:49:24+09:00"
+  },
+  {
+    "title": "君がいるから",
+    "artist": "菅原紗由理",
+    "metadata": {
+      "releaseDate": "2009-12-02",
+      "releaseYear": 2009,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 354,
+      "collectionName": "君がいるから - EP",
+      "itunesTrackId": 339961792,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:49:26+09:00"
+  },
+  {
+    "title": "できっこないを やらなくちゃ",
+    "artist": "サンボマスター",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:49:27+09:00"
+  },
+  {
+    "title": "第ゼロ感",
+    "artist": "10-FEET",
+    "metadata": {
+      "releaseDate": "2022-11-09",
+      "releaseYear": 2022,
+      "decade": "2020年代",
+      "genre": "ロック",
+      "durationSeconds": 288,
+      "collectionName": "第ゼロ感 - Single",
+      "itunesTrackId": 1652587504,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:49:29+09:00"
+  },
+  {
+    "title": "ノスタルジックレインフォール",
+    "artist": "CHiCO with HoneyWorks",
+    "metadata": {
+      "releaseDate": "2018-01-19",
+      "releaseYear": 2018,
+      "decade": "2010年代",
+      "genre": "アニメ",
+      "durationSeconds": 238,
+      "collectionName": "私を染めるiの歌",
+      "itunesTrackId": 1537336376,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:49:30+09:00"
+  },
+  {
+    "title": "素直になれなくて",
+    "artist": "シカゴ",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:49:32+09:00"
+  },
+  {
+    "title": "瞳を閉じて",
+    "artist": "平井堅",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:49:33+09:00"
+  },
+  {
+    "title": "トドカナイカラ",
+    "artist": "平井堅",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:49:34+09:00"
+  },
+  {
+    "title": "また逢う日まで",
+    "artist": "平井大",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:49:36+09:00"
+  },
+  {
+    "title": "Stand by me, Stand by you.",
+    "artist": "平井大",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:49:37+09:00"
+  },
+  {
+    "title": "祈り花",
+    "artist": "平井大",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:49:39+09:00"
+  },
+  {
+    "title": "幸せのレシピ",
+    "artist": "平井大",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:49:40+09:00"
+  },
+  {
+    "title": "アイコトバ",
+    "artist": "アイナ・ジ・エンド",
+    "metadata": {
+      "releaseDate": "2023-10-27",
+      "releaseYear": 2023,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 284,
+      "collectionName": "アイコトバ - Single",
+      "itunesTrackId": 1712079509,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:49:41+09:00"
+  },
+  {
+    "title": "百花繚乱",
+    "artist": "幾田りら",
+    "metadata": {
+      "releaseDate": "2025-01-10",
+      "releaseYear": 2025,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 179,
+      "collectionName": "百花繚乱 - Single",
+      "itunesTrackId": 1786972177,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:49:43+09:00"
+  },
+  {
+    "title": "アンビバレント",
+    "artist": "Uru",
+    "metadata": {
+      "releaseDate": "2024-01-20",
+      "releaseYear": 2024,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 242,
+      "collectionName": "アンビバレント - Single",
+      "itunesTrackId": 1723078323,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:49:44+09:00"
+  },
+  {
+    "title": "ひとりごと",
+    "artist": "Omoinotake",
+    "metadata": {
+      "releaseDate": "2025-04-05",
+      "releaseYear": 2025,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 277,
+      "collectionName": "ひとりごと - Single",
+      "itunesTrackId": 1804611254,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:49:46+09:00"
+  },
+  {
+    "title": "愛は薬",
+    "artist": "wacci",
+    "metadata": {
+      "releaseDate": "2024-01-07",
+      "releaseYear": 2024,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 265,
+      "collectionName": "愛は薬 - Single",
+      "itunesTrackId": 1721860959,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:49:59+09:00"
+  },
+  {
+    "title": "ビギニング",
+    "artist": "井上大輔",
+    "metadata": {
+      "releaseDate": "1982-01-01",
+      "releaseYear": 1982,
+      "decade": "1980年代",
+      "genre": "アニメ",
+      "durationSeconds": 204,
+      "collectionName": "めぐりあい - Single",
+      "itunesTrackId": 1244018759,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:50:01+09:00"
+  },
+  {
+    "title": "葛飾ラプソディー",
+    "artist": "堂島孝平",
+    "metadata": {
+      "releaseDate": "1997-01-01",
+      "releaseYear": 1997,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 169,
+      "collectionName": "葛飾ラプソディー - Single",
+      "itunesTrackId": 1525310841,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:50:02+09:00"
+  },
+  {
+    "title": "ココロソマリ",
+    "artist": "水瀬いのり",
+    "metadata": {
+      "releaseDate": "2020-01-29",
+      "releaseYear": 2020,
+      "decade": "2020年代",
+      "genre": "アニメ",
+      "durationSeconds": 289,
+      "collectionName": "ココロソマリ - Single",
+      "itunesTrackId": 1494875710,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:50:03+09:00"
+  },
+  {
+    "title": "オトナブルー",
+    "artist": "新しい学校のリーダーズ",
+    "metadata": {
+      "releaseDate": "2020-02-28",
+      "releaseYear": 2020,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 186,
+      "collectionName": "オトナブルー - Single",
+      "itunesTrackId": 1498880491,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:50:05+09:00"
+  },
+  {
+    "title": "私は最強",
+    "artist": "Ado",
+    "metadata": {
+      "releaseDate": "2022-06-22",
+      "releaseYear": 2022,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 257,
+      "collectionName": "ウタの歌 ONE PIECE FILM RED",
+      "itunesTrackId": 1636446959,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:50:06+09:00"
+  },
+  {
+    "title": "きかんしゃトーマスのテーマ",
+    "artist": "マイク・オドネル、ジュニア・キャンベル",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:50:08+09:00"
+  },
+  {
+    "title": "A列車で行こう",
+    "artist": "ビリー・ストレイホーン",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:50:09+09:00"
+  },
+  {
+    "title": "銀の龍の背に乗って",
+    "artist": "中島みゆき",
+    "metadata": {
+      "releaseDate": "2003-07-23",
+      "releaseYear": 2003,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 376,
+      "collectionName": "恋文",
+      "itunesTrackId": 118543010,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:50:10+09:00"
+  },
+  {
+    "title": "デンジャー・ゾーン",
+    "artist": "ケニー・ロギンス",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:50:12+09:00"
+  },
+  {
+    "title": "ワタリドリ",
+    "artist": "Alexandros",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:50:13+09:00"
+  },
+  {
+    "title": "手紙",
+    "artist": "諫山実生",
+    "metadata": {
+      "releaseDate": "2003-03-12",
+      "releaseYear": 2003,
+      "decade": "2000年代",
+      "genre": "ポップ",
+      "durationSeconds": 240,
+      "collectionName": "撫子の華",
+      "itunesTrackId": 720355322,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:50:15+09:00"
+  },
+  {
+    "title": "手紙",
+    "artist": "坂本真綾",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:50:16+09:00"
+  },
+  {
+    "title": "手紙",
+    "artist": "Mr.Children",
+    "metadata": {
+      "releaseDate": "1996-06-24",
+      "releaseYear": 1996,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 170,
+      "collectionName": "深海",
+      "itunesTrackId": 1375009926,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:50:18+09:00"
+  },
+  {
+    "title": "星屑ビーナス",
+    "artist": "Aimer",
+    "metadata": {
+      "releaseDate": "2012-08-15",
+      "releaseYear": 2012,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 253,
+      "collectionName": "あなたに出会わなければ〜夏雪冬花〜 / 星屑ビーナス - Single",
+      "itunesTrackId": 1536124176,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:50:19+09:00"
+  },
+  {
+    "title": "Carrying Happiness",
+    "artist": "Mrs. GREEN APPLE",
+    "metadata": {
+      "releaseDate": "2025-07-19",
+      "releaseYear": 2025,
+      "decade": "2020年代",
+      "genre": "ロック",
+      "durationSeconds": 222,
+      "collectionName": "Carrying Happiness - Single",
+      "itunesTrackId": 1826924334,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:50:20+09:00"
+  },
+  {
+    "title": "ラブソング",
+    "artist": "上野大樹",
+    "metadata": {
+      "releaseDate": "2021-02-14",
+      "releaseYear": 2021,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 273,
+      "collectionName": "ラブソング - Single",
+      "itunesTrackId": 1550243871,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:50:22+09:00"
+  },
+  {
+    "title": "革命道中",
+    "artist": "アイナ・ジ・エンド",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:50:23+09:00"
+  },
+  {
+    "title": "紡ぐ",
+    "artist": "とた",
+    "metadata": {
+      "releaseDate": "2023-02-01",
+      "releaseYear": 2023,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 231,
+      "collectionName": "紡ぐ - Single",
+      "itunesTrackId": 1665555903,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:50:25+09:00"
+  },
+  {
+    "title": "ランデヴー",
+    "artist": "シャイトープ",
+    "metadata": {
+      "releaseDate": "2023-04-25",
+      "releaseYear": 2023,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 238,
+      "collectionName": "誘拐 / ランデヴー - Single",
+      "itunesTrackId": 1684131728,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:50:26+09:00"
+  },
+  {
+    "title": "香水",
+    "artist": "瑛人",
+    "metadata": {
+      "releaseDate": "2019-04-21",
+      "releaseYear": 2019,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 253,
+      "collectionName": "香水 - Single",
+      "itunesTrackId": 1524596325,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:50:28+09:00"
+  },
+  {
+    "title": "Make you happy",
+    "artist": "NiziU",
+    "metadata": {
+      "releaseDate": "2020-06-30",
+      "releaseYear": 2020,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 185,
+      "collectionName": "Make you happy - EP",
+      "itunesTrackId": 1538127026,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:50:29+09:00"
+  },
+  {
+    "title": "恋するフォーチュンクッキー",
+    "artist": "AKB48",
+    "metadata": {
+      "releaseDate": "2013-08-21",
+      "releaseYear": 2013,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 287,
+      "collectionName": "恋するフォーチュンクッキー (Type A) - EP",
+      "itunesTrackId": 681020904,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:50:30+09:00"
+  },
+  {
+    "title": "夏の影",
+    "artist": "Mrs. GREEN APPLE",
+    "metadata": {
+      "releaseDate": "2025-08-11",
+      "releaseYear": 2025,
+      "decade": "2020年代",
+      "genre": "ロック",
+      "durationSeconds": 247,
+      "collectionName": "夏の影 - Single",
+      "itunesTrackId": 1831207784,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:50:32+09:00"
+  },
+  {
+    "title": "YAH YAH YAH",
+    "artist": "CHAGE&ASKA",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:50:34+09:00"
+  },
+  {
+    "title": "トウキョウ・シャンディ・ランデヴ",
+    "artist": "MAISONdes",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:50:35+09:00"
+  },
+  {
+    "title": "トリセツ",
+    "artist": "西野カナ",
+    "metadata": {
+      "releaseDate": "2015-09-09",
+      "releaseYear": 2015,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 262,
+      "collectionName": "トリセツ - Single",
+      "itunesTrackId": 1537253742,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:50:36+09:00"
+  },
+  {
+    "title": "会いたくて 会いたくて",
+    "artist": "西野カナ",
+    "metadata": {
+      "releaseDate": "2010-05-19",
+      "releaseYear": 2010,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 284,
+      "collectionName": "会いたくて 会いたくて - Single",
+      "itunesTrackId": 1537240509,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:50:38+09:00"
+  },
+  {
+    "title": "Lovers",
+    "artist": "sumika",
+    "metadata": {
+      "releaseDate": "2016-05-25",
+      "releaseYear": 2016,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 251,
+      "collectionName": "Familia",
+      "itunesTrackId": 1447923303,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:50:39+09:00"
+  },
+  {
+    "title": "愛燦燦",
+    "artist": "美空ひばり",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:50:41+09:00"
+  },
+  {
+    "title": "ハッピーラッキーチャッピー",
+    "artist": "ano",
+    "metadata": {
+      "releaseDate": "2025-06-04",
+      "releaseYear": 2025,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 185,
+      "collectionName": "BONE BORN BOMB",
+      "itunesTrackId": 1889741674,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:50:42+09:00"
+  },
+  {
+    "title": "キミとルララ",
+    "artist": "キミとアイドルプリキュア♪",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:50:44+09:00"
+  },
+  {
+    "title": "恋風",
+    "artist": "幾田りら",
+    "metadata": {
+      "releaseDate": "2025-04-07",
+      "releaseYear": 2025,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 182,
+      "collectionName": "恋風 - Single",
+      "itunesTrackId": 1805325622,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:50:45+09:00"
+  },
+  {
+    "title": "残酷な夜に輝け",
+    "artist": "LiSA",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:50:46+09:00"
+  },
+  {
+    "title": "オリビアを聴きながら",
+    "artist": "杏里",
+    "metadata": {
+      "releaseDate": "1978-01-01",
+      "releaseYear": 1978,
+      "decade": "1970年代",
+      "genre": "J-Pop",
+      "durationSeconds": 279,
+      "collectionName": "杏里-apricot jam-",
+      "itunesTrackId": 838835291,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:50:48+09:00"
+  },
+  {
+    "title": "シンデレラボーイ",
+    "artist": "Saucy Dog",
+    "metadata": {
+      "releaseDate": "2021-08-18",
+      "releaseYear": 2021,
+      "decade": "2020年代",
+      "genre": "ロック",
+      "durationSeconds": 234,
+      "collectionName": "レイジーサンデー",
+      "itunesTrackId": 1839433876,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:50:49+09:00"
+  },
+  {
+    "title": "三日月",
+    "artist": "絢香",
+    "metadata": {
+      "releaseDate": "2006-09-27",
+      "releaseYear": 2006,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 278,
+      "collectionName": "三日月 - Single",
+      "itunesTrackId": 193412328,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:50:51+09:00"
+  },
+  {
+    "title": "ちいさい秋みつけた",
+    "artist": "中田喜直",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:50:52+09:00"
+  },
+  {
+    "title": "まっかな秋",
+    "artist": "小林秀雄",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:50:54+09:00"
+  },
+  {
+    "title": "もみじ",
+    "artist": "岡野貞一",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:50:56+09:00"
+  },
+  {
+    "title": "ツキミソウ",
+    "artist": "Novelbright",
+    "metadata": {
+      "releaseDate": "2020-12-11",
+      "releaseYear": 2020,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 308,
+      "collectionName": "ツキミソウ - Single",
+      "itunesTrackId": 1542887040,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:50:57+09:00"
+  },
+  {
+    "title": "コイスルオトメ",
+    "artist": "いきものがかり",
+    "metadata": {
+      "releaseDate": "2006-10-18",
+      "releaseYear": 2006,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 318,
+      "collectionName": "コイスルオトメ - EP",
+      "itunesTrackId": 1536231249,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:50:58+09:00"
+  },
+  {
+    "title": "エイリアンズ",
+    "artist": "キリンジ",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:51:00+09:00"
+  },
+  {
+    "title": "スターライトパレード",
+    "artist": "SEKAI NO OWARI",
+    "metadata": {
+      "releaseDate": "2011-11-23",
+      "releaseYear": 2011,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 344,
+      "collectionName": "スターライトパレード - Single",
+      "itunesTrackId": 984448550,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:51:01+09:00"
+  },
+  {
+    "title": "ウルトラマンの歌",
+    "artist": "みすず児童合唱団、コーロ・ステルラ",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:51:03+09:00"
+  },
+  {
+    "title": "愛を伝えたいだとか",
+    "artist": "あいみょん",
+    "metadata": {
+      "releaseDate": "2017-04-14",
+      "releaseYear": 2017,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 235,
+      "collectionName": "愛を伝えたいだとか - EP",
+      "itunesTrackId": 1218860394,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:51:04+09:00"
+  },
+  {
+    "title": "星間飛行",
+    "artist": "ランカ・リー＝中島愛",
+    "metadata": {
+      "releaseDate": "2008-06-25",
+      "releaseYear": 2008,
+      "decade": "2000年代",
+      "genre": "アニメ",
+      "durationSeconds": 232,
+      "collectionName": "MBS・TBS系TVアニメーション マクロスF(フロンティア) オリジナルサウンドトラック2 娘トラ☆",
+      "itunesTrackId": 469329897,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:51:06+09:00"
+  },
+  {
+    "title": "KING",
+    "artist": "Kanaria",
+    "metadata": {
+      "releaseDate": "2020-08-02",
+      "releaseYear": 2020,
+      "decade": "2020年代",
+      "genre": "アニメ",
+      "durationSeconds": 135,
+      "collectionName": "KING - Single",
+      "itunesTrackId": 1525673476,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:51:07+09:00"
+  },
+  {
+    "title": "明日晴れるかな",
+    "artist": "桑田佳祐",
+    "metadata": {
+      "releaseDate": "2007-05-16",
+      "releaseYear": 2007,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 315,
+      "collectionName": "明日晴れるかな - Single",
+      "itunesTrackId": 1082738072,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:51:08+09:00"
+  },
+  {
+    "title": "イエスタデイ",
+    "artist": "Official髭男dism",
+    "metadata": {
+      "releaseDate": "2019-09-11",
+      "releaseYear": 2019,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 299,
+      "collectionName": "Traveler",
+      "itunesTrackId": 1479397583,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:51:10+09:00"
+  },
+  {
+    "title": "インフェルノ",
+    "artist": "Mrs. GREEN APPLE",
+    "metadata": {
+      "releaseDate": "2019-07-18",
+      "releaseYear": 2019,
+      "decade": "2010年代",
+      "genre": "ロック",
+      "durationSeconds": 213,
+      "collectionName": "インフェルノ - Single",
+      "itunesTrackId": 1471459432,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:51:11+09:00"
+  },
+  {
+    "title": "心拍数♯0822",
+    "artist": "蝶々P",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:51:13+09:00"
+  },
+  {
+    "title": "ぎゅっと。",
+    "artist": "もさを。",
+    "metadata": {
+      "releaseDate": "2020-07-27",
+      "releaseYear": 2020,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 270,
+      "collectionName": "ぎゅっと。 - Single",
+      "itunesTrackId": 1523598194,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:51:14+09:00"
+  },
+  {
+    "title": "UNICORN",
+    "artist": "澤野弘之",
+    "metadata": {
+      "releaseDate": "2010-09-09",
+      "releaseYear": 2010,
+      "decade": "2010年代",
+      "genre": "TV サウンドトラック",
+      "durationSeconds": 287,
+      "collectionName": "機動戦士ガンダムUC オリジナルサウンドトラック 1",
+      "itunesTrackId": 1524640234,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:51:15+09:00"
+  },
+  {
+    "title": "Blue Dragon",
+    "artist": "澤野弘之",
+    "metadata": {
+      "releaseDate": "2006-06-07",
+      "releaseYear": 2006,
+      "decade": "2000年代",
+      "genre": "サウンドトラック",
+      "durationSeconds": 295,
+      "collectionName": "「医龍 Team Medical Dragon」オリジナルサウンドトラック",
+      "itunesTrackId": 1443237459,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:51:17+09:00"
+  },
+  {
+    "title": "ninelie",
+    "artist": "imer with chelly(EGOIST)",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:51:18+09:00"
+  },
+  {
+    "title": "E0$-3:罪",
+    "artist": "澤野弘之",
+    "metadata": {
+      "releaseDate": "2015-04-08",
+      "releaseYear": 2015,
+      "decade": "2010年代",
+      "genre": "アニメ",
+      "durationSeconds": 129,
+      "collectionName": "七つの大罪 オリジナル・サウンドトラック 2",
+      "itunesTrackId": 1537791539,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:51:20+09:00"
+  },
+  {
+    "title": "10月無口な君を忘れる",
+    "artist": "あたらよ",
+    "metadata": {
+      "releaseDate": "2021-03-24",
+      "releaseYear": 2021,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 332,
+      "collectionName": "10月無口な君を忘れる - Single",
+      "itunesTrackId": 1558400919,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:51:21+09:00"
+  },
+  {
+    "title": "Crazy Party Night ～ぱんぷきんの逆襲～",
+    "artist": "きゃりーぱみゅぱみゅ",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:51:22+09:00"
+  },
+  {
+    "title": "ハロウィン・ナイト",
+    "artist": "AKB48",
+    "metadata": {
+      "releaseDate": "2015-08-26",
+      "releaseYear": 2015,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 307,
+      "collectionName": "ハロウィン・ナイト (Type A) - EP",
+      "itunesTrackId": 1029291701,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:51:24+09:00"
+  },
+  {
+    "title": "私のお気に入り(My Favorite Things)",
+    "artist": "リチャード・ロジャース",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:51:25+09:00"
+  },
+  {
+    "title": "IRIS OUT",
+    "artist": "米津玄師",
+    "metadata": {
+      "releaseDate": "2025-09-15",
+      "releaseYear": 2025,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 152,
+      "collectionName": "IRIS OUT - Single",
+      "itunesTrackId": 1837658529,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:51:27+09:00"
+  },
+  {
+    "title": "ラスト・クリスマス",
+    "artist": "Wham!",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:51:28+09:00"
+  },
+  {
+    "title": "ヴァンパイア",
+    "artist": "DECO*27",
+    "metadata": {
+      "releaseDate": "2021-03-09",
+      "releaseYear": 2021,
+      "decade": "2020年代",
+      "genre": "アニメ",
+      "durationSeconds": 178,
+      "collectionName": "ヴァンパイア - Single",
+      "itunesTrackId": 1555448592,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:51:30+09:00"
+  },
+  {
+    "title": "恋人がサンタクロース",
+    "artist": "松任谷由実",
+    "metadata": {
+      "releaseDate": "1980-12-01",
+      "releaseYear": 1980,
+      "decade": "1980年代",
+      "genre": "J-Pop",
+      "durationSeconds": 306,
+      "collectionName": "SURF & SNOW",
+      "itunesTrackId": 1436009955,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:51:31+09:00"
+  },
+  {
+    "title": "Wherever you are",
+    "artist": "ONE OK ROCK",
+    "metadata": {
+      "releaseDate": "2010-06-09",
+      "releaseYear": 2010,
+      "decade": "2010年代",
+      "genre": "ロック",
+      "durationSeconds": 296,
+      "collectionName": "Nicheシンドローム",
+      "itunesTrackId": 1838917139,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:51:32+09:00"
+  },
+  {
+    "title": "スターマーカー",
+    "artist": "KANA-BOON",
+    "metadata": {
+      "releaseDate": "2020-02-01",
+      "releaseYear": 2020,
+      "decade": "2020年代",
+      "genre": "ロック",
+      "durationSeconds": 215,
+      "collectionName": "スターマーカー - Single",
+      "itunesTrackId": 1536466358,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:51:34+09:00"
+  },
+  {
+    "title": "僕はここにいる",
+    "artist": "山崎まさよし",
+    "metadata": {
+      "releaseDate": "1998-11-11",
+      "releaseYear": 1998,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 258,
+      "collectionName": "The Road To Yamazaki - The Best For Beginners (Standards)",
+      "itunesTrackId": 1442902260,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:51:35+09:00"
+  },
+  {
+    "title": "オールドファッション",
+    "artist": "back number",
+    "metadata": {
+      "releaseDate": "2018-11-09",
+      "releaseYear": 2018,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 253,
+      "collectionName": "オールドファッション - EP",
+      "itunesTrackId": 1441482867,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:51:37+09:00"
+  },
+  {
+    "title": "津軽海峡・冬景色",
+    "artist": "石川さゆり",
+    "metadata": {
+      "releaseDate": "1977-01-01",
+      "releaseYear": 1977,
+      "decade": "1970年代",
+      "genre": "演歌",
+      "durationSeconds": 225,
+      "collectionName": "石川さゆり45周年盤, Vol. I",
+      "itunesTrackId": 1838960470,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:51:38+09:00"
+  },
+  {
+    "title": "break",
+    "artist": "宮本笑里",
+    "metadata": {
+      "releaseDate": "2008-01-01",
+      "releaseYear": 2008,
+      "decade": "2000年代",
+      "genre": "クラシック",
+      "durationSeconds": 254,
+      "collectionName": "dream",
+      "itunesTrackId": 1537293109,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:51:40+09:00"
+  },
+  {
+    "title": "君がいるだけで",
+    "artist": "米米CLUB",
+    "metadata": {
+      "releaseDate": "1992-05-02",
+      "releaseYear": 1992,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 279,
+      "collectionName": "HARVEST -SINGLES 1992-1997-",
+      "itunesTrackId": 1537347334,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:51:41+09:00"
+  },
+  {
+    "title": "Overdose",
+    "artist": "なとり",
+    "metadata": {
+      "releaseDate": "2022-09-07",
+      "releaseYear": 2022,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 197,
+      "collectionName": "Overdose - Single",
+      "itunesTrackId": 1640410315,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:51:43+09:00"
+  },
+  {
+    "title": "こんなに近くで...",
+    "artist": "Crystal Kay",
+    "metadata": {
+      "releaseDate": "2007-02-28",
+      "releaseYear": 2007,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 241,
+      "collectionName": "ALL YOURS",
+      "itunesTrackId": 1536254630,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:51:44+09:00"
+  },
+  {
+    "title": "月灯りふんわり落ちてくる夜",
+    "artist": "小川七生",
+    "metadata": {
+      "releaseDate": "1997-12-17",
+      "releaseYear": 1997,
+      "decade": "1990年代",
+      "genre": "アニメ",
+      "durationSeconds": 249,
+      "collectionName": "月灯りふんわり落ちてくる夜 - Single",
+      "itunesTrackId": 1657418958,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:51:45+09:00"
+  },
+  {
+    "title": "ヒカリへ",
+    "artist": "miwa",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:51:47+09:00"
+  },
+  {
+    "title": "さよならエレジー",
+    "artist": "菅田将暉",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:51:48+09:00"
+  },
+  {
+    "title": "サウダージ",
+    "artist": "ポルノグラフィティ",
+    "metadata": {
+      "releaseDate": "2000-01-01",
+      "releaseYear": 2000,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 261,
+      "collectionName": "PORNO GRAFFITTI BEST RED'S",
+      "itunesTrackId": 1537232408,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:51:50+09:00"
+  },
+  {
+    "title": "恋人ごっこ",
+    "artist": "マカロニえんぴつ",
+    "metadata": {
+      "releaseDate": "2020-02-07",
+      "releaseYear": 2020,
+      "decade": "2020年代",
+      "genre": "ロック",
+      "durationSeconds": 197,
+      "collectionName": "恋人ごっこ - Single",
+      "itunesTrackId": 1496731154,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:51:51+09:00"
+  },
+  {
+    "title": "イケナイ太陽",
+    "artist": "ORANGE RANGE",
+    "metadata": {
+      "releaseDate": "2007-07-18",
+      "releaseYear": 2007,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 242,
+      "collectionName": "イケナイ太陽 - Single",
+      "itunesTrackId": 1537392624,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:51:53+09:00"
+  },
+  {
+    "title": "世界が終るまでは…",
+    "artist": "WANDS",
+    "metadata": {
+      "releaseDate": "1996-03-16",
+      "releaseYear": 1996,
+      "decade": "1990年代",
+      "genre": "ロック",
+      "durationSeconds": 316,
+      "collectionName": "Best of WANDS: History",
+      "itunesTrackId": 75465805,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:51:59+09:00"
+  },
+  {
+    "title": "大阪LOVER",
+    "artist": "DREAMS COME TRUE",
+    "metadata": {
+      "releaseDate": "2007-03-07",
+      "releaseYear": 2007,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 267,
+      "collectionName": "大阪LOVER - Single",
+      "itunesTrackId": 1444614244,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:52:01+09:00"
+  },
+  {
+    "title": "島人ぬ宝",
+    "artist": "BEGIN",
+    "metadata": {
+      "releaseDate": "2002-05-22",
+      "releaseYear": 2002,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 320,
+      "collectionName": "島人ぬ宝 - EP",
+      "itunesTrackId": 1838699008,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:52:02+09:00"
+  },
+  {
+    "title": "最後の雨",
+    "artist": "中西保志",
+    "metadata": {
+      "releaseDate": "1992-09-21",
+      "releaseYear": 1992,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 283,
+      "collectionName": "YASUSHI NAKANISHI SINGLE COLLECTION",
+      "itunesTrackId": 470116064,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:52:04+09:00"
+  },
+  {
+    "title": "シングルベッド",
+    "artist": "シャ乱Q",
+    "metadata": {
+      "releaseDate": "1994-07-01",
+      "releaseYear": 1994,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 324,
+      "collectionName": "シャ乱Qベスト 〜四半世紀伝説〜",
+      "itunesTrackId": 1536777679,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:52:05+09:00"
+  },
+  {
+    "title": "チャンカパーナ",
+    "artist": "NEWS",
+    "metadata": {
+      "releaseDate": "2012-07-18",
+      "releaseYear": 2012,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 260,
+      "collectionName": "チャンカパーナ - EP",
+      "itunesTrackId": 1765461309,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:52:06+09:00"
+  },
+  {
+    "title": "気まぐれロマンティック",
+    "artist": "いきものがかり",
+    "metadata": {
+      "releaseDate": "2008-12-03",
+      "releaseYear": 2008,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 245,
+      "collectionName": "気まぐれロマンティック - Single",
+      "itunesTrackId": 1536256436,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:52:08+09:00"
+  },
+  {
+    "title": "Blue Jeans",
+    "artist": "HANA",
+    "metadata": {
+      "releaseDate": "2025-07-14",
+      "releaseYear": 2025,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 207,
+      "collectionName": "Blue Jeans - Single",
+      "itunesTrackId": 1821849522,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:52:09+09:00"
+  },
+  {
+    "title": "Bling-Bang-Bang-Born",
+    "artist": "Creepy Nuts",
+    "metadata": {
+      "releaseDate": "2024-01-07",
+      "releaseYear": 2024,
+      "decade": "2020年代",
+      "genre": "ヒップホップ／ラップ",
+      "durationSeconds": 168,
+      "collectionName": "Bling-Bang-Bang-Born - Single",
+      "itunesTrackId": 1720332181,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:52:11+09:00"
+  },
+  {
+    "title": "ハレンチ",
+    "artist": "ちゃんみな",
+    "metadata": {
+      "releaseDate": "2021-09-24",
+      "releaseYear": 2021,
+      "decade": "2020年代",
+      "genre": "ヒップホップ／ラップ",
+      "durationSeconds": 199,
+      "collectionName": "ハレンチ",
+      "itunesTrackId": 1585848051,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:52:12+09:00"
+  },
+  {
+    "title": "愛のかたまり",
+    "artist": "Kinki Kids",
+    "metadata": {
+      "releaseDate": "2001-11-14",
+      "releaseYear": 2001,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 288,
+      "collectionName": "39",
+      "itunesTrackId": 1810382629,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:52:13+09:00"
+  },
+  {
+    "title": "旅路",
+    "artist": "藤井風",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:52:15+09:00"
+  },
+  {
+    "title": "月光花",
+    "artist": "Janne Da Arc",
+    "metadata": {
+      "releaseDate": "2003-09-22",
+      "releaseYear": 2003,
+      "decade": "2000年代",
+      "genre": "ロック",
+      "durationSeconds": 297,
+      "collectionName": "JOKER",
+      "itunesTrackId": 843626327,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:52:16+09:00"
+  },
+  {
+    "title": "そっけない",
+    "artist": "RADWIMPS",
+    "metadata": {
+      "releaseDate": "2018-12-12",
+      "releaseYear": 2018,
+      "decade": "2010年代",
+      "genre": "ロック",
+      "durationSeconds": 392,
+      "collectionName": "ANTI ANTI GENERATION",
+      "itunesTrackId": 1518516333,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:52:18+09:00"
+  },
+  {
+    "title": "ぞうさん",
+    "artist": "團伊玖磨作曲",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:52:19+09:00"
+  },
+  {
+    "title": "アイアイ",
+    "artist": "宇野誠一郎作曲",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:52:21+09:00"
+  },
+  {
+    "title": "揺れる想い",
+    "artist": "ZARD",
+    "metadata": {
+      "releaseDate": "1993-05-19",
+      "releaseYear": 1993,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 265,
+      "collectionName": "ZARD BLEND～SUN&STONE～",
+      "itunesTrackId": 75712664,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:52:22+09:00"
+  },
+  {
+    "title": "女々しくて",
+    "artist": "ゴールデンボンバー",
+    "metadata": {
+      "releaseDate": "2009-10-21",
+      "releaseYear": 2009,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 248,
+      "collectionName": "ザ・ゴールデンベスト~Pressure~",
+      "itunesTrackId": 376156350,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:52:24+09:00"
+  },
+  {
+    "title": "ポリリズム",
+    "artist": "Perfume",
+    "metadata": {
+      "releaseDate": "2007-09-12",
+      "releaseYear": 2007,
+      "decade": "2000年代",
+      "genre": "エレクトロニック",
+      "durationSeconds": 250,
+      "collectionName": "GAME",
+      "itunesTrackId": 657666313,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:52:25+09:00"
+  },
+  {
+    "title": "ホワイトキス",
+    "artist": "鈴木鈴木",
+    "metadata": {
+      "releaseDate": "2021-11-18",
+      "releaseYear": 2021,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 275,
+      "collectionName": "ホワイトキス - Single",
+      "itunesTrackId": 1593497539,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:52:27+09:00"
+  },
+  {
+    "title": "め組のひと",
+    "artist": "ラッツ&スター",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:52:28+09:00"
+  },
+  {
+    "title": "ノスタルジア",
+    "artist": "いきものがかり",
+    "metadata": {
+      "releaseDate": "2010-03-10",
+      "releaseYear": 2010,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 340,
+      "collectionName": "ノスタルジア - EP",
+      "itunesTrackId": 1536260454,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:52:29+09:00"
+  },
+  {
+    "title": "笑顔",
+    "artist": "いきものがかり",
+    "metadata": {
+      "releaseDate": "2013-07-10",
+      "releaseYear": 2013,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 301,
+      "collectionName": "笑顔 - EP",
+      "itunesTrackId": 1536269605,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:52:31+09:00"
+  },
+  {
+    "title": "メリーゴーランド",
+    "artist": "優里",
+    "metadata": {
+      "releaseDate": "2022-12-22",
+      "releaseYear": 2022,
+      "decade": "2020年代",
+      "genre": "ロック",
+      "durationSeconds": 256,
+      "collectionName": "メリーゴーランド - Single",
+      "itunesTrackId": 1657348387,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:52:32+09:00"
+  },
+  {
+    "title": "ぶんぶんぶん",
+    "artist": "作曲者不詳（ボヘミア民謡)",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:52:33+09:00"
+  },
+  {
+    "title": "さよならの夏",
+    "artist": "手嶌葵",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:52:35+09:00"
+  },
+  {
+    "title": "幸せならてをたたこう",
+    "artist": "坂本九",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:52:36+09:00"
+  },
+  {
+    "title": "マジンガーZ",
+    "artist": "水木一郎",
+    "metadata": {
+      "releaseDate": "1999-04-21",
+      "releaseYear": 1999,
+      "decade": "1990年代",
+      "genre": "アニメ",
+      "durationSeconds": 118,
+      "collectionName": "スーパーロボット魂 ボーカルベストセレクション",
+      "itunesTrackId": 458237797,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:52:38+09:00"
+  },
+  {
+    "title": "鉄腕アトム",
+    "artist": "上高田少年合唱団",
+    "metadata": {
+      "releaseDate": "2015-07-29",
+      "releaseYear": 2015,
+      "decade": "2010年代",
+      "genre": "歌謡曲",
+      "durationSeconds": 150,
+      "collectionName": "<戦後70年 歌のあゆみ> こどものうた ~とんがり帽子・みかんの花さく丘~",
+      "itunesTrackId": 1018806356,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:52:39+09:00"
+  },
+  {
+    "title": "魔訶不思議アドベンチャー!",
+    "artist": "高橋洋樹",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:52:41+09:00"
+  },
+  {
+    "title": "Flower Dance",
+    "artist": "DJ OKAWARI",
+    "metadata": {
+      "releaseDate": "2010-09-29",
+      "releaseYear": 2010,
+      "decade": "2010年代",
+      "genre": "ヒップホップ／ラップ",
+      "durationSeconds": 264,
+      "collectionName": "A Cup Of Coffee - Single",
+      "itunesTrackId": 392228034,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:52:42+09:00"
+  },
+  {
+    "title": "愛は勝つ",
+    "artist": "KAN",
+    "metadata": {
+      "releaseDate": "1990-09-01",
+      "releaseYear": 1990,
+      "decade": "1990年代",
+      "genre": "ポップ",
+      "durationSeconds": 248,
+      "collectionName": "野球選手が夢だった",
+      "itunesTrackId": 1443308178,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:52:43+09:00"
+  },
+  {
+    "title": "もらい泣き",
+    "artist": "一青窈",
+    "metadata": {
+      "releaseDate": "2002-10-30",
+      "releaseYear": 2002,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 281,
+      "collectionName": "もらい泣き - Single",
+      "itunesTrackId": 157112134,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:52:45+09:00"
+  },
+  {
+    "title": "月",
+    "artist": "文部省唱歌(作詞、作曲不詳)",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:52:46+09:00"
+  },
+  {
+    "title": "ロマンティックあげるよ",
+    "artist": "橋本潮",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:52:48+09:00"
+  },
+  {
+    "title": "GO-GO たまごっち",
+    "artist": "ならゆりあ",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:52:59+09:00"
+  },
+  {
+    "title": "PIANO*GIRL",
+    "artist": "OSTER project",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:53:01+09:00"
+  },
+  {
+    "title": "JANE DOE",
+    "artist": "米津玄師、宇多田ヒカル",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:53:02+09:00"
+  },
+  {
+    "title": "ビンクスの酒",
+    "artist": "麦わら海賊団",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:53:03+09:00"
+  },
+  {
+    "title": "ウイスキーが、お好きでしょ",
+    "artist": "SAYURI",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:53:05+09:00"
+  },
+  {
+    "title": "ファジーネーブル",
+    "artist": "Conton Candy",
+    "metadata": {
+      "releaseDate": "2023-04-26",
+      "releaseYear": 2023,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 237,
+      "collectionName": "ファジーネーブル - Single",
+      "itunesTrackId": 1681024620,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:53:06+09:00"
+  },
+  {
+    "title": "都忘れ",
+    "artist": "GLAY",
+    "metadata": {
+      "releaseDate": "1996-11-18",
+      "releaseYear": 1996,
+      "decade": "1990年代",
+      "genre": "ロック",
+      "durationSeconds": 304,
+      "collectionName": "BELOVED",
+      "itunesTrackId": 989804527,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:53:08+09:00"
+  },
+  {
+    "title": "美しき残酷な世界",
+    "artist": "日笠陽子",
+    "metadata": {
+      "releaseDate": "2013-05-08",
+      "releaseYear": 2013,
+      "decade": "2010年代",
+      "genre": "アニメ",
+      "durationSeconds": 297,
+      "collectionName": "美しき残酷な世界【通常盤】- EP",
+      "itunesTrackId": 635819165,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:53:09+09:00"
+  },
+  {
+    "title": "コントラスト",
+    "artist": "TOMOO",
+    "metadata": {
+      "releaseDate": "2025-01-08",
+      "releaseYear": 2025,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 258,
+      "collectionName": "コントラスト - Single",
+      "itunesTrackId": 1785578366,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:53:11+09:00"
+  },
+  {
+    "title": "Komm, susser Tod",
+    "artist": "ARIANNE",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:53:12+09:00"
+  },
+  {
+    "title": "カラフル",
+    "artist": "ClariS",
+    "metadata": {
+      "releaseDate": "2013-10-27",
+      "releaseYear": 2013,
+      "decade": "2010年代",
+      "genre": "アニメ",
+      "durationSeconds": 273,
+      "collectionName": "カラフル - Single",
+      "itunesTrackId": 1537263406,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:53:13+09:00"
+  },
+  {
+    "title": "チューリップ",
+    "artist": "井上武士",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:53:15+09:00"
+  },
+  {
+    "title": "森のくまさん",
+    "artist": "リー・デビッド",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:53:16+09:00"
+  },
+  {
+    "title": "夜行",
+    "artist": "ヨルシカ",
+    "metadata": {
+      "releaseDate": "2020-03-04",
+      "releaseYear": 2020,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 204,
+      "collectionName": "夜行 - Single",
+      "itunesTrackId": 1498698119,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:53:18+09:00"
+  },
+  {
+    "title": "左右盲",
+    "artist": "ヨルシカ",
+    "metadata": {
+      "releaseDate": "2022-07-25",
+      "releaseYear": 2022,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 267,
+      "collectionName": "Morning Breeze - 朝に聴きたいJ-POP -",
+      "itunesTrackId": 1644782351,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:53:19+09:00"
+  },
+  {
+    "title": "光",
+    "artist": "宇多田ヒカル",
+    "metadata": {
+      "releaseDate": "2002-03-20",
+      "releaseYear": 2002,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 301,
+      "collectionName": "光 - EP",
+      "itunesTrackId": 1444860451,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:53:21+09:00"
+  },
+  {
+    "title": "One Last Kiss",
+    "artist": "宇多田ヒカル",
+    "metadata": {
+      "releaseDate": "2021-03-09",
+      "releaseYear": 2021,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 252,
+      "collectionName": "One Last Kiss",
+      "itunesTrackId": 1542953977,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:53:22+09:00"
+  },
+  {
+    "title": "STILL LOVE HER (失われた風景)",
+    "artist": "TM NETWORK",
+    "metadata": {
+      "releaseDate": "1987-01-01",
+      "releaseYear": 1987,
+      "decade": "1980年代",
+      "genre": "ロック",
+      "durationSeconds": 349,
+      "collectionName": "TAKASHI UTSUNOMIYA THE BEST \"FILES\"",
+      "itunesTrackId": 1537051814,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:53:23+09:00"
+  },
+  {
+    "title": "おばけなんてないさ",
+    "artist": "峯陽",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:53:26+09:00"
+  },
+  {
+    "title": "Happy Birthday to You",
+    "artist": "Mildred J. Hill、Patty Smith Hill",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:53:27+09:00"
+  },
+  {
+    "title": "HAPPY HAPPY BIRTHDAY",
+    "artist": "DREAMS COME TRUE",
+    "metadata": {
+      "releaseDate": "1993-12-04",
+      "releaseYear": 1993,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 76,
+      "collectionName": "MAGIC",
+      "itunesTrackId": 1536199616,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:53:28+09:00"
+  },
+  {
+    "title": "ようかい体操第一",
+    "artist": "Dream5",
+    "metadata": {
+      "releaseDate": "2014-04-23",
+      "releaseYear": 2014,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 239,
+      "collectionName": "Break Out / ようかい体操第一 - Single",
+      "itunesTrackId": 857572447,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:53:30+09:00"
+  },
+  {
+    "title": "愛のうた",
+    "artist": "ストロベリー・フラワー",
+    "metadata": {
+      "releaseDate": "2006-11-29",
+      "releaseYear": 2006,
+      "decade": "2000年代",
+      "genre": "サウンドトラック",
+      "durationSeconds": 186,
+      "collectionName": "愛のうた ~ ピクミンCMソング - Single",
+      "itunesTrackId": 715708921,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:53:31+09:00"
+  },
+  {
+    "title": "愛とか恋とか",
+    "artist": "Novelbright",
+    "metadata": {
+      "releaseDate": "2022-04-15",
+      "releaseYear": 2022,
+      "decade": "2020年代",
+      "genre": "ロック",
+      "durationSeconds": 232,
+      "collectionName": "Assort",
+      "itunesTrackId": 1617575013,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:53:33+09:00"
+  },
+  {
+    "title": "Dynamite",
+    "artist": "BTS",
+    "metadata": {
+      "releaseDate": "2020-08-21",
+      "releaseYear": 2020,
+      "decade": "2020年代",
+      "genre": "K-Pop",
+      "durationSeconds": 199,
+      "collectionName": "Dynamite - EP",
+      "itunesTrackId": 1528831888,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:53:34+09:00"
+  },
+  {
+    "title": "愛唄",
+    "artist": "GReeeeN",
+    "metadata": {
+      "releaseDate": "2007-05-16",
+      "releaseYear": 2007,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 235,
+      "collectionName": "いままでのA面、B面ですと!?",
+      "itunesTrackId": 1440746860,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:53:36+09:00"
+  },
+  {
+    "title": "イイじゃん",
+    "artist": "M!LK",
+    "metadata": {
+      "releaseDate": "2025-02-17",
+      "releaseYear": 2025,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 198,
+      "collectionName": "イイじゃん - Single",
+      "itunesTrackId": 1794499543,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:53:38+09:00"
+  },
+  {
+    "title": "明日の私に幸あれ",
+    "artist": "ナナヲアカリ",
+    "metadata": {
+      "releaseDate": "2025-01-18",
+      "releaseYear": 2025,
+      "decade": "2020年代",
+      "genre": "ロック",
+      "durationSeconds": 215,
+      "collectionName": "明日の私に幸あれ - Single",
+      "itunesTrackId": 1787114805,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:53:40+09:00"
+  },
+  {
+    "title": "手紙",
+    "artist": "Uru",
+    "metadata": {
+      "releaseDate": "2025-08-13",
+      "releaseYear": 2025,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 245,
+      "collectionName": "手紙 - Single",
+      "itunesTrackId": 1828857729,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:53:41+09:00"
+  },
+  {
+    "title": "君の好きなとこ",
+    "artist": "平井堅",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:53:43+09:00"
+  },
+  {
+    "title": "灯を護る",
+    "artist": "スピッツ",
+    "metadata": {
+      "releaseDate": "2025-10-06",
+      "releaseYear": 2025,
+      "decade": "2020年代",
+      "genre": "ロック",
+      "durationSeconds": 214,
+      "collectionName": "灯を護る - Single",
+      "itunesTrackId": 1841799445,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:53:44+09:00"
+  },
+  {
+    "title": "flos",
+    "artist": "R Sound Design",
+    "metadata": {
+      "releaseDate": "2018-03-08",
+      "releaseYear": 2018,
+      "decade": "2010年代",
+      "genre": "アニメ",
+      "durationSeconds": 275,
+      "collectionName": "flos - Single",
+      "itunesTrackId": 1373125555,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:53:46+09:00"
+  },
+  {
+    "title": "歌うたいのバラッド",
+    "artist": "斉藤和義",
+    "metadata": {
+      "releaseDate": "1997-11-21",
+      "releaseYear": 1997,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 396,
+      "collectionName": "Because",
+      "itunesTrackId": 1281425806,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:53:47+09:00"
+  },
+  {
+    "title": "陽だまり",
+    "artist": "村下孝蔵",
+    "metadata": {
+      "releaseDate": "1980-01-01",
+      "releaseYear": 1980,
+      "decade": "1980年代",
+      "genre": "歌謡曲",
+      "durationSeconds": 242,
+      "collectionName": "七夕夜想曲〜村下孝蔵最高選曲集 其の壱",
+      "itunesTrackId": 1538456299,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:53:49+09:00"
+  },
+  {
+    "title": "This Is Halloween",
+    "artist": "ダニー・エルフマン",
+    "metadata": {
+      "releaseDate": "2023-02-08",
+      "releaseYear": 2023,
+      "decade": "2020年代",
+      "genre": "サウンドトラック",
+      "durationSeconds": 148,
+      "collectionName": "KINGDOM HEARTS - HD 2.5 ReMIX - (Original Soundtrack)",
+      "itunesTrackId": 1669115108,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:53:50+09:00"
+  },
+  {
+    "title": "プラットフォーム",
+    "artist": "Uru",
+    "metadata": {
+      "releaseDate": "2025-10-15",
+      "releaseYear": 2025,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 210,
+      "collectionName": "プラットフォーム - Single",
+      "itunesTrackId": 1843380734,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:53:52+09:00"
+  },
+  {
+    "title": "かえるの合唱",
+    "artist": "ドイツ民謡",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:53:53+09:00"
+  },
+  {
+    "title": "ノンフィクション",
+    "artist": "平井堅",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:53:55+09:00"
+  },
+  {
+    "title": "君は薔薇より美しい",
+    "artist": "布施明",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:53:56+09:00"
+  },
+  {
+    "title": "冬が終わる前に",
+    "artist": "清水翔太",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:54:00+09:00"
+  },
+  {
+    "title": "冬のうた",
+    "artist": "Kiroro",
+    "metadata": {
+      "releaseDate": "1998-11-21",
+      "releaseYear": 1998,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 348,
+      "collectionName": "Kiroroのうた ①",
+      "itunesTrackId": 106845813,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:54:01+09:00"
+  },
+  {
+    "title": "冬がはじまるよ",
+    "artist": "槇原敬之",
+    "metadata": {
+      "releaseDate": "1991-11-10",
+      "releaseYear": 1991,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 231,
+      "collectionName": "君は僕の宝物",
+      "itunesTrackId": 284522066,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:54:03+09:00"
+  },
+  {
+    "title": "冬と春",
+    "artist": "back number",
+    "metadata": {
+      "releaseDate": "2024-01-24",
+      "releaseYear": 2024,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 257,
+      "collectionName": "冬と春 - Single",
+      "itunesTrackId": 1723932449,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:54:04+09:00"
+  },
+  {
+    "title": "冬のプレゼント",
+    "artist": "もさを。",
+    "metadata": {
+      "releaseDate": "2020-11-30",
+      "releaseYear": 2020,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 302,
+      "collectionName": "冬のプレゼント - Single",
+      "itunesTrackId": 1540891246,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:54:06+09:00"
+  },
+  {
+    "title": "冬のこもりうた",
+    "artist": "原田知世",
+    "metadata": {
+      "releaseDate": "2019-10-16",
+      "releaseYear": 2019,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 282,
+      "collectionName": "Candle Lights",
+      "itunesTrackId": 1482063640,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:54:07+09:00"
+  },
+  {
+    "title": "あなたに出会わなければ～夏雪冬花～",
+    "artist": "Aimer",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:54:08+09:00"
+  },
+  {
+    "title": "蝶々結び",
+    "artist": "Aimer",
+    "metadata": {
+      "releaseDate": "2016-08-17",
+      "releaseYear": 2016,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 307,
+      "collectionName": "蝶々結び - Single",
+      "itunesTrackId": 1538258769,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:54:10+09:00"
+  },
+  {
+    "title": "人形の夢と目覚め",
+    "artist": "テオドール・エステン",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:54:11+09:00"
+  },
+  {
+    "title": "朝ごはんの歌",
+    "artist": "手嶌葵",
+    "metadata": {
+      "releaseDate": "2011-07-06",
+      "releaseYear": 2011,
+      "decade": "2010年代",
+      "genre": "ヴォーカル",
+      "durationSeconds": 176,
+      "collectionName": "コクリコ坂から歌集",
+      "itunesTrackId": 445827824,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:54:13+09:00"
+  },
+  {
+    "title": "春よ、来い",
+    "artist": "松任谷由実",
+    "metadata": {
+      "releaseDate": "1994-10-24",
+      "releaseYear": 1994,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 289,
+      "collectionName": "春よ、来い - Single",
+      "itunesTrackId": 1436012884,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:54:14+09:00"
+  },
+  {
+    "title": "AlwayS",
+    "artist": "NiziU",
+    "metadata": {
+      "releaseDate": "2024-12-03",
+      "releaseYear": 2024,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 261,
+      "collectionName": "AlwayS - Single",
+      "itunesTrackId": 1780495330,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:54:15+09:00"
+  },
+  {
+    "title": "友 ～旅立ちの時～",
+    "artist": "ゆず",
+    "metadata": {
+      "releaseDate": "2013-09-18",
+      "releaseYear": 2013,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 276,
+      "collectionName": "ゆずイロハ1997-2017",
+      "itunesTrackId": 1223976833,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:54:17+09:00"
+  },
+  {
+    "title": "赤いスイートピー",
+    "artist": "松田聖子",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:54:18+09:00"
+  },
+  {
+    "title": "青い珊瑚礁",
+    "artist": "松田聖子",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:54:20+09:00"
+  },
+  {
+    "title": "HAPPY BIRTHDAY",
+    "artist": "back number",
+    "metadata": {
+      "releaseDate": "2019-02-19",
+      "releaseYear": 2019,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 259,
+      "collectionName": "HAPPY BIRTHDAY - EP",
+      "itunesTrackId": 1452746756,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:54:21+09:00"
+  },
+  {
+    "title": "帰りたくなったよ",
+    "artist": "いきものがかり",
+    "metadata": {
+      "releaseDate": "2008-04-16",
+      "releaseYear": 2008,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 367,
+      "collectionName": "My song  Your song",
+      "itunesTrackId": 1536256938,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:54:22+09:00"
+  },
+  {
+    "title": "ちょうちょう",
+    "artist": "ドイツ民謡",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:54:24+09:00"
+  },
+  {
+    "title": "KICK BACK",
+    "artist": "米津玄師",
+    "metadata": {
+      "releaseDate": "2022-10-12",
+      "releaseYear": 2022,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 193,
+      "collectionName": "KICK BACK - Single",
+      "itunesTrackId": 1648272180,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:54:25+09:00"
+  },
+  {
+    "title": "とてと",
+    "artist": "パペットスンスン",
+    "metadata": {
+      "releaseDate": "2025-06-25",
+      "releaseYear": 2025,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 163,
+      "collectionName": "とてと - Single",
+      "itunesTrackId": 1821143767,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:54:27+09:00"
+  },
+  {
+    "title": "1991",
+    "artist": "米津玄師",
+    "metadata": {
+      "releaseDate": "2025-10-13",
+      "releaseYear": 2025,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 227,
+      "collectionName": "1991 - Single",
+      "itunesTrackId": 1844275014,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:54:28+09:00"
+  },
+  {
+    "title": "春風",
+    "artist": "Rihwa",
+    "metadata": {
+      "releaseDate": "2014-02-26",
+      "releaseYear": 2014,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 334,
+      "collectionName": "BORDERLESS",
+      "itunesTrackId": 853560905,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:54:30+09:00"
+  },
+  {
+    "title": "超最強",
+    "artist": "超ときめき♡宣伝部",
+    "metadata": {
+      "releaseDate": "2024-12-04",
+      "releaseYear": 2024,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 200,
+      "collectionName": "ときめきルールブック",
+      "itunesTrackId": 1780265107,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:54:31+09:00"
+  },
+  {
+    "title": "はちゃめちゃわちゃライフ!",
+    "artist": "FRUITS ZIPPER",
+    "metadata": {
+      "releaseDate": "2025-10-04",
+      "releaseYear": 2025,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 233,
+      "collectionName": "はちゃめちゃわちゃライフ! / JAM - EP",
+      "itunesTrackId": 1839369466,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:54:32+09:00"
+  },
+  {
+    "title": "エーデルワイス",
+    "artist": "ロジャース&ハマースタイン",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:54:34+09:00"
+  },
+  {
+    "title": "プラチナ",
+    "artist": "坂本真綾",
+    "metadata": {
+      "releaseDate": "1999-10-21",
+      "releaseYear": 1999,
+      "decade": "1990年代",
+      "genre": "アニメ",
+      "durationSeconds": 250,
+      "collectionName": "プラチナ - Single",
+      "itunesTrackId": 543496280,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:54:35+09:00"
+  },
+  {
+    "title": "たしかなこと",
+    "artist": "小田和正",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:54:37+09:00"
+  },
+  {
+    "title": "雨",
+    "artist": "森高千里",
+    "metadata": {
+      "releaseDate": "1987-07-25",
+      "releaseYear": 1987,
+      "decade": "1980年代",
+      "genre": "J-Pop",
+      "durationSeconds": 273,
+      "collectionName": "雨 - Single",
+      "itunesTrackId": 528971992,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:54:38+09:00"
+  },
+  {
+    "title": "雨",
+    "artist": "弘田竜太郎",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:54:40+09:00"
+  },
+  {
+    "title": "雨と僕の話",
+    "artist": "back number",
+    "metadata": {
+      "releaseDate": "2019-03-27",
+      "releaseYear": 2019,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 234,
+      "collectionName": "MAGIC",
+      "itunesTrackId": 1456063433,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:54:41+09:00"
+  },
+  {
+    "title": "ファッションモンスター",
+    "artist": "きゃりーぱみゅぱみゅ",
+    "metadata": {
+      "releaseDate": "2012-10-17",
+      "releaseYear": 2012,
+      "decade": "2010年代",
+      "genre": "エレクトロニック",
+      "durationSeconds": 277,
+      "collectionName": "ファッションモンスター - Single",
+      "itunesTrackId": 567017941,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:54:42+09:00"
+  },
+  {
+    "title": "未来",
+    "artist": "コブクロ",
+    "metadata": {
+      "releaseDate": "2007-06-13",
+      "releaseYear": 2007,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 317,
+      "collectionName": "ALL TIME BEST 1998-2018",
+      "itunesTrackId": 1441818357,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:54:44+09:00"
+  },
+  {
+    "title": "ある未来より愛を込めて",
+    "artist": "back number",
+    "metadata": {
+      "releaseDate": "2025-06-20",
+      "releaseYear": 2025,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 247,
+      "collectionName": "ある未来より愛を込めて - Single",
+      "itunesTrackId": 1820851477,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:54:45+09:00"
+  },
+  {
+    "title": "未来",
+    "artist": "Kalafina",
+    "metadata": {
+      "releaseDate": "2012-10-24",
+      "releaseYear": 2012,
+      "decade": "2010年代",
+      "genre": "アニメ",
+      "durationSeconds": 273,
+      "collectionName": "Consolation",
+      "itunesTrackId": 1537251340,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:54:47+09:00"
+  },
+  {
+    "title": "透明人間",
+    "artist": "東京事変",
+    "metadata": {
+      "releaseDate": "2021-12-22",
+      "releaseYear": 2021,
+      "decade": "2020年代",
+      "genre": "ロック",
+      "durationSeconds": 272,
+      "collectionName": "総合",
+      "itunesTrackId": 1594482567,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:54:48+09:00"
+  },
+  {
+    "title": "長く短い祭",
+    "artist": "椎名林檎",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:54:50+09:00"
+  },
+  {
+    "title": "好きすぎて滅！",
+    "artist": "M!LK",
+    "metadata": {
+      "releaseDate": "2025-10-27",
+      "releaseYear": 2025,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 212,
+      "collectionName": "好きすぎて滅! - Single",
+      "itunesTrackId": 1846753946,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:54:51+09:00"
+  },
+  {
+    "title": "すてきなホリデイ",
+    "artist": "竹内まりや",
+    "metadata": {
+      "releaseDate": "2001-08-22",
+      "releaseYear": 2001,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 278,
+      "collectionName": "Bon Appetit!",
+      "itunesTrackId": 257401162,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:54:52+09:00"
+  },
+  {
+    "title": "プラスティック・ラヴ",
+    "artist": "竹内まりや",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:54:54+09:00"
+  },
+  {
+    "title": "Love me, Love you",
+    "artist": "Mrs. GREEN APPLE",
+    "metadata": {
+      "releaseDate": "2018-02-14",
+      "releaseYear": 2018,
+      "decade": "2010年代",
+      "genre": "ロック",
+      "durationSeconds": 283,
+      "collectionName": "Love me, Love you - EP",
+      "itunesTrackId": 1441018140,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:54:55+09:00"
+  },
+  {
+    "title": "Forever Love",
+    "artist": "X JAPAN",
+    "metadata": {
+      "releaseDate": "1996-07-08",
+      "releaseYear": 1996,
+      "decade": "1990年代",
+      "genre": "ロック",
+      "durationSeconds": 518,
+      "collectionName": "Forever Love - Single",
+      "itunesTrackId": 1886167293,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:54:59+09:00"
+  },
+  {
+    "title": "The Christmas Song",
+    "artist": "Nat King Cole",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:55:00+09:00"
+  },
+  {
+    "title": "恋人たちのクリスマス",
+    "artist": "マライア・キャリー",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:55:02+09:00"
+  },
+  {
+    "title": "クリスマス・イブ",
+    "artist": "山下達郎",
+    "metadata": {
+      "releaseDate": "2013-11-20",
+      "releaseYear": 2013,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 254,
+      "collectionName": "クリスマス・イブ (30th Anniversary Edition) - EP",
+      "itunesTrackId": 1300670407,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:55:03+09:00"
+  },
+  {
+    "title": "あわてんぼうのサンタクロース",
+    "artist": "小林亜星",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:55:05+09:00"
+  },
+  {
+    "title": "サンタが街にやってくる",
+    "artist": "ヘヴン・ギレスピー、フレッド・クーツ",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:55:06+09:00"
+  },
+  {
+    "title": "ジングルベル",
+    "artist": "ジェームズ・ロード・ピアポント",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:55:08+09:00"
+  },
+  {
+    "title": "きよしこの夜",
+    "artist": "ヨゼフ・モール、フランツ・クサーヴァー・グルーバー",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:55:09+09:00"
+  },
+  {
+    "title": "もろびとこぞりて",
+    "artist": "ゲオルク・フリードリヒ・ヘンデル",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:55:10+09:00"
+  },
+  {
+    "title": "Winter Bells",
+    "artist": "倉木麻衣",
+    "metadata": {
+      "releaseDate": "2002-01-17",
+      "releaseYear": 2002,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 279,
+      "collectionName": "Winter Bells - Single",
+      "itunesTrackId": 1714221548,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:55:12+09:00"
+  },
+  {
+    "title": "バニラ",
+    "artist": "きゃない",
+    "metadata": {
+      "releaseDate": "2022-03-09",
+      "releaseYear": 2022,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 251,
+      "collectionName": "バニラ - Single",
+      "itunesTrackId": 1611103469,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:55:13+09:00"
+  },
+  {
+    "title": "恋をして",
+    "artist": "HY",
+    "metadata": {
+      "releaseDate": "2024-12-11",
+      "releaseYear": 2024,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 363,
+      "collectionName": "恋をして - Single",
+      "itunesTrackId": 1780907436,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:55:15+09:00"
+  },
+  {
+    "title": "TAKUMI/匠",
+    "artist": "松谷卓",
+    "metadata": {
+      "releaseDate": "2000-08-23",
+      "releaseYear": 2000,
+      "decade": "2000年代",
+      "genre": "サウンドトラック",
+      "durationSeconds": 282,
+      "collectionName": "珠玉のインスト・クラシック ベストヒット35曲!〜Epic35〜",
+      "itunesTrackId": 1536311937,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:55:16+09:00"
+  },
+  {
+    "title": "We Wish You a Merry Christmas",
+    "artist": "イギリス民謡",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:55:18+09:00"
+  },
+  {
+    "title": "笑ったり転んだり",
+    "artist": "ハンバート ハンバート",
+    "metadata": {
+      "releaseDate": "2025-10-01",
+      "releaseYear": 2025,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 195,
+      "collectionName": "笑ったり転んだり - Single",
+      "itunesTrackId": 1834112550,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:55:19+09:00"
+  },
+  {
+    "title": "愛の言霊 ～Spiritual Message～",
+    "artist": "サザンオールスターズ",
+    "metadata": {
+      "releaseDate": "1996-05-20",
+      "releaseYear": 1996,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 342,
+      "collectionName": "愛の言霊(ことだま) ~Spiritual Message~ - Single",
+      "itunesTrackId": 949251804,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:55:20+09:00"
+  },
+  {
+    "title": "TSUNAMI",
+    "artist": "サザンオールスターズ",
+    "metadata": {
+      "releaseDate": "2000-01-26",
+      "releaseYear": 2000,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 316,
+      "collectionName": "TSUNAMI - Single",
+      "itunesTrackId": 949250892,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:55:22+09:00"
+  },
+  {
+    "title": "TOMORROW",
+    "artist": "岡本真夜",
+    "metadata": {
+      "releaseDate": "1995-05-10",
+      "releaseYear": 1995,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 287,
+      "collectionName": "TOMORROW / BLUE STAR - EP",
+      "itunesTrackId": 291351980,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:55:23+09:00"
+  },
+  {
+    "title": "365日",
+    "artist": "Mr.Children",
+    "metadata": {
+      "releaseDate": "2010-12-01",
+      "releaseYear": 2010,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 336,
+      "collectionName": "Mr.Children 2005 - 2010 <macro>",
+      "itunesTrackId": 1374993078,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:55:25+09:00"
+  },
+  {
+    "title": "前前前世",
+    "artist": "RADWIMPS",
+    "metadata": {
+      "releaseDate": "2016-11-23",
+      "releaseYear": 2016,
+      "decade": "2010年代",
+      "genre": "ロック",
+      "durationSeconds": 275,
+      "collectionName": "人間開花",
+      "itunesTrackId": 1518844828,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:55:26+09:00"
+  },
+  {
+    "title": "賜物",
+    "artist": "RADWIMPS",
+    "metadata": {
+      "releaseDate": "2025-04-18",
+      "releaseYear": 2025,
+      "decade": "2020年代",
+      "genre": "ロック",
+      "durationSeconds": 290,
+      "collectionName": "賜物 - Single",
+      "itunesTrackId": 1805033133,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:55:27+09:00"
+  },
+  {
+    "title": "ノーチラス",
+    "artist": "ヨルシカ",
+    "metadata": {
+      "releaseDate": "2019-08-28",
+      "releaseYear": 2019,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 241,
+      "collectionName": "エルマ",
+      "itunesTrackId": 1474062410,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:55:29+09:00"
+  },
+  {
+    "title": "やさしい気持ち",
+    "artist": "CHARA",
+    "metadata": {
+      "releaseDate": "1997-04-23",
+      "releaseYear": 1997,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 212,
+      "collectionName": "Sugar Hunter 〜THE BEST LOVE SONGS OF CHARA〜",
+      "itunesTrackId": 1536255283,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:55:30+09:00"
+  },
+  {
+    "title": "最後の優しさ",
+    "artist": "JAY'ED",
+    "metadata": {
+      "releaseDate": "2009-02-04",
+      "releaseYear": 2009,
+      "decade": "2000年代",
+      "genre": "R&B／ソウル",
+      "durationSeconds": 257,
+      "collectionName": "最後の優しさ/SUNLIGHT - Single",
+      "itunesTrackId": 303414186,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:55:32+09:00"
+  },
+  {
+    "title": "ヒーロー",
+    "artist": "FUNKY MONKEY BABYS",
+    "metadata": {
+      "releaseDate": "2000-01-01",
+      "releaseYear": 2000,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 296,
+      "collectionName": "ヒーロー/明日へ - Single",
+      "itunesTrackId": 338515101,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:55:33+09:00"
+  },
+  {
+    "title": "さすらい",
+    "artist": "奥田民生",
+    "metadata": {
+      "releaseDate": "1998-03-18",
+      "releaseYear": 1998,
+      "decade": "1990年代",
+      "genre": "ロック",
+      "durationSeconds": 203,
+      "collectionName": "股旅",
+      "itunesTrackId": 1537348515,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:55:35+09:00"
+  },
+  {
+    "title": "Have Yourself a Merry Little Christmas",
+    "artist": "ヒュー・マーティン",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:55:36+09:00"
+  },
+  {
+    "title": "サクラウサギ",
+    "artist": "川崎鷹也",
+    "metadata": {
+      "releaseDate": "2021-01-15",
+      "releaseYear": 2021,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 319,
+      "collectionName": "サクラウサギ - Single",
+      "itunesTrackId": 1546887855,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:55:37+09:00"
+  },
+  {
+    "title": "あたしを彼女にしたいなら",
+    "artist": "コレサワ",
+    "metadata": {
+      "releaseDate": "2015-12-16",
+      "releaseYear": 2015,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 244,
+      "collectionName": "女子、ジョーキョー。 - EP",
+      "itunesTrackId": 1063702346,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:55:39+09:00"
+  },
+  {
+    "title": "ミッドナイト・リフレクション",
+    "artist": "NOMELON NOLEMON",
+    "metadata": {
+      "releaseDate": "2025-01-18",
+      "releaseYear": 2025,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 221,
+      "collectionName": "ミッドナイト・リフレクション - Single",
+      "itunesTrackId": 1787659169,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:55:40+09:00"
+  },
+  {
+    "title": "桜が降る夜は",
+    "artist": "あいみょん",
+    "metadata": {
+      "releaseDate": "2021-02-17",
+      "releaseYear": 2021,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 275,
+      "collectionName": "桜が降る夜は - Single",
+      "itunesTrackId": 1551664064,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:55:42+09:00"
+  },
+  {
+    "title": "手のひらを太陽に",
+    "artist": "いずみたく",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:55:43+09:00"
+  },
+  {
+    "title": "らしさ",
+    "artist": "Official髭男dism",
+    "metadata": {
+      "releaseDate": "2025-08-06",
+      "releaseYear": 2025,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 303,
+      "collectionName": "らしさ - Single",
+      "itunesTrackId": 1826940240,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:55:45+09:00"
+  },
+  {
+    "title": "Funny Bunny",
+    "artist": "the pillows",
+    "metadata": {
+      "releaseDate": "1999-12-02",
+      "releaseYear": 1999,
+      "decade": "1990年代",
+      "genre": "ロック",
+      "durationSeconds": 220,
+      "collectionName": "HAPPY BIVOUAC",
+      "itunesTrackId": 317681417,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:55:46+09:00"
+  },
+  {
+    "title": "Share The World",
+    "artist": "東方神起",
+    "metadata": {
+      "releaseDate": "2009-04-22",
+      "releaseYear": 2009,
+      "decade": "2000年代",
+      "genre": "ポップ",
+      "durationSeconds": 207,
+      "collectionName": "Share The World/ウィーアー! - EP",
+      "itunesTrackId": 311618211,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:56:00+09:00"
+  },
+  {
+    "title": "蛍の光",
+    "artist": "作曲者不詳",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:56:01+09:00"
+  },
+  {
+    "title": "Autumn Leaves",
+    "artist": "ジョゼフ・コズマ",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:56:03+09:00"
+  },
+  {
+    "title": "Moon River",
+    "artist": "ヘンリー・マンシーニ",
+    "metadata": {
+      "releaseDate": "1961-01-01",
+      "releaseYear": 1961,
+      "decade": "1960年代",
+      "genre": "サウンドトラック",
+      "durationSeconds": 164,
+      "collectionName": "Breakfast At Tiffany's (Music from the Motion Picture) [Remastered]",
+      "itunesTrackId": 306677750,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:56:04+09:00"
+  },
+  {
+    "title": "Fly Me To The Moon",
+    "artist": "バート・ハワード",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:56:06+09:00"
+  },
+  {
+    "title": "Misty",
+    "artist": "エロル・ガーナー",
+    "metadata": {
+      "releaseDate": "1954-07-01",
+      "releaseYear": 1954,
+      "decade": "1950年代",
+      "genre": "ジャズ",
+      "durationSeconds": 169,
+      "collectionName": "The Original Misty",
+      "itunesTrackId": 1443144347,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:56:07+09:00"
+  },
+  {
+    "title": "ムーンライト伝説",
+    "artist": "DALI",
+    "metadata": {
+      "releaseDate": "2000-06-21",
+      "releaseYear": 2000,
+      "decade": "2000年代",
+      "genre": "アニメ",
+      "durationSeconds": 176,
+      "collectionName": "美少女戦士セーラームーン ベスト",
+      "itunesTrackId": 1542353773,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:56:09+09:00"
+  },
+  {
+    "title": "青い車",
+    "artist": "スピッツ",
+    "metadata": {
+      "releaseDate": "1994-09-21",
+      "releaseYear": 1994,
+      "decade": "1990年代",
+      "genre": "ロック",
+      "durationSeconds": 279,
+      "collectionName": "空の飛び方",
+      "itunesTrackId": 1440779327,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:56:10+09:00"
+  },
+  {
+    "title": "風といっしょに",
+    "artist": "小林幸子",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:56:12+09:00"
+  },
+  {
+    "title": "愛♡スクリ～ム！",
+    "artist": "AiScReam",
+    "metadata": {
+      "releaseDate": "2025-01-21",
+      "releaseYear": 2025,
+      "decade": "2020年代",
+      "genre": "アニメ",
+      "durationSeconds": 262,
+      "collectionName": "愛♡スクリ～ム! - EP",
+      "itunesTrackId": 1785614776,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:56:13+09:00"
+  },
+  {
+    "title": "呼び声",
+    "artist": "Vaundy",
+    "metadata": {
+      "releaseDate": "2025-12-24",
+      "releaseYear": 2025,
+      "decade": "2020年代",
+      "genre": "ロック",
+      "durationSeconds": 234,
+      "collectionName": "呼び声 - Single",
+      "itunesTrackId": 1859586540,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:56:14+09:00"
+  },
+  {
+    "title": "アドレナ",
+    "artist": "YOASOBI",
+    "metadata": {
+      "releaseDate": "2026-01-04",
+      "releaseYear": 2026,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 186,
+      "collectionName": "アドレナ - Single",
+      "itunesTrackId": 1861370949,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:56:16+09:00"
+  },
+  {
+    "title": "最後の彼女になりたかった",
+    "artist": "コレサワ",
+    "metadata": {
+      "releaseDate": "2020-01-15",
+      "releaseYear": 2020,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 285,
+      "collectionName": "失恋スクラップ",
+      "itunesTrackId": 1490385560,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:56:17+09:00"
+  },
+  {
+    "title": "pink",
+    "artist": "シャイトープ",
+    "metadata": {
+      "releaseDate": "2023-02-13",
+      "releaseYear": 2023,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 265,
+      "collectionName": "pink - Single",
+      "itunesTrackId": 1670931224,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:56:19+09:00"
+  },
+  {
+    "title": "たんぽぽ",
+    "artist": "遊助",
+    "metadata": {
+      "releaseDate": "2009-06-24",
+      "releaseYear": 2009,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 334,
+      "collectionName": "たんぽぽ/海賊船/其の拳 - EP",
+      "itunesTrackId": 1537405046,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:56:20+09:00"
+  },
+  {
+    "title": "Memories",
+    "artist": "MAN WITH A MISSION",
+    "metadata": {
+      "releaseDate": "2016-01-27",
+      "releaseYear": 2016,
+      "decade": "2010年代",
+      "genre": "ロック",
+      "durationSeconds": 278,
+      "collectionName": "Memories - Single",
+      "itunesTrackId": 1537555916,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:56:22+09:00"
+  },
+  {
+    "title": "泥中に咲く",
+    "artist": "ウォルピスカーター",
+    "metadata": {
+      "releaseDate": "2018-12-26",
+      "releaseYear": 2018,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 287,
+      "collectionName": "これからもウォルピス社の提供でお送りします。",
+      "itunesTrackId": 1446682679,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:56:23+09:00"
+  },
+  {
+    "title": "備忘録",
+    "artist": "高瀬統也",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:56:24+09:00"
+  },
+  {
+    "title": "セロリ",
+    "artist": "山崎まさよし",
+    "metadata": {
+      "releaseDate": "1996-09-01",
+      "releaseYear": 1996,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 255,
+      "collectionName": "YAMAZAKI MASAYOSHI the BEST / BLUE PERIOD",
+      "itunesTrackId": 1440883056,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:56:26+09:00"
+  },
+  {
+    "title": "初恋サイダー",
+    "artist": "Buono!",
+    "metadata": {
+      "releaseDate": "2012-01-18",
+      "releaseYear": 2012,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 211,
+      "collectionName": "Buono! COMPLETE",
+      "itunesTrackId": 1511117841,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:56:27+09:00"
+  },
+  {
+    "title": "ギブス",
+    "artist": "椎名林檎",
+    "metadata": {
+      "releaseDate": "2000-01-26",
+      "releaseYear": 2000,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 329,
+      "collectionName": "ギブス - Single",
+      "itunesTrackId": 1384342132,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:56:29+09:00"
+  },
+  {
+    "title": "fragile",
+    "artist": "Every Little Thing",
+    "metadata": {
+      "releaseDate": "1999-03-31",
+      "releaseYear": 1999,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 290,
+      "collectionName": "Every Best Single ~COMPLETE~",
+      "itunesTrackId": 1159580791,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:56:30+09:00"
+  },
+  {
+    "title": "さらば恋人",
+    "artist": "堺正章",
+    "metadata": {
+      "releaseDate": "2014-05-28",
+      "releaseYear": 2014,
+      "decade": "2010年代",
+      "genre": "演歌",
+      "durationSeconds": 202,
+      "collectionName": "殿のスポットライト",
+      "itunesTrackId": 877542049,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:56:31+09:00"
+  },
+  {
+    "title": "ひだまりの詩",
+    "artist": "Le Couple",
+    "metadata": {
+      "releaseDate": "1997-05-02",
+      "releaseYear": 1997,
+      "decade": "1990年代",
+      "genre": "サウンドトラック",
+      "durationSeconds": 279,
+      "collectionName": "ひとつ屋根の下 2",
+      "itunesTrackId": 1445975705,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:56:33+09:00"
+  },
+  {
+    "title": "Swallowtail Butterfly ～あいのうた～",
+    "artist": "YEN TOWN BAND",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:56:34+09:00"
+  },
+  {
+    "title": "やぎさんゆうびん",
+    "artist": "團伊玖磨",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:56:36+09:00"
+  },
+  {
+    "title": "おやすみ泣き声、さよなら歌姫",
+    "artist": "クリープハイプ",
+    "metadata": {
+      "releaseDate": "2012-10-03",
+      "releaseYear": 2012,
+      "decade": "2010年代",
+      "genre": "ロック",
+      "durationSeconds": 238,
+      "collectionName": "おやすみ泣き声、さよなら歌姫 - Single",
+      "itunesTrackId": 561857683,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:56:37+09:00"
+  },
+  {
+    "title": "ミカヅキ",
+    "artist": "さユり",
+    "metadata": {
+      "releaseDate": "2015-08-26",
+      "releaseYear": 2015,
+      "decade": "2010年代",
+      "genre": "ロック",
+      "durationSeconds": 263,
+      "collectionName": "ミカヅキ-special edition - Single",
+      "itunesTrackId": 1536015134,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:56:39+09:00"
+  },
+  {
+    "title": "フィクション",
+    "artist": "sumika",
+    "metadata": {
+      "releaseDate": "2018-04-25",
+      "releaseYear": 2018,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 233,
+      "collectionName": "Fiction e.p",
+      "itunesTrackId": 1537461096,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:56:40+09:00"
+  },
+  {
+    "title": "コイワズライ",
+    "artist": "Aimer",
+    "metadata": {
+      "releaseDate": "2019-03-18",
+      "releaseYear": 2019,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 235,
+      "collectionName": "Sun Dance",
+      "itunesTrackId": 1538261229,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:56:42+09:00"
+  },
+  {
+    "title": "SAD SONG",
+    "artist": "ちゃんみな",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:56:43+09:00"
+  },
+  {
+    "title": "情熱大陸",
+    "artist": "葉加瀬太郎",
+    "metadata": {
+      "releaseDate": "2000-08-23",
+      "releaseYear": 2000,
+      "decade": "2000年代",
+      "genre": "サウンドトラック",
+      "durationSeconds": 303,
+      "collectionName": "BEST of image",
+      "itunesTrackId": 1537323110,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:56:44+09:00"
+  },
+  {
+    "title": "Another Day of Sun",
+    "artist": "ジャスティン・ハーウィッツ",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:56:46+09:00"
+  },
+  {
+    "title": "世界には愛しかない",
+    "artist": "欅坂46",
+    "metadata": {
+      "releaseDate": "2016-08-10",
+      "releaseYear": 2016,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 296,
+      "collectionName": "永遠より長い一瞬 ~あの頃、確かに存在した私たち~(Complete Edition)",
+      "itunesTrackId": 1533414468,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:56:47+09:00"
+  },
+  {
+    "title": "海の声",
+    "artist": "浦島太郎（桐谷健太）",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:56:49+09:00"
+  },
+  {
+    "title": "ふたつ星",
+    "artist": "I WiSH",
+    "metadata": {
+      "releaseDate": "2003-08-27",
+      "releaseYear": 2003,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 295,
+      "collectionName": "THE COMPLETE COLLECTION OF I WiSH",
+      "itunesTrackId": 1537055929,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:56:50+09:00"
+  },
+  {
+    "title": "ら・ら・ら",
+    "artist": "大黒摩季",
+    "metadata": {
+      "releaseDate": "1995-07-19",
+      "releaseYear": 1995,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 264,
+      "collectionName": "Greatest Hits 1991-2016 ~All Singles + ~",
+      "itunesTrackId": 1490814556,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:56:51+09:00"
+  },
+  {
+    "title": "みかんの花咲く丘",
+    "artist": "井口小夜子",
+    "metadata": {
+      "releaseDate": "2021-12-08",
+      "releaseYear": 2021,
+      "decade": "2020年代",
+      "genre": "チルドレン・ミュージック",
+      "durationSeconds": 168,
+      "collectionName": "昭和の童謡のあゆみ～キングレコード90周年を彩る100曲",
+      "itunesTrackId": 1597901812,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:56:53+09:00"
+  },
+  {
+    "title": "はじめてのチュウ",
+    "artist": "あんしんパパ",
+    "metadata": {
+      "releaseDate": "2015-12-16",
+      "releaseYear": 2015,
+      "decade": "2010年代",
+      "genre": "アニメ",
+      "durationSeconds": 265,
+      "collectionName": "藤子・F・不二雄 生誕90周年 藤子・F・不二雄 TV MUSIC HISTORY II -藤子・F・不二雄作品集2-",
+      "itunesTrackId": 1756878660,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:56:54+09:00"
+  },
+  {
+    "title": "また あした",
+    "artist": "Every Little Thing",
+    "metadata": {
+      "releaseDate": "2003-11-12",
+      "releaseYear": 2003,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 298,
+      "collectionName": "Every Best Single 2 ~middLe period~",
+      "itunesTrackId": 1036794790,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:56:56+09:00"
+  },
+  {
+    "title": "Around The World",
+    "artist": "MONKEY MAJIK",
+    "metadata": {
+      "releaseDate": "2006-05-24",
+      "releaseYear": 2006,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 225,
+      "collectionName": "Around The World - EP",
+      "itunesTrackId": 122899374,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:56:57+09:00"
+  },
+  {
+    "title": "あの素晴しい愛をもう一度",
+    "artist": "加藤和彦、北山修",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:56:58+09:00"
+  },
+  {
+    "title": "lulu.",
+    "artist": "Mrs. GREEN APPLE",
+    "metadata": {
+      "releaseDate": "2026-01-12",
+      "releaseYear": 2026,
+      "decade": "2020年代",
+      "genre": "ロック",
+      "durationSeconds": 271,
+      "collectionName": "lulu. - Single",
+      "itunesTrackId": 1867354081,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:57:00+09:00"
+  },
+  {
+    "title": "大丈夫",
+    "artist": "RADWIMPS",
+    "metadata": {
+      "releaseDate": "2019-11-27",
+      "releaseYear": 2019,
+      "decade": "2010年代",
+      "genre": "ロック",
+      "durationSeconds": 334,
+      "collectionName": "天気の子 (complete version) - EP",
+      "itunesTrackId": 1518516241,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:57:01+09:00"
+  },
+  {
+    "title": "火星人",
+    "artist": "ヨルシカ",
+    "metadata": {
+      "releaseDate": "2026-02-19",
+      "releaseYear": 2026,
+      "decade": "2020年代",
+      "genre": "オルタナティブ",
+      "durationSeconds": 235,
+      "collectionName": "火星人 - Single",
+      "itunesTrackId": 1809266711,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:57:03+09:00"
+  },
+  {
+    "title": "裸の勇者",
+    "artist": "Vaundy",
+    "metadata": {
+      "releaseDate": "2022-01-07",
+      "releaseYear": 2022,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 202,
+      "collectionName": "裸の勇者 - EP",
+      "itunesTrackId": 1600223385,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:57:04+09:00"
+  },
+  {
+    "title": "裸の心",
+    "artist": "あいみょん",
+    "metadata": {
+      "releaseDate": "2020-05-01",
+      "releaseYear": 2020,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 297,
+      "collectionName": "裸の心 - Single",
+      "itunesTrackId": 1508133095,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:57:06+09:00"
+  },
+  {
+    "title": "さよならぼくたちのようちえん",
+    "artist": "新沢としひこ",
+    "metadata": {
+      "releaseDate": "2001-07-18",
+      "releaseYear": 2001,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 181,
+      "collectionName": "歌でおぼえる手話ソングブック ともだちになるために",
+      "itunesTrackId": 1585757834,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:57:07+09:00"
+  },
+  {
+    "title": "詠人",
+    "artist": "北島三郎",
+    "metadata": {
+      "releaseDate": "1998-10-07",
+      "releaseYear": 1998,
+      "decade": "1990年代",
+      "genre": "演歌",
+      "durationSeconds": 207,
+      "collectionName": "北島三郎芸道60周年 ～ファンと歩んだ永遠の輝き～ Ⅱ",
+      "itunesTrackId": 1598600874,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:57:09+09:00"
+  },
+  {
+    "title": "あなたに逢いたくて～Missing You～",
+    "artist": "松田聖子",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:57:10+09:00"
+  },
+  {
+    "title": "あなた",
+    "artist": "小坂明子",
+    "metadata": {
+      "releaseDate": "2013-06-26",
+      "releaseYear": 2013,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 291,
+      "collectionName": "懐想",
+      "itunesTrackId": 658255435,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:57:11+09:00"
+  },
+  {
+    "title": "Song for…",
+    "artist": "HY",
+    "metadata": {
+      "releaseDate": "2004-07-14",
+      "releaseYear": 2004,
+      "decade": "2000年代",
+      "genre": "ロック",
+      "durationSeconds": 289,
+      "collectionName": "TRUNK",
+      "itunesTrackId": 297289539,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:57:13+09:00"
+  },
+  {
+    "title": "まつり",
+    "artist": "藤井風",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:57:14+09:00"
+  },
+  {
+    "title": "butterfly",
+    "artist": "木村カエラ",
+    "metadata": {
+      "releaseDate": "2009-06-01",
+      "releaseYear": 2009,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 256,
+      "collectionName": "Butterfly - Single",
+      "itunesTrackId": 317854200,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:57:16+09:00"
+  },
+  {
+    "title": "どうしてもどうしても",
+    "artist": "back number",
+    "metadata": {
+      "releaseDate": "2025-12-27",
+      "releaseYear": 2025,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 227,
+      "collectionName": "どうしてもどうしても - Single",
+      "itunesTrackId": 1860453512,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:57:17+09:00"
+  },
+  {
+    "title": "乾杯",
+    "artist": "長渕剛",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:57:18+09:00"
+  },
+  {
+    "title": "明日、春が来たら",
+    "artist": "松たか子",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:57:20+09:00"
+  },
+  {
+    "title": "タッチ",
+    "artist": "岩崎良美",
+    "metadata": {
+      "releaseDate": "1985-03-21",
+      "releaseYear": 1985,
+      "decade": "1980年代",
+      "genre": "歌謡曲",
+      "durationSeconds": 193,
+      "collectionName": "タッチ",
+      "itunesTrackId": 963626798,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:57:21+09:00"
+  },
+  {
+    "title": "Love so sweet",
+    "artist": "嵐",
+    "metadata": {
+      "releaseDate": "2007-02-21",
+      "releaseYear": 2007,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 290,
+      "collectionName": "Love so sweet - Single",
+      "itunesTrackId": 1485857408,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:57:23+09:00"
+  },
+  {
+    "title": "桜",
+    "artist": "コブクロ",
+    "metadata": {
+      "releaseDate": "2004-09-01",
+      "releaseYear": 2004,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 362,
+      "collectionName": "ALL TIME BEST 1998-2018",
+      "itunesTrackId": 1441818306,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:57:24+09:00"
+  },
+  {
+    "title": "桜",
+    "artist": "清水翔太",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:57:26+09:00"
+  },
+  {
+    "title": "さくらさくら",
+    "artist": "作曲者不詳",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:57:27+09:00"
+  },
+  {
+    "title": "花は桜 君は美し",
+    "artist": "いきものがかり",
+    "metadata": {
+      "releaseDate": "2008-01-30",
+      "releaseYear": 2008,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 266,
+      "collectionName": "花は桜 君は美し - Single",
+      "itunesTrackId": 1536255265,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:57:29+09:00"
+  },
+  {
+    "title": "桜晴",
+    "artist": "優里",
+    "metadata": {
+      "releaseDate": "2021-02-19",
+      "releaseYear": 2021,
+      "decade": "2020年代",
+      "genre": "ロック",
+      "durationSeconds": 236,
+      "collectionName": "桜晴 - Single",
+      "itunesTrackId": 1551902206,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:57:30+09:00"
+  },
+  {
+    "title": "桜",
+    "artist": "河口恭吾",
+    "metadata": {
+      "releaseDate": "2003-12-10",
+      "releaseYear": 2003,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 278,
+      "collectionName": "STARS FROM DECADE〜輝ける星たち〜",
+      "itunesTrackId": 73284488,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:57:31+09:00"
+  },
+  {
+    "title": "大切なもの",
+    "artist": "ロードオブメジャー",
+    "metadata": {
+      "releaseDate": "2002-08-28",
+      "releaseYear": 2002,
+      "decade": "2000年代",
+      "genre": "ロック",
+      "durationSeconds": 190,
+      "collectionName": "大切なもの - Single",
+      "itunesTrackId": 164812481,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:57:33+09:00"
+  },
+  {
+    "title": "エジソン",
+    "artist": "水曜日のカンパネラ",
+    "metadata": {
+      "releaseDate": "2018-06-22",
+      "releaseYear": 2018,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 194,
+      "collectionName": "招き猫 / エジソン - Single",
+      "itunesTrackId": 1607835071,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:57:34+09:00"
+  },
+  {
+    "title": "カタオモイ",
+    "artist": "Aimer",
+    "metadata": {
+      "releaseDate": "2016-09-21",
+      "releaseYear": 2016,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 207,
+      "collectionName": "daydream",
+      "itunesTrackId": 1538259004,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:57:36+09:00"
+  },
+  {
+    "title": "夢を信じて",
+    "artist": "徳永英明",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:57:37+09:00"
+  },
+  {
+    "title": "オー・シャンゼリゼ",
+    "artist": "ジョー・ダッサン",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:57:38+09:00"
+  },
+  {
+    "title": "青春の影",
+    "artist": "チューリップ",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:57:40+09:00"
+  },
+  {
+    "title": "虹とスニーカーの頃",
+    "artist": "チューリップ",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:57:41+09:00"
+  },
+  {
+    "title": "Honto",
+    "artist": "sumika",
+    "metadata": {
+      "releaseDate": "2026-01-29",
+      "releaseYear": 2026,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 222,
+      "collectionName": "Honto - Single",
+      "itunesTrackId": 1868974829,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:57:43+09:00"
+  },
+  {
+    "title": "拝啓、少年よ",
+    "artist": "Hump Back",
+    "metadata": {
+      "releaseDate": "2018-06-10",
+      "releaseYear": 2018,
+      "decade": "2010年代",
+      "genre": "ロック",
+      "durationSeconds": 189,
+      "collectionName": "拝啓、少年よ",
+      "itunesTrackId": 1395024580,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:58:00+09:00"
+  },
+  {
+    "title": "Happiness",
+    "artist": "嵐",
+    "metadata": {
+      "releaseDate": "2007-09-05",
+      "releaseYear": 2007,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 258,
+      "collectionName": "Happiness - Single",
+      "itunesTrackId": 1485847849,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:58:01+09:00"
+  },
+  {
+    "title": "曇天",
+    "artist": "DOES",
+    "metadata": {
+      "releaseDate": "2008-06-18",
+      "releaseYear": 2008,
+      "decade": "2000年代",
+      "genre": "ロック",
+      "durationSeconds": 191,
+      "collectionName": "曇天 - Single",
+      "itunesTrackId": 1536371431,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:58:02+09:00"
+  },
+  {
+    "title": "とくべチュ、して",
+    "artist": "＝LOVE",
+    "metadata": {
+      "releaseDate": "2025-02-10",
+      "releaseYear": 2025,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 239,
+      "collectionName": "とくべチュ、して - Single",
+      "itunesTrackId": 1794066813,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:58:04+09:00"
+  },
+  {
+    "title": "YELL",
+    "artist": "いきものがかり",
+    "metadata": {
+      "releaseDate": "2009-09-23",
+      "releaseYear": 2009,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 358,
+      "collectionName": "YELL/じょいふる - EP",
+      "itunesTrackId": 1536258194,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:58:05+09:00"
+  },
+  {
+    "title": "Honesty",
+    "artist": "ビリー・ジョエル",
+    "metadata": {
+      "releaseDate": "1978-10-12",
+      "releaseYear": 1978,
+      "decade": "1970年代",
+      "genre": "ポップ",
+      "durationSeconds": 234,
+      "collectionName": "52nd Street",
+      "itunesTrackId": 259573440,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:58:07+09:00"
+  },
+  {
+    "title": "壊れかけのRadio",
+    "artist": "徳永英明",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:58:08+09:00"
+  },
+  {
+    "title": "爆裂愛してる",
+    "artist": "M!LK",
+    "metadata": {
+      "releaseDate": "2026-02-18",
+      "releaseYear": 2026,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 204,
+      "collectionName": "爆裂愛してる / 好きすぎて滅! - EP",
+      "itunesTrackId": 1869537742,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:58:10+09:00"
+  },
+  {
+    "title": "ともに",
+    "artist": "WANIMA",
+    "metadata": {
+      "releaseDate": "2016-08-03",
+      "releaseYear": 2016,
+      "decade": "2010年代",
+      "genre": "ロック",
+      "durationSeconds": 207,
+      "collectionName": "Everybody!!",
+      "itunesTrackId": 1319369442,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:58:11+09:00"
+  },
+  {
+    "title": "チェックのワンピース",
+    "artist": "back number",
+    "metadata": {
+      "releaseDate": "2011-10-26",
+      "releaseYear": 2011,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 282,
+      "collectionName": "スーパースター",
+      "itunesTrackId": 1451570485,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:58:13+09:00"
+  },
+  {
+    "title": "切手のないおくりもの",
+    "artist": "財津和夫",
+    "metadata": {
+      "releaseDate": "2004-09-01",
+      "releaseYear": 2004,
+      "decade": "2000年代",
+      "genre": "歌謡曲",
+      "durationSeconds": 150,
+      "collectionName": "サボテンの花 ~ grown up",
+      "itunesTrackId": 348065491,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:58:14+09:00"
+  },
+  {
+    "title": "Again",
+    "artist": "Mr.Children",
+    "metadata": {
+      "releaseDate": "2026-01-19",
+      "releaseYear": 2026,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 294,
+      "collectionName": "Again - Single",
+      "itunesTrackId": 1861663797,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:58:16+09:00"
+  },
+  {
+    "title": "シル・ヴ・プレジデント",
+    "artist": "P丸様。",
+    "metadata": {
+      "releaseDate": "2021-03-17",
+      "releaseYear": 2021,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 190,
+      "collectionName": "Sunny!!",
+      "itunesTrackId": 1556015464,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:58:17+09:00"
+  },
+  {
+    "title": "mix juiceのいうとおり",
+    "artist": "UNISON SQUARE GARDEN",
+    "metadata": {
+      "releaseDate": "2016-07-06",
+      "releaseYear": 2016,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 289,
+      "collectionName": "Dr.Izzy",
+      "itunesTrackId": 1128654736,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:58:19+09:00"
+  },
+  {
+    "title": "今はいいんだよ。",
+    "artist": "MIMI",
+    "metadata": {
+      "releaseDate": "2026-06-10",
+      "releaseYear": 2026,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 147,
+      "collectionName": "MIMI 10th Anniversary Album",
+      "itunesTrackId": 6775758408,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:58:20+09:00"
+  },
+  {
+    "title": "SAKURAドロップス",
+    "artist": "宇多田ヒカル",
+    "metadata": {
+      "releaseDate": "2001-01-01",
+      "releaseYear": 2001,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 299,
+      "collectionName": "SAKURAドロップス - EP",
+      "itunesTrackId": 1444862816,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:58:21+09:00"
+  },
+  {
+    "title": "サクラ咲ケ",
+    "artist": "嵐",
+    "metadata": {
+      "releaseDate": "2005-03-23",
+      "releaseYear": 2005,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 262,
+      "collectionName": "サクラ咲ケ - Single",
+      "itunesTrackId": 1485848978,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:58:23+09:00"
+  },
+  {
+    "title": "勿忘",
+    "artist": "Awesome City Club",
+    "metadata": {
+      "releaseDate": "2021-01-27",
+      "releaseYear": 2021,
+      "decade": "2020年代",
+      "genre": "ロック",
+      "durationSeconds": 252,
+      "collectionName": "Grower",
+      "itunesTrackId": 1548406507,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:58:24+09:00"
+  },
+  {
+    "title": "パラボラ",
+    "artist": "Official髭男dism",
+    "metadata": {
+      "releaseDate": "2020-04-10",
+      "releaseYear": 2020,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 301,
+      "collectionName": "パラボラ - Single",
+      "itunesTrackId": 1505478865,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:58:26+09:00"
+  },
+  {
+    "title": "エルダーフラワー",
+    "artist": "Official髭男dism",
+    "metadata": {
+      "releaseDate": "2026-03-30",
+      "releaseYear": 2026,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 286,
+      "collectionName": "エルダーフラワー - Single",
+      "itunesTrackId": 1883590250,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:58:27+09:00"
+  },
+  {
+    "title": "GOOD DAY",
+    "artist": "Mrs. GREEN APPLE",
+    "metadata": {
+      "releaseDate": "2025-09-28",
+      "releaseYear": 2025,
+      "decade": "2020年代",
+      "genre": "ロック",
+      "durationSeconds": 257,
+      "collectionName": "GOOD DAY - Single",
+      "itunesTrackId": 1841344390,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:58:29+09:00"
+  },
+  {
+    "title": "桜恋",
+    "artist": "もさを。",
+    "metadata": {
+      "releaseDate": "2021-02-22",
+      "releaseYear": 2021,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 247,
+      "collectionName": "桜恋 - Single",
+      "itunesTrackId": 1553708900,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:58:30+09:00"
+  },
+  {
+    "title": "もう恋なんてしない",
+    "artist": "槇原敬之",
+    "metadata": {
+      "releaseDate": "1992-05-25",
+      "releaseYear": 1992,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 273,
+      "collectionName": "君は僕の宝物",
+      "itunesTrackId": 284522040,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:58:32+09:00"
+  },
+  {
+    "title": "melt bitter",
+    "artist": "さとうもか",
+    "metadata": {
+      "releaseDate": "2020-01-22",
+      "releaseYear": 2020,
+      "decade": "2020年代",
+      "genre": "ポップ",
+      "durationSeconds": 310,
+      "collectionName": "melt bitter - Single",
+      "itunesTrackId": 1490118581,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:58:33+09:00"
+  },
+  {
+    "title": "Brand New Tomorrow",
+    "artist": "家入レオ",
+    "metadata": {
+      "releaseDate": "2016-07-06",
+      "releaseYear": 2016,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 281,
+      "collectionName": "WE",
+      "itunesTrackId": 1124863474,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:58:35+09:00"
+  },
+  {
+    "title": "Sincerely",
+    "artist": "TRUE",
+    "metadata": {
+      "releaseDate": "2018-01-31",
+      "releaseYear": 2018,
+      "decade": "2010年代",
+      "genre": "アニメ",
+      "durationSeconds": 275,
+      "collectionName": "Sincerely - Single",
+      "itunesTrackId": 1486980090,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:58:36+09:00"
+  },
+  {
+    "title": "瞬き",
+    "artist": "back number",
+    "metadata": {
+      "releaseDate": "2017-12-20",
+      "releaseYear": 2017,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 323,
+      "collectionName": "瞬き - EP",
+      "itunesTrackId": 1440902624,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:58:38+09:00"
+  },
+  {
+    "title": "水",
+    "artist": "中島みゆき",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:58:39+09:00"
+  },
+  {
+    "title": "PRIDE",
+    "artist": "今井美樹",
+    "metadata": {
+      "releaseDate": "1996-11-04",
+      "releaseYear": 1996,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 363,
+      "collectionName": "PRIDE - Single",
+      "itunesTrackId": 142415286,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:58:40+09:00"
+  },
+  {
+    "title": "I am",
+    "artist": "森田真奈美",
+    "metadata": {
+      "releaseDate": "2024-11-23",
+      "releaseYear": 2024,
+      "decade": "2020年代",
+      "genre": "ジャズ",
+      "durationSeconds": 400,
+      "collectionName": "HANDS ON",
+      "itunesTrackId": 1828852045,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:58:42+09:00"
+  },
+  {
+    "title": "ONE WORLD",
+    "artist": "吉川晃司",
+    "metadata": {
+      "releaseDate": "2014-06-25",
+      "releaseYear": 2014,
+      "decade": "2010年代",
+      "genre": "ロック",
+      "durationSeconds": 246,
+      "collectionName": "SINGLES+",
+      "itunesTrackId": 887388931,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:58:43+09:00"
+  },
+  {
+    "title": "VISIONS",
+    "artist": "NAQT VANE",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:58:45+09:00"
+  },
+  {
+    "title": "おどるポンポコリン",
+    "artist": "B.B.クィーンズ",
+    "metadata": {
+      "releaseDate": "1990-04-04",
+      "releaseYear": 1990,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 194,
+      "collectionName": "おどるポンポコリン - Single",
+      "itunesTrackId": 1893019546,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:58:46+09:00"
+  },
+  {
+    "title": "宝島",
+    "artist": "T-SQUARE",
+    "metadata": {
+      "releaseDate": "1986-03-05",
+      "releaseYear": 1986,
+      "decade": "1980年代",
+      "genre": "ジャズ",
+      "durationSeconds": 303,
+      "collectionName": "S・P・O・R・T・S",
+      "itunesTrackId": 1538800833,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:58:48+09:00"
+  },
+  {
+    "title": "アイデア",
+    "artist": "星野源",
+    "metadata": {
+      "releaseDate": "2018-08-20",
+      "releaseYear": 2018,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 279,
+      "collectionName": "アイデア - Single",
+      "itunesTrackId": 1417065830,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:58:49+09:00"
+  },
+  {
+    "title": "風のゆくえ",
+    "artist": "Ado",
+    "metadata": {
+      "releaseDate": "2022-08-10",
+      "releaseYear": 2022,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 272,
+      "collectionName": "ウタの歌 ONE PIECE FILM RED",
+      "itunesTrackId": 1636447280,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:59:00+09:00"
+  },
+  {
+    "title": "元彼女のみなさまへ",
+    "artist": "コレサワ",
+    "metadata": {
+      "releaseDate": "2024-09-04",
+      "releaseYear": 2024,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 249,
+      "collectionName": "元彼女のみなさまへ - Single",
+      "itunesTrackId": 1763577076,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:59:01+09:00"
+  },
+  {
+    "title": "アイガアル",
+    "artist": "Every Little Thing",
+    "metadata": {
+      "releaseDate": "1999-03-31",
+      "releaseYear": 1999,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 245,
+      "collectionName": "Every Best Single 2 ~laTe period~",
+      "itunesTrackId": 1036800906,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:59:03+09:00"
+  },
+  {
+    "title": "素敵だね",
+    "artist": "RIKKI",
+    "metadata": {
+      "releaseDate": "1987-01-01",
+      "releaseYear": 1987,
+      "decade": "1980年代",
+      "genre": "テレビゲーム",
+      "durationSeconds": 334,
+      "collectionName": "FINAL FANTASY X Original Soundtrack",
+      "itunesTrackId": 62445434,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:59:04+09:00"
+  },
+  {
+    "title": "ハルノヒ",
+    "artist": "あいみょん",
+    "metadata": {
+      "releaseDate": "2019-03-13",
+      "releaseYear": 2019,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 327,
+      "collectionName": "ハルノヒ - Single",
+      "itunesTrackId": 1455341000,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:59:05+09:00"
+  },
+  {
+    "title": "Sakura",
+    "artist": "レミオロメン",
+    "metadata": {
+      "releaseDate": "2009-02-14",
+      "releaseYear": 2009,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 297,
+      "collectionName": "レミオベスト",
+      "itunesTrackId": 1857511993,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:59:07+09:00"
+  },
+  {
+    "title": "Oz.",
+    "artist": "yama",
+    "metadata": {
+      "releaseDate": "2021-10-22",
+      "releaseYear": 2021,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 194,
+      "collectionName": "Oz. - Single",
+      "itunesTrackId": 1589026080,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:59:08+09:00"
+  },
+  {
+    "title": "初恋",
+    "artist": "村下孝蔵",
+    "metadata": {
+      "releaseDate": "1980-01-01",
+      "releaseYear": 1980,
+      "decade": "1980年代",
+      "genre": "歌謡曲",
+      "durationSeconds": 223,
+      "collectionName": "GOLDEN☆BEST 村下孝蔵ベスト・セレクト・ソングズ",
+      "itunesTrackId": 1536742023,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:59:10+09:00"
+  },
+  {
+    "title": "愛が生まれた日",
+    "artist": "藤谷美和子・大内義昭",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:59:11+09:00"
+  },
+  {
+    "title": "100万回の「I love you」",
+    "artist": "Rake",
+    "metadata": {
+      "releaseDate": "2011-03-09",
+      "releaseYear": 2011,
+      "decade": "2010年代",
+      "genre": "ロック",
+      "durationSeconds": 241,
+      "collectionName": "100万回の「I love you」 - EP",
+      "itunesTrackId": 1535810514,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:59:13+09:00"
+  },
+  {
+    "title": "ベイビー・アイラブユー",
+    "artist": "TEE",
+    "metadata": {
+      "releaseDate": "2010-10-27",
+      "releaseYear": 2010,
+      "decade": "2010年代",
+      "genre": "ポップ",
+      "durationSeconds": 305,
+      "collectionName": "Kido I Raku",
+      "itunesTrackId": 1443277802,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:59:14+09:00"
+  },
+  {
+    "title": "ウィアートル",
+    "artist": "rionos",
+    "metadata": {
+      "releaseDate": "2018-02-24",
+      "releaseYear": 2018,
+      "decade": "2010年代",
+      "genre": "アニメ",
+      "durationSeconds": 287,
+      "collectionName": "映画『さよならの朝に約束の花をかざろう』オリジナルサウンドトラック",
+      "itunesTrackId": 1857550678,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:59:16+09:00"
+  },
+  {
+    "title": "夢花火",
+    "artist": "Novelbright",
+    "metadata": {
+      "releaseDate": "2020-05-10",
+      "releaseYear": 2020,
+      "decade": "2020年代",
+      "genre": "ロック",
+      "durationSeconds": 258,
+      "collectionName": "WONDERLAND",
+      "itunesTrackId": 1509874088,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:59:17+09:00"
+  },
+  {
+    "title": "今日という日を",
+    "artist": "Uru",
+    "metadata": {
+      "releaseDate": "2026-02-09",
+      "releaseYear": 2026,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 278,
+      "collectionName": "今日という日を - Single",
+      "itunesTrackId": 1871116827,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:59:19+09:00"
+  },
+  {
+    "title": "じょいふる",
+    "artist": "いきものがかり",
+    "metadata": {
+      "releaseDate": "2009-09-23",
+      "releaseYear": 2009,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 199,
+      "collectionName": "YELL/じょいふる - EP",
+      "itunesTrackId": 1536258195,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:59:20+09:00"
+  },
+  {
+    "title": "愛人",
+    "artist": "テレサ・テン",
+    "metadata": {
+      "releaseDate": "1985-03-01",
+      "releaseYear": 1985,
+      "decade": "1980年代",
+      "genre": "J-Pop",
+      "durationSeconds": 225,
+      "collectionName": "テレサ・テン 40/40 ~ベスト・セレクション",
+      "itunesTrackId": 1440657324,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:59:22+09:00"
+  },
+  {
+    "title": "Sign",
+    "artist": "Mr.Children",
+    "metadata": {
+      "releaseDate": "2004-05-26",
+      "releaseYear": 2004,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 322,
+      "collectionName": "I ♥ U",
+      "itunesTrackId": 1374928853,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:59:23+09:00"
+  },
+  {
+    "title": "ごはん食べヨ",
+    "artist": "Mega Shinnosuke",
+    "metadata": {
+      "releaseDate": "2025-10-08",
+      "releaseYear": 2025,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 188,
+      "collectionName": "ごはん食べヨ - Single",
+      "itunesTrackId": 1843292478,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:59:25+09:00"
+  },
+  {
+    "title": "星降る海",
+    "artist": "月見ヤチヨ(CV.早見沙織)",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:59:26+09:00"
+  },
+  {
+    "title": "ray",
+    "artist": "BUMP OF CHICKEN",
+    "metadata": {
+      "releaseDate": "2014-03-12",
+      "releaseYear": 2014,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 301,
+      "collectionName": "RAY",
+      "itunesTrackId": 1464635122,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:59:28+09:00"
+  },
+  {
+    "title": "勇者王誕生!",
+    "artist": "遠藤正明",
+    "metadata": {
+      "releaseDate": "1997-02-21",
+      "releaseYear": 1997,
+      "decade": "1990年代",
+      "genre": "アニメ",
+      "durationSeconds": 236,
+      "collectionName": "「勇者王ガオガイガー」オープニングテーマ 勇者王誕生! - Single",
+      "itunesTrackId": 1535175166,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:59:29+09:00"
+  },
+  {
+    "title": "Beautiful World",
+    "artist": "宇多田ヒカル",
+    "metadata": {
+      "releaseDate": "2007-08-29",
+      "releaseYear": 2007,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 317,
+      "collectionName": "Utada Hikaru Single Collection Vol.2 (2014 Remastered)",
+      "itunesTrackId": 1440747562,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:59:30+09:00"
+  },
+  {
+    "title": "輝きは君の中に",
+    "artist": "鈴木結女",
+    "metadata": {
+      "releaseDate": "1995-05-19",
+      "releaseYear": 1995,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 278,
+      "collectionName": "SINGLES & MORE",
+      "itunesTrackId": 1835392997,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:59:32+09:00"
+  },
+  {
+    "title": "僕らの戦場",
+    "artist": "ワルキューレ",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:59:33+09:00"
+  },
+  {
+    "title": "15の夜",
+    "artist": "尾崎豊",
+    "metadata": {
+      "releaseDate": "1983-12-01",
+      "releaseYear": 1983,
+      "decade": "1980年代",
+      "genre": "ロック",
+      "durationSeconds": 331,
+      "collectionName": "SATURDAY〜ROCK'N'ROLL BEST OF YUTAKA OZAKI",
+      "itunesTrackId": 1537396266,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:59:35+09:00"
+  },
+  {
+    "title": "駅",
+    "artist": "中森明菜 / 竹内まりや(Self Cover)",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:59:36+09:00"
+  },
+  {
+    "title": "桜流し",
+    "artist": "宇多田ヒカル",
+    "metadata": {
+      "releaseDate": "2012-11-17",
+      "releaseYear": 2012,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 281,
+      "collectionName": "Fantôme",
+      "itunesTrackId": 1428769931,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:59:38+09:00"
+  },
+  {
+    "title": "TOMORROW",
+    "artist": "BISH",
+    "metadata": {
+      "releaseDate": "2020-04-13",
+      "releaseYear": 2020,
+      "decade": "2020年代",
+      "genre": "ロック",
+      "durationSeconds": 222,
+      "collectionName": "TOMORROW - Single",
+      "itunesTrackId": 1506752177,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:59:39+09:00"
+  },
+  {
+    "title": "希望の轍",
+    "artist": "サザンオールスターズ",
+    "metadata": {
+      "releaseDate": "1990-09-01",
+      "releaseYear": 1990,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 255,
+      "collectionName": "海のYeah!!",
+      "itunesTrackId": 949272139,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:59:41+09:00"
+  },
+  {
+    "title": "RIDE ON TIME",
+    "artist": "山下達郎",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:59:42+09:00"
+  },
+  {
+    "title": "バレッタ",
+    "artist": "乃木坂46",
+    "metadata": {
+      "releaseDate": "2013-11-27",
+      "releaseYear": 2013,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 260,
+      "collectionName": "バレッタ TypeA - EP",
+      "itunesTrackId": 1537524739,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:59:43+09:00"
+  },
+  {
+    "title": "Never Ending World",
+    "artist": "SEKAI NO OWARI",
+    "metadata": {
+      "releaseDate": "2011-08-17",
+      "releaseYear": 2011,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 269,
+      "collectionName": "ENTERTAINMENT",
+      "itunesTrackId": 984426760,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:59:45+09:00"
+  },
+  {
+    "title": "水流のロック",
+    "artist": "日食なつこ",
+    "metadata": {
+      "releaseDate": "2014-08-19",
+      "releaseYear": 2014,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 181,
+      "collectionName": "逆光で見えない",
+      "itunesTrackId": 1564444819,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:59:46+09:00"
+  },
+  {
+    "title": "Ti Amo",
+    "artist": "Exile",
+    "metadata": {
+      "releaseDate": "2008-09-24",
+      "releaseYear": 2008,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 346,
+      "collectionName": "The Birthday ~Ti Amo~",
+      "itunesTrackId": 1014857750,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:59:48+09:00"
+  },
+  {
+    "title": "思秋期",
+    "artist": "岩崎宏美",
+    "metadata": {
+      "releaseDate": "1977-09-05",
+      "releaseYear": 1977,
+      "decade": "1970年代",
+      "genre": "歌謡曲",
+      "durationSeconds": 257,
+      "collectionName": "思秋期 (Original Cover Art) - Single",
+      "itunesTrackId": 219108110,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:59:49+09:00"
+  },
+  {
+    "title": "また君に恋してる",
+    "artist": "ビリーバンバン / 坂本冬美(Cover)",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:59:51+09:00"
+  },
+  {
+    "title": "まなざしは光",
+    "artist": "キタニタツヤ",
+    "metadata": {
+      "releaseDate": "2025-07-06",
+      "releaseYear": 2025,
+      "decade": "2020年代",
+      "genre": "オルタナティブ",
+      "durationSeconds": 207,
+      "collectionName": "まなざしは光 - Single",
+      "itunesTrackId": 1822254657,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:59:52+09:00"
+  },
+  {
+    "title": "名前のない怪物",
+    "artist": "EGOIST",
+    "metadata": {
+      "releaseDate": "2012-12-05",
+      "releaseYear": 2012,
+      "decade": "2010年代",
+      "genre": "アニメ",
+      "durationSeconds": 317,
+      "collectionName": "名前のない怪物",
+      "itunesTrackId": 1537444998,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:59:54+09:00"
+  },
+  {
+    "title": "つぐない",
+    "artist": "テレサ・テン",
+    "metadata": {
+      "releaseDate": "1984-01-21",
+      "releaseYear": 1984,
+      "decade": "1980年代",
+      "genre": "J-Pop",
+      "durationSeconds": 230,
+      "collectionName": "テレサ・テン 40/40 ~ベスト・セレクション",
+      "itunesTrackId": 1440657322,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T19:59:59+09:00"
+  },
+  {
+    "title": "怪物",
+    "artist": "YOASOBI",
+    "metadata": {
+      "releaseDate": "2021-01-06",
+      "releaseYear": 2021,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 206,
+      "collectionName": "怪物 - Single",
+      "itunesTrackId": 1544083979,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T20:00:01+09:00"
+  },
+  {
+    "title": "only my railgun",
+    "artist": "fripSide",
+    "metadata": {
+      "releaseDate": "2009-11-04",
+      "releaseYear": 2009,
+      "decade": "2000年代",
+      "genre": "アニメ",
+      "durationSeconds": 254,
+      "collectionName": "infinite synthesis",
+      "itunesTrackId": 1804662307,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T20:00:02+09:00"
+  },
+  {
+    "title": "甲賀忍法帖",
+    "artist": "陰陽座",
+    "metadata": {
+      "releaseDate": "2005-04-27",
+      "releaseYear": 2005,
+      "decade": "2000年代",
+      "genre": "メタル",
+      "durationSeconds": 242,
+      "collectionName": "甲賀忍法帖 - Single",
+      "itunesTrackId": 537847103,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T20:00:04+09:00"
+  },
+  {
+    "title": "明日へのbrilliant road",
+    "artist": "angela",
+    "metadata": {
+      "releaseDate": "2003-05-21",
+      "releaseYear": 2003,
+      "decade": "2000年代",
+      "genre": "アニメ",
+      "durationSeconds": 300,
+      "collectionName": "宝箱 -TREASURE BOX-",
+      "itunesTrackId": 270010825,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T20:00:05+09:00"
+  },
+  {
+    "title": "1/6の夢旅人2002",
+    "artist": "樋口了一",
+    "metadata": {
+      "releaseDate": "2003-01-01",
+      "releaseYear": 2003,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 237,
+      "collectionName": "1/6の夢旅人2002",
+      "itunesTrackId": 261733307,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T20:00:07+09:00"
+  },
+  {
+    "title": "思いがかさなるその前に…",
+    "artist": "平井堅",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T20:00:08+09:00"
+  },
+  {
+    "title": "AXIA～ダイスキでダイキライ～",
+    "artist": "ワルキューレ",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T20:00:09+09:00"
+  },
+  {
+    "title": "愛の讃歌",
+    "artist": "エディット・ピアフ",
+    "metadata": {
+      "releaseDate": "1990-09-30",
+      "releaseYear": 1990,
+      "decade": "1990年代",
+      "genre": "ワールド",
+      "durationSeconds": 206,
+      "collectionName": "ベスト・オブ・シャンソン ~ばら色の人生~",
+      "itunesTrackId": 793704774,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T20:00:11+09:00"
+  },
+  {
+    "title": "Good-bye days",
+    "artist": "YUI for 雨音薫",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T20:00:12+09:00"
+  },
+  {
+    "title": "冬の花",
+    "artist": "宮本浩次",
+    "metadata": {
+      "releaseDate": "2019-02-12",
+      "releaseYear": 2019,
+      "decade": "2010年代",
+      "genre": "ロック",
+      "durationSeconds": 241,
+      "collectionName": "冬の花 - Single",
+      "itunesTrackId": 1451684198,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T20:00:14+09:00"
+  },
+  {
+    "title": "夜の踊り子",
+    "artist": "サカナクション",
+    "metadata": {
+      "releaseDate": "2012-08-29",
+      "releaseYear": 2012,
+      "decade": "2010年代",
+      "genre": "ロック",
+      "durationSeconds": 302,
+      "collectionName": "夜の踊り子",
+      "itunesTrackId": 552294051,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T20:00:15+09:00"
+  },
+  {
+    "title": "銀河街の悪夢",
+    "artist": "SEKAI NO OWARI",
+    "metadata": {
+      "releaseDate": "2014-01-22",
+      "releaseYear": 2014,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 383,
+      "collectionName": "Tree",
+      "itunesTrackId": 955796432,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T20:00:17+09:00"
+  },
+  {
+    "title": "異邦人",
+    "artist": "久保田早紀",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T20:00:18+09:00"
+  },
+  {
+    "title": "サヨナラバス",
+    "artist": "ゆず",
+    "metadata": {
+      "releaseDate": "1999-03-17",
+      "releaseYear": 1999,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 224,
+      "collectionName": "ゆずえん",
+      "itunesTrackId": 422248325,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T20:00:20+09:00"
+  },
+  {
+    "title": "紫陽花",
+    "artist": "PEOPLE 1",
+    "metadata": {
+      "releaseDate": "2022-06-29",
+      "releaseYear": 2022,
+      "decade": "2020年代",
+      "genre": "ロック",
+      "durationSeconds": 237,
+      "collectionName": "紫陽花 - Single",
+      "itunesTrackId": 1629869309,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T20:00:21+09:00"
+  },
+  {
+    "title": "夜桜お七",
+    "artist": "坂本冬美",
+    "metadata": {
+      "releaseDate": "2009-12-02",
+      "releaseYear": 2009,
+      "decade": "2000年代",
+      "genre": "歌謡曲",
+      "durationSeconds": 323,
+      "collectionName": "道 ~デラックス盤~",
+      "itunesTrackId": 1439283144,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T20:00:22+09:00"
+  },
+  {
+    "title": "me me she",
+    "artist": "RADWIMPS",
+    "metadata": {
+      "releaseDate": "2006-12-06",
+      "releaseYear": 2006,
+      "decade": "2000年代",
+      "genre": "ロック",
+      "durationSeconds": 281,
+      "collectionName": "RADWIMPS 4 ~おかずのごはん~",
+      "itunesTrackId": 1511080485,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T20:00:24+09:00"
+  },
+  {
+    "title": "いい日旅立ち",
+    "artist": "山口百恵",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T20:00:25+09:00"
+  },
+  {
+    "title": "Five",
+    "artist": "嵐",
+    "metadata": {
+      "releaseDate": "2026-03-04",
+      "releaseYear": 2026,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 268,
+      "collectionName": "Five - Single",
+      "itunesTrackId": 1879525016,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T20:00:27+09:00"
+  },
+  {
+    "title": "少女A",
+    "artist": "中森明菜",
+    "metadata": {
+      "releaseDate": "1982-07-28",
+      "releaseYear": 1982,
+      "decade": "1980年代",
+      "genre": "J-Pop",
+      "durationSeconds": 214,
+      "collectionName": "AKINA BOX",
+      "itunesTrackId": 256803586,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T20:00:28+09:00"
+  },
+  {
+    "title": "ウミユリ海底譚",
+    "artist": "n-buna",
+    "metadata": {
+      "releaseDate": "2014-04-26",
+      "releaseYear": 2014,
+      "decade": "2010年代",
+      "genre": "アニメ",
+      "durationSeconds": 237,
+      "collectionName": "カーテンコールが止む前に",
+      "itunesTrackId": 1672217866,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T20:00:30+09:00"
+  },
+  {
+    "title": "朝顔",
+    "artist": "折坂悠太",
+    "metadata": {
+      "releaseDate": "2019-08-04",
+      "releaseYear": 2019,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 337,
+      "collectionName": "朝顔 - EP",
+      "itunesTrackId": 1554822811,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T20:00:31+09:00"
+  },
+  {
+    "title": "マーメイドラプソディー",
+    "artist": "SEKAI NO OWARI",
+    "metadata": {
+      "releaseDate": "2015-01-14",
+      "releaseYear": 2015,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 320,
+      "collectionName": "Tree",
+      "itunesTrackId": 955796412,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T20:00:33+09:00"
+  },
+  {
+    "title": "炎と森のカーニバル",
+    "artist": "SEKAI NO OWARI",
+    "metadata": {
+      "releaseDate": "2014-04-09",
+      "releaseYear": 2014,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 298,
+      "collectionName": "Tree",
+      "itunesTrackId": 955796389,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T20:00:34+09:00"
+  },
+  {
+    "title": "Habit",
+    "artist": "SEKAI NO OWARI",
+    "metadata": {
+      "releaseDate": "2022-06-22",
+      "releaseYear": 2022,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 253,
+      "collectionName": "Habit - Single",
+      "itunesTrackId": 1618345214,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T20:00:35+09:00"
+  },
+  {
+    "title": "虹色の戦争",
+    "artist": "SEKAI NO OWARI",
+    "metadata": {
+      "releaseDate": "2010-04-07",
+      "releaseYear": 2010,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 337,
+      "collectionName": "EARTH",
+      "itunesTrackId": 1447614089,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T20:00:37+09:00"
+  },
+  {
+    "title": "風と町",
+    "artist": "Mrs. GREEN APPLE",
+    "metadata": {
+      "releaseDate": "2026-04-13",
+      "releaseYear": 2026,
+      "decade": "2020年代",
+      "genre": "ロック",
+      "durationSeconds": 219,
+      "collectionName": "風と町 - Single",
+      "itunesTrackId": 1891943326,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T20:00:38+09:00"
+  },
+  {
+    "title": "ビーナスベルト",
+    "artist": "あいみょん",
+    "metadata": {
+      "releaseDate": "2025-10-22",
+      "releaseYear": 2025,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 330,
+      "collectionName": "ビーナスベルト - EP",
+      "itunesTrackId": 1838374870,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T20:00:40+09:00"
+  },
+  {
+    "title": "Tomorrow never knows",
+    "artist": "Mr.Children",
+    "metadata": {
+      "releaseDate": "1994-11-10",
+      "releaseYear": 1994,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 308,
+      "collectionName": "Tomorrow never knows - Single",
+      "itunesTrackId": 1374950946,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T20:00:41+09:00"
+  },
+  {
+    "title": "秒針を噛む",
+    "artist": "ずっと真夜中でいいのに。",
+    "metadata": {
+      "releaseDate": "2018-06-04",
+      "releaseYear": 2018,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 259,
+      "collectionName": "秒針を噛む - Single",
+      "itunesTrackId": 1428083880,
+      "matchStatus": "needs_review",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T20:00:43+09:00"
+  },
+  {
+    "title": "ぼくたちの失敗",
+    "artist": "森田童子",
+    "metadata": {
+      "releaseDate": "1976-11-21",
+      "releaseYear": 1976,
+      "decade": "1970年代",
+      "genre": "J-Pop",
+      "durationSeconds": 202,
+      "collectionName": "ぼくたちの失敗 森田童子ベストコレクション",
+      "itunesTrackId": 1439290787,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T20:00:44+09:00"
+  },
+  {
+    "title": "ピタゴラスイッチ オープニングテーマ",
+    "artist": "栗原正己",
+    "metadata": {
+      "releaseDate": "2010-08-18",
+      "releaseYear": 2010,
+      "decade": "2010年代",
+      "genre": "ミュージック",
+      "durationSeconds": 32,
+      "collectionName": "ピタゴラスイッチ うたのCD",
+      "itunesTrackId": 939159964,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T20:00:46+09:00"
+  },
+  {
+    "title": "RE:I AM",
+    "artist": "Aimer",
+    "metadata": {
+      "releaseDate": "2013-03-20",
+      "releaseYear": 2013,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 348,
+      "collectionName": "RE:I AM EP",
+      "itunesTrackId": 1536126125,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T20:00:47+09:00"
+  },
+  {
+    "title": "Wild Flowers",
+    "artist": "RAMAR",
+    "metadata": {
+      "releaseDate": "2009-09-16",
+      "releaseYear": 2009,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 274,
+      "collectionName": "BRIDGE -RAMAR THE BEST!!-",
+      "itunesTrackId": 345885292,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T20:00:49+09:00"
+  },
+  {
+    "title": "涙そうそう",
+    "artist": "森山良子 / 夏川りみ(Cover)",
+    "metadata": {
+      "releaseDate": null,
+      "releaseYear": null,
+      "decade": null,
+      "genre": null,
+      "durationSeconds": null,
+      "collectionName": null,
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T20:00:50+09:00"
+  },
+  {
+    "title": "春に舞う",
+    "artist": "Ado",
+    "metadata": {
+      "releaseDate": "2026-05-12",
+      "releaseYear": 2026,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 238,
+      "collectionName": "春に舞う - Single",
+      "itunesTrackId": 6766202664,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T20:00:52+09:00"
+  },
+  {
+    "title": "パッパパラダイス",
+    "artist": "宇多田ヒカル",
+    "metadata": {
+      "releaseDate": "2026-05-06",
+      "releaseYear": 2026,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 231,
+      "collectionName": "パッパパラダイス - Single",
+      "itunesTrackId": 1886240225,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T20:00:59+09:00"
+  },
+  {
+    "title": "あぶく",
+    "artist": "ヨルシカ",
+    "metadata": {
+      "releaseDate": "2026-04-22",
+      "releaseYear": 2026,
+      "decade": "2020年代",
+      "genre": "オルタナティブ",
+      "durationSeconds": 235,
+      "collectionName": "あぶく - Single",
+      "itunesTrackId": 1889425904,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T20:01:01+09:00"
+  },
+  {
+    "title": "アイドルパワー",
+    "artist": "M!LK",
+    "metadata": {
+      "releaseDate": "2026-04-27",
+      "releaseYear": 2026,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 230,
+      "collectionName": "アイドルパワー - Single",
+      "itunesTrackId": 6762737233,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T20:01:02+09:00"
+  },
+  {
+    "title": "スターダスト",
+    "artist": "Official髭男dism",
+    "metadata": {
+      "releaseDate": "2026-04-13",
+      "releaseYear": 2026,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 289,
+      "collectionName": "スターダスト - Single",
+      "itunesTrackId": 1887793931,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T20:01:04+09:00"
+  },
+  {
+    "title": "One Love",
+    "artist": "嵐",
+    "metadata": {
+      "releaseDate": "2008-06-25",
+      "releaseYear": 2008,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 285,
+      "collectionName": "One Love - Single",
+      "itunesTrackId": 1485847813,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T20:01:05+09:00"
+  },
+  {
+    "title": "果てない空",
+    "artist": "嵐",
+    "metadata": {
+      "releaseDate": "2010-11-10",
+      "releaseYear": 2010,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 265,
+      "collectionName": "果てない空 - Single",
+      "itunesTrackId": 1485849202,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T20:01:06+09:00"
+  },
+  {
+    "title": "炎のさだめ",
+    "artist": "TETSU",
+    "metadata": {
+      "releaseDate": "1983-01-01",
+      "releaseYear": 1983,
+      "decade": "1980年代",
+      "genre": "TV サウンドトラック",
+      "durationSeconds": 200,
+      "collectionName": "装甲騎兵ボトムズ TV版 オリジナル・サウンドトラック 総音楽集",
+      "itunesTrackId": 1554454566,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T20:01:08+09:00"
+  },
+  {
+    "title": "Who What Who What",
+    "artist": "凛として時雨",
+    "metadata": {
+      "releaseDate": "2015-01-14",
+      "releaseYear": 2015,
+      "decade": "2010年代",
+      "genre": "ロック",
+      "durationSeconds": 222,
+      "collectionName": "Who What Who What - Single",
+      "itunesTrackId": 1535617938,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T20:01:09+09:00"
+  },
+  {
+    "title": "誰かの願いが叶うころ",
+    "artist": "宇多田ヒカル",
+    "metadata": {
+      "releaseDate": "2004-04-21",
+      "releaseYear": 2004,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 268,
+      "collectionName": "Utada Hikaru Single Collection Vol.2 (2014 Remastered)",
+      "itunesTrackId": 1440747924,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T20:01:11+09:00"
+  },
+  {
+    "title": "いきどまり",
+    "artist": "星野源",
+    "metadata": {
+      "releaseDate": "2025-11-14",
+      "releaseYear": 2025,
+      "decade": "2020年代",
+      "genre": "オルタナティブ",
+      "durationSeconds": 167,
+      "collectionName": "いきどまり - Single",
+      "itunesTrackId": 1851939757,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T20:01:12+09:00"
+  },
+  {
+    "title": "巡ループ",
+    "artist": "Perfume",
+    "metadata": {
+      "releaseDate": "2025-07-10",
+      "releaseYear": 2025,
+      "decade": "2020年代",
+      "genre": "エレクトロニック",
+      "durationSeconds": 252,
+      "collectionName": "巡ループ - Single",
+      "itunesTrackId": 1823905372,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T20:01:13+09:00"
+  },
+  {
+    "title": "Part of me",
+    "artist": "Mrs. GREEN APPLE",
+    "metadata": {
+      "releaseDate": "2022-07-07",
+      "releaseYear": 2022,
+      "decade": "2020年代",
+      "genre": "ロック",
+      "durationSeconds": 333,
+      "collectionName": "Unity - EP",
+      "itunesTrackId": 1627629634,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T20:01:15+09:00"
+  },
+  {
+    "title": "プレゼント",
+    "artist": "マルシィ",
+    "metadata": {
+      "releaseDate": "2024-09-25",
+      "releaseYear": 2024,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 249,
+      "collectionName": "プレゼント - Single",
+      "itunesTrackId": 1767743853,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T20:01:16+09:00"
+  },
+  {
+    "title": "ラブソング",
+    "artist": "マルシィ",
+    "metadata": {
+      "releaseDate": "2023-11-15",
+      "releaseYear": 2023,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 257,
+      "collectionName": "ラブソング - Single",
+      "itunesTrackId": 1706253735,
+      "matchStatus": "auto_matched",
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T20:01:18+09:00"
+  }
+]

--- a/nemupipiano-musiclist-search/data/dictionary/music_metadata.json
+++ b/nemupipiano-musiclist-search/data/dictionary/music_metadata.json
@@ -11,7 +11,11 @@
       "collectionName": "偽物語 劇伴音楽集",
       "itunesTrackId": 1535798069,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -32,14 +36,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:36:56+09:00"
+    "generatedAt": "2026-06-27T21:07:31+09:00"
   },
   {
     "title": "キセキ",
@@ -53,7 +63,11 @@
       "collectionName": "いままでのA面、B面ですと!?",
       "itunesTrackId": 1440746936,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -74,7 +88,11 @@
       "collectionName": "コネクト - EP",
       "itunesTrackId": 1537241619,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -95,7 +113,11 @@
       "collectionName": "壱",
       "itunesTrackId": 1599543187,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -108,43 +130,66 @@
     "title": "点描の唄",
     "artist": "Mrs. GREEN APPLE",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2018-07-31",
+      "releaseYear": 2018,
+      "decade": "2010年代",
+      "genre": "ロック",
+      "durationSeconds": 307,
+      "collectionName": "Summer Festival Japan 2022",
+      "itunesTrackId": 1636003243,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 10,
+      "candidateReleaseDates": [
+        "2018-07-31",
+        "2018-08-01",
+        "2019-10-02"
+      ],
+      "reviewReason": [
+        "multiple_release_dates",
+        "normalized_match",
+        "title_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:37:02+09:00"
+    "generatedAt": "2026-06-27T21:07:32+09:00"
   },
   {
     "title": "千本桜",
     "artist": "黒うさP",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2012-02-29",
+      "releaseYear": 2012,
+      "decade": "2010年代",
+      "genre": "ポップ",
+      "durationSeconds": 252,
+      "collectionName": "千本桜 (feat. 初音ミク) - Single",
+      "itunesTrackId": 505371452,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 3,
+      "candidateReleaseDates": [
+        "2012-02-29",
+        "2015-03-18"
+      ],
+      "reviewReason": [
+        "multiple_release_dates",
+        "normalized_match",
+        "title_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:37:03+09:00"
+    "generatedAt": "2026-06-27T21:07:33+09:00"
   },
   {
     "title": "群青",
@@ -158,7 +203,11 @@
       "collectionName": "群青 - Single",
       "itunesTrackId": 1528119630,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -179,7 +228,11 @@
       "collectionName": "ドライフラワー - Single",
       "itunesTrackId": 1534620183,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -200,7 +253,11 @@
       "collectionName": "春泥棒 - Single",
       "itunesTrackId": 1545098596,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -213,22 +270,32 @@
     "title": "DANDAN心惹かれてく",
     "artist": "FIELD OF VIEW",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "1997-10-08",
+      "releaseYear": 1997,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 214,
+      "collectionName": "Complete of Field of View - At the Being Studio",
+      "itunesTrackId": 77295564,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "override_exact",
+      "candidateCount": 2,
+      "candidateReleaseDates": [
+        "1997-10-08",
+        "2020-05-13"
+      ],
+      "reviewReason": [
+        "multiple_release_dates",
+        "search_override_used"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:37:09+09:00"
+    "generatedAt": "2026-06-27T21:07:36+09:00"
   },
   {
     "title": "夜空",
@@ -242,7 +309,11 @@
       "collectionName": "夜空 - Single",
       "itunesTrackId": 1611322200,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -255,43 +326,60 @@
     "title": "小さな恋の歌",
     "artist": "MONGOL800",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2001-09-16",
+      "releaseYear": 2001,
+      "decade": "2000年代",
+      "genre": "オルタナティブ",
+      "durationSeconds": 223,
+      "collectionName": "MESSAGE",
+      "itunesTrackId": 273169347,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "override_exact",
+      "candidateCount": 2,
+      "candidateReleaseDates": [
+        "2001-09-16"
+      ],
+      "reviewReason": [
+        "search_override_used"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:37:11+09:00"
+    "generatedAt": "2026-06-27T21:07:39+09:00"
   },
   {
     "title": "Rain",
     "artist": "秦基博",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2013-05-29",
+      "releaseYear": 2013,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 294,
+      "collectionName": "All Time Best ハタモトヒロ (はじめまして盤)",
+      "itunesTrackId": 1440866239,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 8,
+      "candidateReleaseDates": [
+        "2013-05-29"
+      ],
+      "reviewReason": [
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:37:13+09:00"
+    "generatedAt": "2026-06-27T21:07:40+09:00"
   },
   {
     "title": "晩餐歌",
@@ -305,14 +393,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:37:14+09:00"
+    "generatedAt": "2026-06-27T21:07:43+09:00"
   },
   {
     "title": "幾億光年",
@@ -326,7 +420,11 @@
       "collectionName": "幾億光年 - Single",
       "itunesTrackId": 1725229931,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -347,7 +445,11 @@
       "collectionName": "花と水飴、最終電車",
       "itunesTrackId": 1648869428,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -368,7 +470,11 @@
       "collectionName": "Memories",
       "itunesTrackId": 1596879565,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -389,7 +495,11 @@
       "collectionName": "花に亡霊 - Single",
       "itunesTrackId": 1506849814,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -410,7 +520,11 @@
       "collectionName": "Soranji - Single",
       "itunesTrackId": 1648865575,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -431,7 +545,11 @@
       "collectionName": "愛をこめて花束を - Single",
       "itunesTrackId": 273951740,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -452,7 +570,11 @@
       "collectionName": "First Love - EP",
       "itunesTrackId": 1445055008,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -473,14 +595,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:37:26+09:00"
+    "generatedAt": "2026-06-27T21:07:44+09:00"
   },
   {
     "title": "花束",
@@ -494,7 +622,11 @@
       "collectionName": "花束 - EP",
       "itunesTrackId": 1451565944,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -515,7 +647,11 @@
       "collectionName": "プロローグ",
       "itunesTrackId": 1538102603,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -536,7 +672,11 @@
       "collectionName": "君はロックを聴かない - EP",
       "itunesTrackId": 1261937430,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -557,14 +697,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:37:32+09:00"
+    "generatedAt": "2026-06-27T21:07:46+09:00"
   },
   {
     "title": "ありがとう",
@@ -578,7 +724,11 @@
       "collectionName": "ありがとう - Single",
       "itunesTrackId": 1536261286,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -599,7 +749,11 @@
       "collectionName": "strobo",
       "itunesTrackId": 1706832137,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -620,7 +774,11 @@
       "collectionName": "3月9日 - Single",
       "itunesTrackId": 1857509406,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -641,7 +799,11 @@
       "collectionName": "紅蓮華 - EP",
       "itunesTrackId": 1538286723,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -662,7 +824,11 @@
       "collectionName": "Mr.Children 2005 - 2010 <macro>",
       "itunesTrackId": 1374993073,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -675,43 +841,63 @@
     "title": "変わらないもの",
     "artist": "奥華子",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2007-09-19",
+      "releaseYear": 2007,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 285,
+      "collectionName": "ガーネット - EP",
+      "itunesTrackId": 262741521,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 4,
+      "candidateReleaseDates": [
+        "2007-09-19"
+      ],
+      "reviewReason": [
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:37:40+09:00"
+    "generatedAt": "2026-06-27T21:07:47+09:00"
   },
   {
     "title": "プラネタリウム",
     "artist": "大塚愛",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2005-09-21",
+      "releaseYear": 2005,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 307,
+      "collectionName": "LOVE COOK",
+      "itunesTrackId": 219766342,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 8,
+      "candidateReleaseDates": [
+        "2005-09-21",
+        "2019-01-01"
+      ],
+      "reviewReason": [
+        "multiple_release_dates",
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:37:41+09:00"
+    "generatedAt": "2026-06-27T21:07:49+09:00"
   },
   {
     "title": "晴る",
@@ -725,7 +911,11 @@
       "collectionName": "晴る - Single",
       "itunesTrackId": 1721450223,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -746,14 +936,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:37:44+09:00"
+    "generatedAt": "2026-06-27T21:07:50+09:00"
   },
   {
     "title": "CHA-LA HEAD-CHA-LA",
@@ -767,7 +963,11 @@
       "collectionName": "影山ヒロノブ POWER LIVE '98",
       "itunesTrackId": 435413360,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -788,7 +988,13 @@
       "collectionName": "残酷な天使のテーゼ - EP",
       "itunesTrackId": 258926790,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -809,7 +1015,11 @@
       "collectionName": "心得 - Single",
       "itunesTrackId": 1681691984,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -830,7 +1040,11 @@
       "collectionName": "水平線 - Single",
       "itunesTrackId": 1579439168,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -851,7 +1065,11 @@
       "collectionName": "テレビ朝日系アニメ「ドラえもん」主題歌 夢をかなえてドラえもん - EP",
       "itunesTrackId": 938553963,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -872,7 +1090,11 @@
       "collectionName": "勇者 - Single",
       "itunesTrackId": 1707001466,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -893,7 +1115,11 @@
       "collectionName": "My song  Your song",
       "itunesTrackId": 1536256935,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -914,14 +1140,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:38:05+09:00"
+    "generatedAt": "2026-06-27T21:07:53+09:00"
   },
   {
     "title": "ひぐらしの泣く頃にyou",
@@ -935,14 +1167,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:38:06+09:00"
+    "generatedAt": "2026-06-27T21:07:55+09:00"
   },
   {
     "title": "Story",
@@ -956,7 +1194,13 @@
       "collectionName": "MIC-AーHOLIC A.I.",
       "itunesTrackId": 1444118054,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -977,7 +1221,13 @@
       "collectionName": "サザンカ - Single",
       "itunesTrackId": 1338627153,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -998,7 +1248,11 @@
       "collectionName": "粉雪 - Single",
       "itunesTrackId": 1857510109,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -1011,43 +1265,63 @@
     "title": "虹",
     "artist": "菅田将暉",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2020-11-10",
+      "releaseYear": 2020,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 259,
+      "collectionName": "虹 - Single",
+      "itunesTrackId": 1537793754,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 2,
+      "candidateReleaseDates": [
+        "2020-11-10",
+        "2022-03-09"
+      ],
+      "reviewReason": [
+        "multiple_release_dates",
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:38:12+09:00"
+    "generatedAt": "2026-06-27T21:07:56+09:00"
   },
   {
     "title": "満ちてゆく",
     "artist": "藤井風",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2024-03-15",
+      "releaseYear": 2024,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 311,
+      "collectionName": "満ちてゆく - Single",
+      "itunesTrackId": 1733130377,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 6,
+      "candidateReleaseDates": [
+        "2024-03-15"
+      ],
+      "reviewReason": [
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:38:13+09:00"
+    "generatedAt": "2026-06-27T21:07:57+09:00"
   },
   {
     "title": "少女レイ",
@@ -1061,7 +1335,13 @@
       "collectionName": "EXIT TUNES PRESENTS Vocaloseasons feat.初音ミク~Summer~",
       "itunesTrackId": 1408577702,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -1082,7 +1362,11 @@
       "collectionName": "ふゆびより(TVアニメ「ゆるキャン△」EDテーマ) - EP",
       "itunesTrackId": 1329451871,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -1095,22 +1379,31 @@
     "title": "雪の華",
     "artist": "中島美嘉",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2003-10-01",
+      "releaseYear": 2003,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 342,
+      "collectionName": "LOVE",
+      "itunesTrackId": 1535484288,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 5,
+      "candidateReleaseDates": [
+        "2003-10-01"
+      ],
+      "reviewReason": [
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:38:17+09:00"
+    "generatedAt": "2026-06-27T21:07:58+09:00"
   },
   {
     "title": "Butter-Fly",
@@ -1124,7 +1417,11 @@
       "collectionName": "Butter-Fly - EP",
       "itunesTrackId": 520527998,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -1145,7 +1442,13 @@
       "collectionName": "僕のこと - EP",
       "itunesTrackId": 1445145789,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -1166,7 +1469,11 @@
       "collectionName": "ときめく恋と青春",
       "itunesTrackId": 1722220691,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -1187,7 +1494,11 @@
       "collectionName": "Subtitle - Single",
       "itunesTrackId": 1648108988,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -1200,22 +1511,31 @@
     "title": "アイノカタチ",
     "artist": "MISIA",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2018-08-22",
+      "releaseYear": 2018,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 266,
+      "collectionName": "アイノカタチ (feat. HIDE) - EP",
+      "itunesTrackId": 1538122206,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 2,
+      "candidateReleaseDates": [
+        "2018-08-22"
+      ],
+      "reviewReason": [
+        "normalized_match",
+        "title_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:38:24+09:00"
+    "generatedAt": "2026-06-27T21:07:59+09:00"
   },
   {
     "title": "糸",
@@ -1229,7 +1549,11 @@
       "collectionName": "命の別名 - Single",
       "itunesTrackId": 1654000188,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -1250,14 +1574,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:38:27+09:00"
+    "generatedAt": "2026-06-27T21:08:01+09:00"
   },
   {
     "title": "明日への扉",
@@ -1271,7 +1601,11 @@
       "collectionName": "THE COMPLETE COLLECTION OF I WiSH",
       "itunesTrackId": 1537055928,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -1292,7 +1626,11 @@
       "collectionName": "フリージア - EP",
       "itunesTrackId": 1535545650,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -1305,22 +1643,30 @@
     "title": "竈門炭治郎のうた",
     "artist": "椎名豪featuring中川奈美",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2019-08-30",
+      "releaseYear": 2019,
+      "decade": "2010年代",
+      "genre": "アニメ",
+      "durationSeconds": 329,
+      "collectionName": "竈門炭治郎のうた (feat. 中川奈美) - Single",
+      "itunesTrackId": 1535801835,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "override_exact",
+      "candidateCount": 1,
+      "candidateReleaseDates": [
+        "2019-08-30"
+      ],
+      "reviewReason": [
+        "search_override_used"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:38:31+09:00"
+    "generatedAt": "2026-06-27T21:08:03+09:00"
   },
   {
     "title": "クリスマスソング",
@@ -1334,7 +1680,11 @@
       "collectionName": "クリスマスソング - EP",
       "itunesTrackId": 1451567627,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -1355,7 +1705,11 @@
       "collectionName": "FRIENDS",
       "itunesTrackId": 75353680,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -1376,7 +1730,11 @@
       "collectionName": "ライラック - Single",
       "itunesTrackId": 1739088799,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -1397,7 +1755,11 @@
       "collectionName": "それを愛と呼ぶなら - EP",
       "itunesTrackId": 1618736429,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -1418,56 +1780,82 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:38:37+09:00"
+    "generatedAt": "2026-06-27T21:08:06+09:00"
   },
   {
     "title": "ガーネット",
     "artist": "奥華子",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2007-09-19",
+      "releaseYear": 2007,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 319,
+      "collectionName": "ガーネット - EP",
+      "itunesTrackId": 262741525,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 3,
+      "candidateReleaseDates": [
+        "2007-09-19",
+        "2012-10-17"
+      ],
+      "reviewReason": [
+        "multiple_release_dates",
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:38:39+09:00"
+    "generatedAt": "2026-06-27T21:08:07+09:00"
   },
   {
     "title": "僕が死のうと思ったのは",
     "artist": "中島美嘉",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2013-08-28",
+      "releaseYear": 2013,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 383,
+      "collectionName": "僕が死のうと思ったのは - EP",
+      "itunesTrackId": 1535532901,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 5,
+      "candidateReleaseDates": [
+        "2013-08-28"
+      ],
+      "reviewReason": [
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:38:40+09:00"
+    "generatedAt": "2026-06-27T21:08:08+09:00"
   },
   {
     "title": "アルジャーノン",
@@ -1481,7 +1869,11 @@
       "collectionName": "アルジャーノン - Single",
       "itunesTrackId": 1667187095,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -1502,7 +1894,11 @@
       "collectionName": "おジャ魔女どれみ Select Best",
       "itunesTrackId": 1537920834,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -1523,7 +1919,11 @@
       "collectionName": "ヒロイン - EP",
       "itunesTrackId": 1451566361,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -1544,14 +1944,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:38:46+09:00"
+    "generatedAt": "2026-06-27T21:08:10+09:00"
   },
   {
     "title": "Pretender",
@@ -1565,7 +1971,11 @@
       "collectionName": "Pretender - Single",
       "itunesTrackId": 1459216694,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -1586,7 +1996,11 @@
       "collectionName": "ハルカ - Single",
       "itunesTrackId": 1541851056,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -1607,7 +2021,13 @@
       "collectionName": "SINGLES 2000-2003",
       "itunesTrackId": 1440627637,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -1628,7 +2048,13 @@
       "collectionName": "innocent world - Single",
       "itunesTrackId": 1374883461,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -1649,14 +2075,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:38:53+09:00"
+    "generatedAt": "2026-06-27T21:08:12+09:00"
   },
   {
     "title": "366日",
@@ -1670,7 +2102,11 @@
       "collectionName": "HeartY",
       "itunesTrackId": 297313686,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -1691,7 +2127,13 @@
       "collectionName": "ハチミツ",
       "itunesTrackId": 1440746483,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -1704,22 +2146,33 @@
     "title": "手紙～拝啓十五の君へ～",
     "artist": "アンジェラ・アキ",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2006-02-08",
+      "releaseYear": 2006,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 310,
+      "collectionName": "TAPESTRY OF SONGS  -THE BEST OF ANGELA AKI",
+      "itunesTrackId": 1536270693,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 4,
+      "candidateReleaseDates": [
+        "2006-02-08",
+        "2009-02-25"
+      ],
+      "reviewReason": [
+        "multiple_release_dates",
+        "normalized_match",
+        "title_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:39:02+09:00"
+    "generatedAt": "2026-06-27T21:08:13+09:00"
   },
   {
     "title": "明日への手紙",
@@ -1733,7 +2186,11 @@
       "collectionName": "Ren'dez-vous",
       "itunesTrackId": 896503389,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -1754,7 +2211,13 @@
       "collectionName": "かわいいだけじゃだめですか? - Single",
       "itunesTrackId": 1804686037,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -1775,7 +2238,13 @@
       "collectionName": "もしもピアノが弾けたなら / いい夢みろよ BESTタッグ - Single",
       "itunesTrackId": 1607991583,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -1796,7 +2265,11 @@
       "collectionName": "桜の木の下",
       "itunesTrackId": 1109978637,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -1817,7 +2290,13 @@
       "collectionName": "黄金の心",
       "itunesTrackId": 1442519987,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -1838,7 +2317,11 @@
       "collectionName": "手紙 - Single",
       "itunesTrackId": 1451566889,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -1859,7 +2342,13 @@
       "collectionName": "SAKURA - EP",
       "itunesTrackId": 1536229540,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -1880,7 +2369,11 @@
       "collectionName": "more than words - EP",
       "itunesTrackId": 1702627144,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -1901,7 +2394,11 @@
       "collectionName": "ダーリン - EP",
       "itunesTrackId": 1790599512,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -1922,7 +2419,11 @@
       "collectionName": "人間開花",
       "itunesTrackId": 1518845612,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -1935,22 +2436,31 @@
     "title": "きらり",
     "artist": "藤井風",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2021-05-21",
+      "releaseYear": 2021,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 232,
+      "collectionName": "きらり - Single",
+      "itunesTrackId": 1564752145,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 16,
+      "candidateReleaseDates": [
+        "2021-05-21"
+      ],
+      "reviewReason": [
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:39:18+09:00"
+    "generatedAt": "2026-06-27T21:08:14+09:00"
   },
   {
     "title": "眠り姫",
@@ -1964,7 +2474,11 @@
       "collectionName": "ENTERTAINMENT",
       "itunesTrackId": 984426767,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -1985,7 +2499,11 @@
       "collectionName": "Lemon - Single",
       "itunesTrackId": 1537460612,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -2006,7 +2524,11 @@
       "collectionName": "カーテンコール - Single",
       "itunesTrackId": 1754899924,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -2027,7 +2549,11 @@
       "collectionName": "シルエット - Single",
       "itunesTrackId": 1536455325,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -2048,7 +2574,11 @@
       "collectionName": "忘れてください - Single",
       "itunesTrackId": 1755182819,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -2069,7 +2599,11 @@
       "collectionName": "天気の子 (complete version) - EP",
       "itunesTrackId": 1518516245,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -2090,14 +2624,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:39:27+09:00"
+    "generatedAt": "2026-06-27T21:08:16+09:00"
   },
   {
     "title": "未来予想図Ⅱ",
@@ -2111,7 +2651,13 @@
       "collectionName": "LOVE GOES ON …",
       "itunesTrackId": 1536186630,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -2132,7 +2678,11 @@
       "collectionName": "ナハトムジーク - Single",
       "itunesTrackId": 1724293062,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -2153,7 +2703,13 @@
       "collectionName": "フェイクファー",
       "itunesTrackId": 1440649500,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -2174,14 +2730,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:39:33+09:00"
+    "generatedAt": "2026-06-27T21:08:18+09:00"
   },
   {
     "title": "なんでもないや",
@@ -2195,35 +2757,49 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:39:34+09:00"
+    "generatedAt": "2026-06-27T21:08:20+09:00"
   },
   {
     "title": "再会",
     "artist": "LiSA×Uru",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2020-11-16",
+      "releaseYear": 2020,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 242,
+      "collectionName": "再会 (produced by Ayase) - Single",
+      "itunesTrackId": 1537406658,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "override_exact",
+      "candidateCount": 1,
+      "candidateReleaseDates": [
+        "2020-11-16"
+      ],
+      "reviewReason": [
+        "search_override_used"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:39:36+09:00"
+    "generatedAt": "2026-06-27T21:08:23+09:00"
   },
   {
     "title": "グランドエスケープ",
@@ -2237,7 +2813,11 @@
       "collectionName": "FOREVER DAZE",
       "itunesTrackId": 1590786969,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -2258,7 +2838,11 @@
       "collectionName": "すずめの戸締まり",
       "itunesTrackId": 1651183709,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -2271,43 +2855,61 @@
     "title": "桜ノ雨",
     "artist": "halyosy",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2012-01-18",
+      "releaseYear": 2012,
+      "decade": "2010年代",
+      "genre": "アニメ",
+      "durationSeconds": 393,
+      "collectionName": "EXIT TUNES PRESENTS Vocaloseasons ~Spring~ (feat. 初音ミク)",
+      "itunesTrackId": 1368263298,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 1,
+      "candidateReleaseDates": [
+        "2012-01-18"
+      ],
+      "reviewReason": [
+        "normalized_match",
+        "title_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:39:40+09:00"
+    "generatedAt": "2026-06-27T21:08:24+09:00"
   },
   {
     "title": "弱虫モンブラン",
     "artist": "DECO*27",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2010-12-15",
+      "releaseYear": 2010,
+      "decade": "2010年代",
+      "genre": "アニメ",
+      "durationSeconds": 240,
+      "collectionName": "愛迷エレジー+",
+      "itunesTrackId": 573839774,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 3,
+      "candidateReleaseDates": [
+        "2010-12-15"
+      ],
+      "reviewReason": [
+        "normalized_match",
+        "title_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:39:42+09:00"
+    "generatedAt": "2026-06-27T21:08:25+09:00"
   },
   {
     "title": "空も飛べるはず",
@@ -2321,7 +2923,11 @@
       "collectionName": "CYCLE HIT 1991-1997 Spitz Complete Single Collection",
       "itunesTrackId": 1440863470,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -2334,22 +2940,31 @@
     "title": "忘れじの言の葉",
     "artist": "未来古代楽団",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2024-06-22",
+      "releaseYear": 2024,
+      "decade": "2020年代",
+      "genre": "ワールド",
+      "durationSeconds": 237,
+      "collectionName": "Forgotten Words 忘れじの言の葉 - EP",
+      "itunesTrackId": 1750878512,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 1,
+      "candidateReleaseDates": [
+        "2024-06-22"
+      ],
+      "reviewReason": [
+        "normalized_match",
+        "title_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:39:44+09:00"
+    "generatedAt": "2026-06-27T21:08:26+09:00"
   },
   {
     "title": "サヨナラの意味",
@@ -2363,7 +2978,11 @@
       "collectionName": "サヨナラの意味 - EP",
       "itunesTrackId": 1537463069,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -2384,14 +3003,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:39:47+09:00"
+    "generatedAt": "2026-06-27T21:08:28+09:00"
   },
   {
     "title": "マツケンサンバⅡ",
@@ -2405,7 +3030,11 @@
       "collectionName": "マツケン・サンバ Ⅱ",
       "itunesTrackId": 1805003595,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -2426,7 +3055,11 @@
       "collectionName": "SOUL QUEST",
       "itunesTrackId": 1558067865,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -2447,7 +3080,11 @@
       "collectionName": "ただ声一つ - Single",
       "itunesTrackId": 1599674592,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -2468,7 +3105,11 @@
       "collectionName": "歌物語 Special Edition",
       "itunesTrackId": 1535798235,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -2489,7 +3130,11 @@
       "collectionName": "夜に駆ける - Single",
       "itunesTrackId": 1490256995,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -2510,7 +3155,13 @@
       "collectionName": "青と夏 - EP",
       "itunesTrackId": 1408505264,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -2531,7 +3182,11 @@
       "collectionName": "ラブレター - Single",
       "itunesTrackId": 1579051058,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -2552,7 +3207,13 @@
       "collectionName": "たばこ - Single",
       "itunesTrackId": 1215143089,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -2573,7 +3234,11 @@
       "collectionName": "あたしだってLove song!",
       "itunesTrackId": 1563394275,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -2594,7 +3259,11 @@
       "collectionName": "群青日和 - Single",
       "itunesTrackId": 1444396093,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -2615,7 +3284,11 @@
       "collectionName": "40周年記念ベストアルバム 日本の恋と、ユーミンと。",
       "itunesTrackId": 1436021777,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -2636,14 +3309,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:40:13+09:00"
+    "generatedAt": "2026-06-27T21:08:30+09:00"
   },
   {
     "title": "上を向いて歩こう",
@@ -2657,7 +3336,13 @@
       "collectionName": "ベスト9!",
       "itunesTrackId": 1465042214,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -2678,7 +3363,11 @@
       "collectionName": "juice",
       "itunesTrackId": 1538282533,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -2699,7 +3388,11 @@
       "collectionName": "Best Friend - Single",
       "itunesTrackId": 1537240311,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -2720,7 +3413,11 @@
       "collectionName": "Traveler",
       "itunesTrackId": 1479397874,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -2741,7 +3438,11 @@
       "collectionName": "TRAD",
       "itunesTrackId": 1502568608,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -2762,7 +3463,13 @@
       "collectionName": "それいけ!アンパンマン ベストヒット’13",
       "itunesTrackId": 582615520,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -2783,35 +3490,50 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:40:23+09:00"
+    "generatedAt": "2026-06-27T21:08:32+09:00"
   },
   {
     "title": "secret base～君がくれたもの～",
     "artist": "ZONE",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2001-08-08",
+      "releaseYear": 2001,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 297,
+      "collectionName": "secret base 〜君がくれたもの〜 - EP",
+      "itunesTrackId": 1537517422,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 2,
+      "candidateReleaseDates": [
+        "2001-08-08"
+      ],
+      "reviewReason": [
+        "normalized_match",
+        "title_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:40:24+09:00"
+    "generatedAt": "2026-06-27T21:08:33+09:00"
   },
   {
     "title": "怪獣",
@@ -2825,7 +3547,11 @@
       "collectionName": "怪獣 - Single",
       "itunesTrackId": 1795905600,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -2846,7 +3572,11 @@
       "collectionName": "YAMAZAKI MASAYOSHI the BEST / BLUE PERIOD -COMPLETE",
       "itunesTrackId": 1442957649,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -2867,14 +3597,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:40:28+09:00"
+    "generatedAt": "2026-06-27T21:08:35+09:00"
   },
   {
     "title": "フィナーレ。",
@@ -2888,7 +3624,11 @@
       "collectionName": "プレロマンス / フィナーレ。 - EP",
       "itunesTrackId": 1638117504,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -2909,7 +3649,11 @@
       "collectionName": "Bunny Girl - EP",
       "itunesTrackId": 1769165500,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -2930,7 +3674,11 @@
       "collectionName": "unravel - Single",
       "itunesTrackId": 1535535911,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -2951,7 +3699,11 @@
       "collectionName": "正解 - EP",
       "itunesTrackId": 1726307099,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -2972,7 +3724,11 @@
       "collectionName": "新しい恋人達に - Single",
       "itunesTrackId": 1755670579,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -2993,7 +3749,11 @@
       "collectionName": "ダンスホール - Single",
       "itunesTrackId": 1623304209,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -3014,7 +3774,11 @@
       "collectionName": "エルフ - Single",
       "itunesTrackId": 1789478393,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -3035,7 +3799,11 @@
       "collectionName": "わたしに花束 - Single",
       "itunesTrackId": 1799216471,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -3056,7 +3824,13 @@
       "collectionName": "EXIT TUNES PRESENTS Vocaloseasons feat.初音ミク~Autumn~",
       "itunesTrackId": 1368260334,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -3077,7 +3851,11 @@
       "collectionName": "テレパシ - Single",
       "itunesTrackId": 1794967656,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -3098,7 +3876,11 @@
       "collectionName": "EXIT TUNES PRESENTS Vocalofantasy feat.初音ミク",
       "itunesTrackId": 985156335,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -3119,7 +3901,11 @@
       "collectionName": "タイムパラドックス - Single",
       "itunesTrackId": 1721130445,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -3140,7 +3926,11 @@
       "collectionName": "アイドル - Single",
       "itunesTrackId": 1679278167,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -3161,7 +3951,11 @@
       "collectionName": "Corridor",
       "itunesTrackId": 1271271759,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -3182,7 +3976,11 @@
       "collectionName": "マリーゴールド - Single",
       "itunesTrackId": 1402042897,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -3203,7 +4001,11 @@
       "collectionName": "だから僕は音楽を辞めた",
       "itunesTrackId": 1648877323,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -3224,7 +4026,11 @@
       "collectionName": "美しい鰭 - Single",
       "itunesTrackId": 1680093755,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -3245,7 +4051,11 @@
       "collectionName": "THE BEST “Blue”",
       "itunesTrackId": 1537252415,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -3266,7 +4076,13 @@
       "collectionName": "僕らまた - Single",
       "itunesTrackId": 1561507415,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -3287,7 +4103,11 @@
       "collectionName": "乾いた唄は魚の餌にちょうどいい",
       "itunesTrackId": 1444128277,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -3308,7 +4128,11 @@
       "collectionName": "BEST OF SOUL",
       "itunesTrackId": 200715360,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -3329,7 +4153,13 @@
       "collectionName": "ロウワー - Single",
       "itunesTrackId": 1592499103,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -3350,14 +4180,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:41:12+09:00"
+    "generatedAt": "2026-06-27T21:08:37+09:00"
   },
   {
     "title": "BOW AND ARROW",
@@ -3371,7 +4207,11 @@
       "collectionName": "BOW AND ARROW - Single",
       "itunesTrackId": 1790607807,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -3384,22 +4224,31 @@
     "title": "真っ白",
     "artist": "藤井風",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2025-02-28",
+      "releaseYear": 2025,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 294,
+      "collectionName": "真っ白 - Single",
+      "itunesTrackId": 1797266719,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 3,
+      "candidateReleaseDates": [
+        "2025-02-28"
+      ],
+      "reviewReason": [
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:41:15+09:00"
+    "generatedAt": "2026-06-27T21:08:38+09:00"
   },
   {
     "title": "春愁",
@@ -3413,7 +4262,11 @@
       "collectionName": "Love me, Love you - EP",
       "itunesTrackId": 1441018143,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -3426,22 +4279,31 @@
     "title": "ひまわりの約束",
     "artist": "秦基博",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2014-08-06",
+      "releaseYear": 2014,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 309,
+      "collectionName": "All Time Best ハタモトヒロ (はじめまして盤)",
+      "itunesTrackId": 1440865459,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 11,
+      "candidateReleaseDates": [
+        "2014-08-06"
+      ],
+      "reviewReason": [
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:41:18+09:00"
+    "generatedAt": "2026-06-27T21:08:39+09:00"
   },
   {
     "title": "猫",
@@ -3455,7 +4317,11 @@
       "collectionName": "僕たちがやりました (Special Edition) - EP",
       "itunesTrackId": 1537750439,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -3476,7 +4342,11 @@
       "collectionName": "向日葵 - Single",
       "itunesTrackId": 1694654875,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -3497,7 +4367,11 @@
       "collectionName": "負け犬にアンコールはいらない",
       "itunesTrackId": 1648876333,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -3518,7 +4392,13 @@
       "collectionName": "CYCLE HIT 1991-1997 Spitz Complete Single Collection",
       "itunesTrackId": 1440863574,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -3539,7 +4419,11 @@
       "collectionName": "SEASIDE SOLILOQUIES",
       "itunesTrackId": 1194947577,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -3560,7 +4444,11 @@
       "collectionName": "会いたい - EP",
       "itunesTrackId": 1774642946,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -3581,7 +4469,13 @@
       "collectionName": "へび - Single",
       "itunesTrackId": 1787471129,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -3602,7 +4496,11 @@
       "collectionName": "rouge",
       "itunesTrackId": 1493377521,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -3623,7 +4521,11 @@
       "collectionName": "remember",
       "itunesTrackId": 1535549717,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -3644,14 +4546,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:41:31+09:00"
+    "generatedAt": "2026-06-27T21:08:59+09:00"
   },
   {
     "title": "若者のすべて",
@@ -3665,7 +4573,11 @@
       "collectionName": "SINGLES 2004-2009",
       "itunesTrackId": 1440725618,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -3686,7 +4598,11 @@
       "collectionName": "はいよろこんで - Single",
       "itunesTrackId": 1745488818,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -3707,7 +4623,11 @@
       "collectionName": "Expressions (MOON Version)",
       "itunesTrackId": 1541673401,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -3728,7 +4648,11 @@
       "collectionName": "Anytime Anywhere - Single",
       "itunesTrackId": 1708333825,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -3749,7 +4673,11 @@
       "collectionName": "TM NETWORK ORIGINAL SINGLES 1984-1999",
       "itunesTrackId": 1536875508,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -3770,7 +4698,11 @@
       "collectionName": "天国 - Single",
       "itunesTrackId": 1810410952,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -3791,7 +4723,11 @@
       "collectionName": "ウィーアー! (TVアニメ『ONE PIECE』オープニングテーマ) - Single",
       "itunesTrackId": 1770907052,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -3804,43 +4740,65 @@
     "title": "可愛くてごめん",
     "artist": "HoneyWorks",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2022-08-28",
+      "releaseYear": 2022,
+      "decade": "2020年代",
+      "genre": "アニメ",
+      "durationSeconds": 220,
+      "collectionName": "告白実行委員会 -FLYING SONGS- 恋してる",
+      "itunesTrackId": 1638049033,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 3,
+      "candidateReleaseDates": [
+        "2022-08-28",
+        "2022-11-21"
+      ],
+      "reviewReason": [
+        "multiple_release_dates",
+        "normalized_match",
+        "title_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:41:43+09:00"
+    "generatedAt": "2026-06-27T21:09:00+09:00"
   },
   {
     "title": "ハロ／ハワユ",
     "artist": "ナノウ",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2010-07-07",
+      "releaseYear": 2010,
+      "decade": "2010年代",
+      "genre": "ポップ",
+      "durationSeconds": 286,
+      "collectionName": "ハロ/ハワユ (feat. 初音ミク&メグッポイド) - Single",
+      "itunesTrackId": 404172749,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 2,
+      "candidateReleaseDates": [
+        "2010-07-07",
+        "2013-09-25"
+      ],
+      "reviewReason": [
+        "multiple_release_dates",
+        "normalized_match",
+        "title_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:41:44+09:00"
+    "generatedAt": "2026-06-27T21:09:01+09:00"
   },
   {
     "title": "雨とカプチーノ",
@@ -3854,7 +4812,11 @@
       "collectionName": "エルマ",
       "itunesTrackId": 1474062330,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -3875,14 +4837,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:41:47+09:00"
+    "generatedAt": "2026-06-27T21:09:04+09:00"
   },
   {
     "title": "繋いだ手から",
@@ -3896,7 +4864,11 @@
       "collectionName": "繋いだ手から - EP",
       "itunesTrackId": 1451566928,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -3917,7 +4889,11 @@
       "collectionName": "クスシキ - Single",
       "itunesTrackId": 1804230388,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -3938,7 +4914,13 @@
       "collectionName": "RAIN - Single",
       "itunesTrackId": 1248216996,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -3959,7 +4941,11 @@
       "collectionName": "Variety - EP",
       "itunesTrackId": 1440745441,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -3980,7 +4966,11 @@
       "collectionName": "青のすみか - Single",
       "itunesTrackId": 1692289314,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -4001,14 +4991,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:42:02+09:00"
+    "generatedAt": "2026-06-27T21:09:06+09:00"
   },
   {
     "title": "GET BACK",
@@ -4022,7 +5018,11 @@
       "collectionName": "GET BACK - Single",
       "itunesTrackId": 1810615468,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -4043,7 +5043,11 @@
       "collectionName": "Tree",
       "itunesTrackId": 955796477,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -4064,7 +5068,11 @@
       "collectionName": "YANKEE",
       "itunesTrackId": 1440792118,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -4085,7 +5093,11 @@
       "collectionName": "「溺れるナイフ」オリジナル・サウンドトラック",
       "itunesTrackId": 1171317144,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -4106,7 +5118,11 @@
       "collectionName": "三日月ロック",
       "itunesTrackId": 1440618811,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -4127,7 +5143,13 @@
       "collectionName": "SPEED POP",
       "itunesTrackId": 989824416,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -4148,14 +5170,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:42:12+09:00"
+    "generatedAt": "2026-06-27T21:09:07+09:00"
   },
   {
     "title": "春の歌",
@@ -4169,7 +5197,13 @@
       "collectionName": "スーベニア",
       "itunesTrackId": 1440738537,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -4190,14 +5224,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:42:15+09:00"
+    "generatedAt": "2026-06-27T21:09:10+09:00"
   },
   {
     "title": "暴れん坊将軍のテーマ",
@@ -4211,14 +5251,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:42:16+09:00"
+    "generatedAt": "2026-06-27T21:09:12+09:00"
   },
   {
     "title": "Dear",
@@ -4232,7 +5278,11 @@
       "collectionName": "Dear - Single",
       "itunesTrackId": 1745507749,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -4253,7 +5303,11 @@
       "collectionName": "CYCLE HIT 1997-2005 Spitz Complete Single Collection",
       "itunesTrackId": 1440893440,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -4274,7 +5328,11 @@
       "collectionName": "ゼロへの調和",
       "itunesTrackId": 219640354,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -4295,7 +5353,13 @@
       "collectionName": "パワード・ワード・ワールド",
       "itunesTrackId": 1641741688,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -4316,14 +5380,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:42:23+09:00"
+    "generatedAt": "2026-06-27T21:09:14+09:00"
   },
   {
     "title": "Realize",
@@ -4337,7 +5407,13 @@
       "collectionName": "Believe / Realize BESTタッグ - Single",
       "itunesTrackId": 1611160767,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -4350,22 +5426,31 @@
     "title": "瑠璃色の地球",
     "artist": "松田聖子",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "1980-01-01",
+      "releaseYear": 1980,
+      "decade": "1980年代",
+      "genre": "J-Pop",
+      "durationSeconds": 265,
+      "collectionName": "I'll fall in love 愛的禮物",
+      "itunesTrackId": 1526178155,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 12,
+      "candidateReleaseDates": [
+        "1980-01-01"
+      ],
+      "reviewReason": [
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:42:26+09:00"
+    "generatedAt": "2026-06-27T21:09:15+09:00"
   },
   {
     "title": "て",
@@ -4379,7 +5464,11 @@
       "collectionName": "瀬と瀬",
       "itunesTrackId": 1540215947,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -4400,14 +5489,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:42:29+09:00"
+    "generatedAt": "2026-06-27T21:09:17+09:00"
   },
   {
     "title": "花束を君に",
@@ -4421,7 +5516,11 @@
       "collectionName": "Fantôme",
       "itunesTrackId": 1428767877,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -4442,14 +5541,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:42:31+09:00"
+    "generatedAt": "2026-06-27T21:09:19+09:00"
   },
   {
     "title": "花",
@@ -4463,7 +5568,11 @@
       "collectionName": "ALL the SINGLES",
       "itunesTrackId": 1537418568,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -4484,7 +5593,11 @@
       "collectionName": "花占い - Single",
       "itunesTrackId": 1706829372,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -4505,7 +5618,11 @@
       "collectionName": "The Four Seasons -spring- 約束 - EP",
       "itunesTrackId": 1757563911,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -4526,7 +5643,13 @@
       "collectionName": "花の名 - Single",
       "itunesTrackId": 1461735360,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -4547,7 +5670,11 @@
       "collectionName": "花の塔 - Single",
       "itunesTrackId": 1630061094,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -4560,64 +5687,93 @@
     "title": "桜坂",
     "artist": "福山雅治",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2000-04-26",
+      "releaseYear": 2000,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 297,
+      "collectionName": "f",
+      "itunesTrackId": 1443062753,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 4,
+      "candidateReleaseDates": [
+        "2000-04-26"
+      ],
+      "reviewReason": [
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:42:40+09:00"
+    "generatedAt": "2026-06-27T21:09:20+09:00"
   },
   {
     "title": "ひまわり",
     "artist": "福山雅治",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2003-08-27",
+      "releaseYear": 2003,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 363,
+      "collectionName": "虹/ひまわり/それがすべてさ",
+      "itunesTrackId": 1445039760,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 4,
+      "candidateReleaseDates": [
+        "2003-08-27",
+        "2006-12-06"
+      ],
+      "reviewReason": [
+        "multiple_release_dates",
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:42:41+09:00"
+    "generatedAt": "2026-06-27T21:09:21+09:00"
   },
   {
     "title": "帰ろう",
     "artist": "藤井風",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2020-05-20",
+      "releaseYear": 2020,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 284,
+      "collectionName": "HELP EVER HURT NEVER",
+      "itunesTrackId": 1505498795,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 2,
+      "candidateReleaseDates": [
+        "2020-05-20"
+      ],
+      "reviewReason": [
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:42:43+09:00"
+    "generatedAt": "2026-06-27T21:09:22+09:00"
   },
   {
     "title": "ケセラセラ",
@@ -4631,7 +5787,11 @@
       "collectionName": "ケセラセラ - Single",
       "itunesTrackId": 1681600508,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -4644,22 +5804,31 @@
     "title": "コーヒールンバ",
     "artist": "ウーゴ・ブランコ",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2018-12-01",
+      "releaseYear": 2018,
+      "decade": "2010年代",
+      "genre": "ワールド",
+      "durationSeconds": 171,
+      "collectionName": "大人のダンス紀行 タンゴ&ラテン&ハワイアン",
+      "itunesTrackId": 1445206312,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 1,
+      "candidateReleaseDates": [
+        "2018-12-01"
+      ],
+      "reviewReason": [
+        "normalized_match",
+        "title_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:42:46+09:00"
+    "generatedAt": "2026-06-27T21:09:22+09:00"
   },
   {
     "title": "コーヒーとシロップ",
@@ -4673,7 +5842,11 @@
       "collectionName": "MAN IN THE MIRROR",
       "itunesTrackId": 1103745757,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -4694,35 +5867,52 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:42:48+09:00"
+    "generatedAt": "2026-06-27T21:09:25+09:00"
   },
   {
     "title": "God knows...",
     "artist": "涼宮ハルヒ(CV.平野 綾)",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2006-06-21",
+      "releaseYear": 2006,
+      "decade": "2000年代",
+      "genre": "アニメ",
+      "durationSeconds": 279,
+      "collectionName": "Imaginary ENOZ featuring HARUHI - EP",
+      "itunesTrackId": 1880587625,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 5,
+      "candidateReleaseDates": [
+        "2006-06-21",
+        "2011-05-25"
+      ],
+      "reviewReason": [
+        "multiple_release_dates",
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:42:50+09:00"
+    "generatedAt": "2026-06-27T21:09:26+09:00"
   },
   {
     "title": "コーヒーハウスにて",
@@ -4736,7 +5926,13 @@
       "collectionName": "トワイライトの風",
       "itunesTrackId": 75027723,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -4757,7 +5953,11 @@
       "collectionName": "jupiter",
       "itunesTrackId": 1464634463,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -4778,7 +5978,13 @@
       "collectionName": "みずいろの手紙/コーヒーショップで",
       "itunesTrackId": 1648093446,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -4799,7 +6005,11 @@
       "collectionName": "ENSEMBLE",
       "itunesTrackId": 1360524272,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -4812,22 +6022,33 @@
     "title": "MELODY",
     "artist": "福山雅治",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "1993-06-02",
+      "releaseYear": 1993,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 270,
+      "collectionName": "MELODY/BABY BABY - Single",
+      "itunesTrackId": 1536003844,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 3,
+      "candidateReleaseDates": [
+        "1993-06-02",
+        "1993-10-21"
+      ],
+      "reviewReason": [
+        "multiple_release_dates",
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:42:57+09:00"
+    "generatedAt": "2026-06-27T21:09:27+09:00"
   },
   {
     "title": "時代",
@@ -4841,7 +6062,11 @@
       "collectionName": "時代/最後の女神 - Single",
       "itunesTrackId": 1653991584,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -4862,7 +6087,11 @@
       "collectionName": "ウタの歌 ONE PIECE FILM RED",
       "itunesTrackId": 1636446946,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -4883,7 +6112,11 @@
       "collectionName": "少年時代 - Single",
       "itunesTrackId": 284457304,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -4904,7 +6137,13 @@
       "collectionName": "美空ひばり プレミアムパッケージ「Best 70+1 Songs」",
       "itunesTrackId": 280271444,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -4925,14 +6164,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:43:04+09:00"
+    "generatedAt": "2026-06-27T21:09:29+09:00"
   },
   {
     "title": "神っぽいな",
@@ -4946,7 +6191,13 @@
       "collectionName": "神っぽいな - Single",
       "itunesTrackId": 1585951058,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -4967,7 +6218,11 @@
       "collectionName": "Love Song - EP",
       "itunesTrackId": 1577551340,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -4988,7 +6243,13 @@
       "collectionName": "水の星へ愛をこめて - Single",
       "itunesTrackId": 1688399963,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -5009,7 +6270,11 @@
       "collectionName": "翔べ!ガンダム/永遠にアムロ - Single",
       "itunesTrackId": 1244019603,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -5030,7 +6295,11 @@
       "collectionName": "哀 戦士/風にひとりで - Single",
       "itunesTrackId": 1244019088,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -5051,7 +6320,11 @@
       "collectionName": "Plazma - Single",
       "itunesTrackId": 1789465887,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -5072,7 +6345,11 @@
       "collectionName": "渡月橋 ~君 想ふ~ - Single",
       "itunesTrackId": 1226258283,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -5093,7 +6370,13 @@
       "collectionName": "名もなき詩 - Single",
       "itunesTrackId": 1374910673,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -5114,7 +6397,13 @@
       "collectionName": "終わりなき旅 - Single",
       "itunesTrackId": 1374906674,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -5135,7 +6424,11 @@
       "collectionName": "しるし - Single",
       "itunesTrackId": 1374876230,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -5156,7 +6449,11 @@
       "collectionName": "アルバム1号",
       "itunesTrackId": 1715782987,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -5177,7 +6474,11 @@
       "collectionName": "愛が灯る - Single",
       "itunesTrackId": 1668706884,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -5198,7 +6499,11 @@
       "collectionName": "For you...3 ~春・旅立ち~",
       "itunesTrackId": 276284384,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -5219,7 +6524,11 @@
       "collectionName": "炎 - EP",
       "itunesTrackId": 1531847485,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -5240,7 +6549,11 @@
       "collectionName": "月夜の悪戯の魔法/CLIMBER×CLIMBER - Single",
       "itunesTrackId": 463446005,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -5261,7 +6574,11 @@
       "collectionName": "PLAYERS - Single",
       "itunesTrackId": 1802134777,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -5282,7 +6599,11 @@
       "collectionName": "Watch me! - Single",
       "itunesTrackId": 1813364855,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -5303,7 +6624,11 @@
       "collectionName": "もう少しだけ - Single",
       "itunesTrackId": 1564444512,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -5324,14 +6649,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:43:30+09:00"
+    "generatedAt": "2026-06-27T21:09:31+09:00"
   },
   {
     "title": "雲は白リンゴは赤",
@@ -5345,7 +6676,13 @@
       "collectionName": "雲は白リンゴは赤 - EP",
       "itunesTrackId": 1499600312,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -5366,7 +6703,11 @@
       "collectionName": "Wonderful Life",
       "itunesTrackId": 1535497507,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -5387,7 +6728,13 @@
       "collectionName": "ゆず一家",
       "itunesTrackId": 422250979,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -5408,7 +6755,13 @@
       "collectionName": "菊次郎の夏 (オリジナル・サウンドトラック)",
       "itunesTrackId": 1498700482,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -5429,14 +6782,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:43:37+09:00"
+    "generatedAt": "2026-06-27T21:09:33+09:00"
   },
   {
     "title": "渚のアデリーヌ",
@@ -5450,7 +6809,13 @@
       "collectionName": "ピアノ ピアノ! ピアノ!!",
       "itunesTrackId": 855011119,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -5471,7 +6836,13 @@
       "collectionName": "Yiruma 2nd Album 'First Love' (The Original & the Very First Recording)",
       "itunesTrackId": 1436677761,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -5492,7 +6863,11 @@
       "collectionName": "I AM: CELINE DION (Original Motion Picture Soundtrack)",
       "itunesTrackId": 1745568934,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -5513,7 +6888,11 @@
       "collectionName": "Let It Be... Naked",
       "itunesTrackId": 1441132706,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -5534,14 +6913,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:43:44+09:00"
+    "generatedAt": "2026-06-27T21:09:35+09:00"
   },
   {
     "title": "戦場のメリークリスマス",
@@ -5555,14 +6940,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:43:46+09:00"
+    "generatedAt": "2026-06-27T21:09:37+09:00"
   },
   {
     "title": "The Rose",
@@ -5576,7 +6967,13 @@
       "collectionName": "The Rose (The Original Soundtrack Recording)",
       "itunesTrackId": 740212490,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -5597,14 +6994,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:43:48+09:00"
+    "generatedAt": "2026-06-27T21:09:39+09:00"
   },
   {
     "title": "天城越え",
@@ -5618,7 +7021,13 @@
       "collectionName": "名唱コレクション 石川さゆり 時代の粋を唄う",
       "itunesTrackId": 1860988958,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -5639,7 +7048,11 @@
       "collectionName": "永遠より長い一瞬 ~あの頃、確かに存在した私たち~(Complete Edition)",
       "itunesTrackId": 1533414469,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -5660,7 +7073,11 @@
       "collectionName": "B album",
       "itunesTrackId": 1810378623,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -5681,7 +7098,13 @@
       "collectionName": "Time goes by - Single",
       "itunesTrackId": 1014864272,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -5702,7 +7125,11 @@
       "collectionName": "Tree",
       "itunesTrackId": 955796395,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -5723,7 +7150,11 @@
       "collectionName": "純恋歌 - Single",
       "itunesTrackId": 1508422678,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -5744,7 +7175,13 @@
       "collectionName": "傑作撰 2001~2005",
       "itunesTrackId": 1444129023,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -5765,7 +7202,11 @@
       "collectionName": "DEEN SINGLES+1",
       "itunesTrackId": 75717512,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -5786,7 +7227,11 @@
       "collectionName": "REQUEST BEST",
       "itunesTrackId": 719990540,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -5807,7 +7252,13 @@
       "collectionName": "BTTB -20th Anniversary Edition-",
       "itunesTrackId": 1434825534,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -5828,14 +7279,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:44:04+09:00"
+    "generatedAt": "2026-06-27T21:09:41+09:00"
   },
   {
     "title": "7月7日、晴れ",
@@ -5849,7 +7306,11 @@
       "collectionName": "7月7日、晴れ サウンドトラック",
       "itunesTrackId": 1536207088,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -5870,7 +7331,13 @@
       "collectionName": "30th Anniversary",
       "itunesTrackId": 6763519747,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -5891,7 +7358,13 @@
       "collectionName": "インディゴ地平線",
       "itunesTrackId": 1440746845,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -5912,7 +7385,13 @@
       "collectionName": "残響散歌 / 朝が来る - EP",
       "itunesTrackId": 1594814706,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -5933,7 +7412,13 @@
       "collectionName": "スピッツ",
       "itunesTrackId": 1443091269,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -5954,7 +7439,11 @@
       "collectionName": "I believe in you",
       "itunesTrackId": 1573810335,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -5975,7 +7464,11 @@
       "collectionName": "NEW KAWAII",
       "itunesTrackId": 1807963404,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -5996,14 +7489,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:44:15+09:00"
+    "generatedAt": "2026-06-27T21:10:00+09:00"
   },
   {
     "title": "シングル・アゲイン",
@@ -6017,7 +7516,11 @@
       "collectionName": "Expressions (MOON Version)",
       "itunesTrackId": 1541673406,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -6038,7 +7541,11 @@
       "collectionName": "Bon Appetit!",
       "itunesTrackId": 257400711,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -6059,14 +7566,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:44:19+09:00"
+    "generatedAt": "2026-06-27T21:10:02+09:00"
   },
   {
     "title": "祝福",
@@ -6080,7 +7593,13 @@
       "collectionName": "祝福 - Single",
       "itunesTrackId": 1645308331,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -6101,14 +7620,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:44:22+09:00"
+    "generatedAt": "2026-06-27T21:10:04+09:00"
   },
   {
     "title": "新宝島",
@@ -6122,7 +7647,13 @@
       "collectionName": "新宝島 - EP",
       "itunesTrackId": 1039793121,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -6143,7 +7674,11 @@
       "collectionName": "Drunk Monkeys",
       "itunesTrackId": 1443163958,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -6164,7 +7699,13 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_not_found",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -6185,7 +7726,11 @@
       "collectionName": "夏空グラフィティ/青春ライン - EP",
       "itunesTrackId": 1536232596,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -6206,7 +7751,13 @@
       "collectionName": "天体観測 - Single",
       "itunesTrackId": 1465863819,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -6227,7 +7778,11 @@
       "collectionName": "貴方の側に。 - Single",
       "itunesTrackId": 1690736863,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -6248,7 +7803,13 @@
       "collectionName": "打上花火 - Single",
       "itunesTrackId": 1263790415,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -6269,14 +7830,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:44:33+09:00"
+    "generatedAt": "2026-06-27T21:10:08+09:00"
   },
   {
     "title": "久遠 ～光と波の記憶～",
@@ -6290,35 +7857,55 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:44:35+09:00"
+    "generatedAt": "2026-06-27T21:10:10+09:00"
   },
   {
     "title": "恋しさと せつなさと 心強さと",
     "artist": "篠原涼子",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "1993-01-01",
+      "releaseYear": 1993,
+      "decade": "1990年代",
+      "genre": "ロック",
+      "durationSeconds": 262,
+      "collectionName": "GOLDEN☆BEST  東京パフォーマンスドール",
+      "itunesTrackId": 1536723564,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 6,
+      "candidateReleaseDates": [
+        "1993-01-01",
+        "1994-07-21",
+        "1995-01-01",
+        "2020-11-18"
+      ],
+      "reviewReason": [
+        "multiple_release_dates",
+        "normalized_match",
+        "title_not_exact",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:44:36+09:00"
+    "generatedAt": "2026-06-27T21:10:11+09:00"
   },
   {
     "title": "恋",
@@ -6332,7 +7919,13 @@
       "collectionName": "恋 - EP",
       "itunesTrackId": 1156375396,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -6353,7 +7946,11 @@
       "collectionName": "世界は恋に落ちている - EP",
       "itunesTrackId": 1537331532,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -6374,7 +7971,11 @@
       "collectionName": "MESSAGE",
       "itunesTrackId": 273169324,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -6387,22 +7988,31 @@
     "title": "ユアーズ",
     "artist": "菅田将暉",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2023-07-29",
+      "releaseYear": 2023,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 267,
+      "collectionName": "ユアーズ - Single",
+      "itunesTrackId": 1697003659,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 2,
+      "candidateReleaseDates": [
+        "2023-07-29"
+      ],
+      "reviewReason": [
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:44:42+09:00"
+    "generatedAt": "2026-06-27T21:10:12+09:00"
   },
   {
     "title": "Cry Baby",
@@ -6416,7 +8026,11 @@
       "collectionName": "Cry Baby - Single",
       "itunesTrackId": 1563683060,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -6437,7 +8051,11 @@
       "collectionName": "Snow halation - EP",
       "itunesTrackId": 1891050046,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -6450,22 +8068,36 @@
     "title": "SWEET MEMORIES",
     "artist": "松田聖子",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "1980-01-01",
+      "releaseYear": 1980,
+      "decade": "1980年代",
+      "genre": "J-Pop",
+      "durationSeconds": 272,
+      "collectionName": "BIBLE",
+      "itunesTrackId": 1536883778,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 10,
+      "candidateReleaseDates": [
+        "1980-01-01",
+        "1983-01-01",
+        "1983-08-01",
+        "1983-12-21",
+        "1996-01-01"
+      ],
+      "reviewReason": [
+        "multiple_release_dates",
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:44:46+09:00"
+    "generatedAt": "2026-06-27T21:10:13+09:00"
   },
   {
     "title": "わたがし",
@@ -6479,7 +8111,11 @@
       "collectionName": "わたがし - EP",
       "itunesTrackId": 1451567084,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -6500,7 +8136,11 @@
       "collectionName": "エスカパレード",
       "itunesTrackId": 1394013614,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -6521,7 +8161,11 @@
       "collectionName": "I LOVE... - Single",
       "itunesTrackId": 1492963535,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -6542,7 +8186,11 @@
       "collectionName": "ミックスナッツ - Single",
       "itunesTrackId": 1616586639,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -6563,35 +8211,52 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:44:53+09:00"
+    "generatedAt": "2026-06-27T21:10:15+09:00"
   },
   {
     "title": "それがあなたの幸せとしても",
     "artist": "Heavenz",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2021-12-01",
+      "releaseYear": 2021,
+      "decade": "2020年代",
+      "genre": "オルタナティブ",
+      "durationSeconds": 272,
+      "collectionName": "Actor Reactor",
+      "itunesTrackId": 1596689944,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 2,
+      "candidateReleaseDates": [
+        "2021-12-01",
+        "2022-05-18"
+      ],
+      "reviewReason": [
+        "multiple_release_dates",
+        "normalized_match",
+        "title_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:44:54+09:00"
+    "generatedAt": "2026-06-27T21:10:16+09:00"
   },
   {
     "title": "うたかた花火",
@@ -6605,7 +8270,11 @@
       "collectionName": "うたかた花火/星が瞬くこんな夜に",
       "itunesTrackId": 1537420032,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -6626,7 +8295,11 @@
       "collectionName": "ロミオとシンデレラ - Single",
       "itunesTrackId": 1648263854,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -6647,7 +8320,11 @@
       "collectionName": "ドーナツホール - Single",
       "itunesTrackId": 1056062119,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -6660,22 +8337,31 @@
     "title": "深海少女",
     "artist": "ゆうゆ",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2012-12-26",
+      "releaseYear": 2012,
+      "decade": "2010年代",
+      "genre": "アニメ",
+      "durationSeconds": 216,
+      "collectionName": "早退系持論",
+      "itunesTrackId": 583251271,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 1,
+      "candidateReleaseDates": [
+        "2012-12-26"
+      ],
+      "reviewReason": [
+        "normalized_match",
+        "title_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:45:01+09:00"
+    "generatedAt": "2026-06-27T21:10:17+09:00"
   },
   {
     "title": "ホシアイ",
@@ -6689,14 +8375,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:45:03+09:00"
+    "generatedAt": "2026-06-27T21:10:19+09:00"
   },
   {
     "title": "宇宙戦艦ヤマト",
@@ -6710,7 +8402,11 @@
       "collectionName": "MOMENT 〜今の向こうの今を〜",
       "itunesTrackId": 1162564855,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -6731,7 +8427,13 @@
       "collectionName": "GODIEGO GREAT BEST VOL.1 -Japanese Version-",
       "itunesTrackId": 477643022,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -6752,14 +8454,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:45:07+09:00"
+    "generatedAt": "2026-06-27T21:10:21+09:00"
   },
   {
     "title": "Over the Rainbow(虹の彼方に)",
@@ -6773,14 +8481,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:45:08+09:00"
+    "generatedAt": "2026-06-27T21:10:23+09:00"
   },
   {
     "title": "あー夏休み",
@@ -6794,7 +8508,13 @@
       "collectionName": "N・A・T・S・U",
       "itunesTrackId": 1535482212,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -6815,7 +8535,13 @@
       "collectionName": "思春期",
       "itunesTrackId": 1536709036,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -6836,7 +8562,11 @@
       "collectionName": "Ray Of Hope",
       "itunesTrackId": 458559023,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -6857,7 +8587,13 @@
       "collectionName": "Deep Forest",
       "itunesTrackId": 75621413,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -6878,7 +8614,13 @@
       "collectionName": "高嶺の花子さん - EP",
       "itunesTrackId": 1451566891,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -6899,7 +8641,13 @@
       "collectionName": "グレイテスト・ヒッツ",
       "itunesTrackId": 1440897282,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -6920,7 +8668,13 @@
       "collectionName": "君がくれた夏 - Single",
       "itunesTrackId": 1026711118,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -6941,7 +8695,13 @@
       "collectionName": "ミツバチ - EP",
       "itunesTrackId": 1537420007,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -6962,7 +8722,11 @@
       "collectionName": "ZARD BEST The  Single  Collection  ～軌跡～",
       "itunesTrackId": 76095814,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -6983,7 +8747,11 @@
       "collectionName": "A COMPLETE ~ALL SINGLES~",
       "itunesTrackId": 289403701,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -7004,35 +8772,53 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:45:24+09:00"
+    "generatedAt": "2026-06-27T21:10:25+09:00"
   },
   {
     "title": "Driver's High",
     "artist": "L'Arc～en～Ciel",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "1998-01-01",
+      "releaseYear": 1998,
+      "decade": "1990年代",
+      "genre": "ロック",
+      "durationSeconds": 253,
+      "collectionName": "TWENITY 1997-1999",
+      "itunesTrackId": 1536474690,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 5,
+      "candidateReleaseDates": [
+        "1998-01-01",
+        "1999-07-01",
+        "2003-03-19"
+      ],
+      "reviewReason": [
+        "multiple_release_dates",
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:45:26+09:00"
+    "generatedAt": "2026-06-27T21:10:26+09:00"
   },
   {
     "title": "アイスクリーム シンドローム",
@@ -7046,7 +8832,13 @@
       "collectionName": "アイスクリーム シンドローム - EP",
       "itunesTrackId": 1444886346,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -7067,7 +8859,11 @@
       "collectionName": "A LONG VACATION",
       "itunesTrackId": 1556260400,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -7080,22 +8876,33 @@
     "title": "チューリングラブ",
     "artist": "ナナヲアカリ",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2020-01-18",
+      "releaseYear": 2020,
+      "decade": "2020年代",
+      "genre": "ロック",
+      "durationSeconds": 220,
+      "collectionName": "チューリングラブ / ピヨ (feat. Sou) - EP",
+      "itunesTrackId": 1538109473,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 4,
+      "candidateReleaseDates": [
+        "2020-01-18",
+        "2020-02-04"
+      ],
+      "reviewReason": [
+        "multiple_release_dates",
+        "normalized_match",
+        "title_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:45:30+09:00"
+    "generatedAt": "2026-06-27T21:10:27+09:00"
   },
   {
     "title": "Diamonds",
@@ -7109,35 +8916,52 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:45:31+09:00"
+    "generatedAt": "2026-06-27T21:10:29+09:00"
   },
   {
     "title": "月光浴",
     "artist": "柴田淳",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2002-06-26",
+      "releaseYear": 2002,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 308,
+      "collectionName": "MUSE'-DREAMUSIC・ Female Vocal Collection-",
+      "itunesTrackId": 103721050,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 6,
+      "candidateReleaseDates": [
+        "2002-06-26",
+        "2007-09-26"
+      ],
+      "reviewReason": [
+        "multiple_release_dates",
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:45:33+09:00"
+    "generatedAt": "2026-06-27T21:10:30+09:00"
   },
   {
     "title": "地上の星",
@@ -7151,7 +8975,11 @@
       "collectionName": "地上の星 / ヘッドライト・テールライト - Single",
       "itunesTrackId": 107232909,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -7172,7 +9000,11 @@
       "collectionName": "Myra - Single",
       "itunesTrackId": 1521618651,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -7185,22 +9017,31 @@
     "title": "W/X/Y",
     "artist": "Tani Yuuki",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2021-05-26",
+      "releaseYear": 2021,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 279,
+      "collectionName": "W / X / Y - Single",
+      "itunesTrackId": 1567158351,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 2,
+      "candidateReleaseDates": [
+        "2021-05-26"
+      ],
+      "reviewReason": [
+        "normalized_match",
+        "title_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:45:37+09:00"
+    "generatedAt": "2026-06-27T21:10:31+09:00"
   },
   {
     "title": "サクラキミワタシ",
@@ -7214,14 +9055,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:45:38+09:00"
+    "generatedAt": "2026-06-27T21:10:33+09:00"
   },
   {
     "title": "白日",
@@ -7235,7 +9082,11 @@
       "collectionName": "白日 - Single",
       "itunesTrackId": 1536027148,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -7256,14 +9107,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:45:41+09:00"
+    "generatedAt": "2026-06-27T21:10:36+09:00"
   },
   {
     "title": "虹",
@@ -7277,7 +9134,11 @@
       "collectionName": "虹の歌集",
       "itunesTrackId": 313439447,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -7298,7 +9159,13 @@
       "collectionName": "10th Anniversary Best RED",
       "itunesTrackId": 1536313320,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -7311,22 +9178,31 @@
     "title": "虹",
     "artist": "福山雅治",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2003-08-27",
+      "releaseYear": 2003,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 247,
+      "collectionName": "5年モノ",
+      "itunesTrackId": 1443215244,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 6,
+      "candidateReleaseDates": [
+        "2003-08-27"
+      ],
+      "reviewReason": [
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:45:47+09:00"
+    "generatedAt": "2026-06-27T21:10:37+09:00"
   },
   {
     "title": "虹",
@@ -7340,7 +9216,11 @@
       "collectionName": "虹/シンプル - EP",
       "itunesTrackId": 1256541190,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -7361,7 +9241,11 @@
       "collectionName": "ウラ嵐BEST 1999-2007",
       "itunesTrackId": 1573383059,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -7382,7 +9266,13 @@
       "collectionName": "虹 - Single",
       "itunesTrackId": 425580467,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -7403,7 +9293,13 @@
       "collectionName": "ALL TIME BEST 1998-2018",
       "itunesTrackId": 1441818340,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -7424,7 +9320,11 @@
       "collectionName": "栄光の軌跡",
       "itunesTrackId": 279405347,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -7445,7 +9345,11 @@
       "collectionName": "ベテルギウス - Single",
       "itunesTrackId": 1589915077,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -7466,7 +9370,13 @@
       "collectionName": "あの夢をなぞって - Single",
       "itunesTrackId": 1494399118,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -7487,7 +9397,13 @@
       "collectionName": "サヨナラ",
       "itunesTrackId": 1594810011,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -7508,14 +9424,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:46:09+09:00"
+    "generatedAt": "2026-06-27T21:10:39+09:00"
   },
   {
     "title": "森の小さなレストラン",
@@ -7529,7 +9451,11 @@
       "collectionName": "森の小さなレストラン - Single",
       "itunesTrackId": 1678898357,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -7550,7 +9476,11 @@
       "collectionName": "ドラえもん - EP",
       "itunesTrackId": 1348205599,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -7571,7 +9501,13 @@
       "collectionName": "Delicious!~The Best of Hitomi Shimatani~",
       "itunesTrackId": 1128272549,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -7592,7 +9528,11 @@
       "collectionName": "夕風ブレンド",
       "itunesTrackId": 1442953655,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -7613,14 +9553,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:46:16+09:00"
+    "generatedAt": "2026-06-27T21:10:41+09:00"
   },
   {
     "title": "ぼくドラえもん",
@@ -7634,14 +9580,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:46:17+09:00"
+    "generatedAt": "2026-06-27T21:10:43+09:00"
   },
   {
     "title": "少年期",
@@ -7655,7 +9607,11 @@
       "collectionName": "ドラえもん 映画主題歌集+挿入歌",
       "itunesTrackId": 1440790935,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -7676,14 +9632,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:46:20+09:00"
+    "generatedAt": "2026-06-27T21:11:01+09:00"
   },
   {
     "title": "ヘドウィグのテーマ",
@@ -7697,14 +9659,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:46:22+09:00"
+    "generatedAt": "2026-06-27T21:11:03+09:00"
   },
   {
     "title": "レイダース・マーチ",
@@ -7718,7 +9686,11 @@
       "collectionName": "インディ・ジョーンズ/クリスタル・スカルの王国 (オリジナル・サウンドトラック)",
       "itunesTrackId": 1400941657,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -7739,14 +9711,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:46:24+09:00"
+    "generatedAt": "2026-06-27T21:11:05+09:00"
   },
   {
     "title": "ミッションインポッシブルのテーマ",
@@ -7760,14 +9738,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:46:26+09:00"
+    "generatedAt": "2026-06-27T21:11:07+09:00"
   },
   {
     "title": "バック・トゥ・ザ・フューチャーのテーマ",
@@ -7781,14 +9765,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:46:27+09:00"
+    "generatedAt": "2026-06-27T21:11:10+09:00"
   },
   {
     "title": "ロッキーのテーマ",
@@ -7802,7 +9792,11 @@
       "collectionName": "Full 70s",
       "itunesTrackId": 1847500253,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -7823,7 +9817,11 @@
       "collectionName": "Pure... Movies",
       "itunesTrackId": 404853969,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -7836,22 +9834,28 @@
     "title": "80日間世界一周",
     "artist": "ビクター・ヤング",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2001-06-25",
+      "releaseYear": 2001,
+      "decade": "2000年代",
+      "genre": "ポップ",
+      "durationSeconds": 159,
+      "collectionName": "懐かしのS盤ヒットアワー マンボ・バカン",
+      "itunesTrackId": 963635293,
+      "matchStatus": "auto_matched",
+      "source": "itunes",
+      "matchStrategy": "primary_exact",
+      "candidateCount": 1,
+      "candidateReleaseDates": [
+        "2001-06-25"
+      ],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:46:32+09:00"
+    "generatedAt": "2026-06-27T21:11:10+09:00"
   },
   {
     "title": "フォレストガンプのテーマ",
@@ -7865,14 +9869,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:46:33+09:00"
+    "generatedAt": "2026-06-27T21:11:12+09:00"
   },
   {
     "title": "月のワルツ",
@@ -7886,7 +9896,13 @@
       "collectionName": "月のワルツ - Single",
       "itunesTrackId": 720409377,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -7907,7 +9923,13 @@
       "collectionName": "エンジェル",
       "itunesTrackId": 260699478,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -7928,7 +9950,11 @@
       "collectionName": "ALL TIME BEST",
       "itunesTrackId": 1537531003,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -7949,7 +9975,11 @@
       "collectionName": "Everything - EP",
       "itunesTrackId": 1536002900,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -7970,7 +10000,13 @@
       "collectionName": "WEDNESDAY〜LOVE SONG BEST OF YUTAKA OZAKI",
       "itunesTrackId": 1537395820,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -7991,14 +10027,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:47:01+09:00"
+    "generatedAt": "2026-06-27T21:11:14+09:00"
   },
   {
     "title": "アンドロメダ",
@@ -8012,7 +10054,13 @@
       "collectionName": "アンドロメダ - EP",
       "itunesTrackId": 1499476930,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -8033,7 +10081,13 @@
       "collectionName": "愛していると言ってくれ オリジナル・サウンドトラック",
       "itunesTrackId": 1536204693,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -8054,7 +10108,11 @@
       "collectionName": "守ってあげたい - Single",
       "itunesTrackId": 1436008910,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -8075,7 +10133,13 @@
       "collectionName": "GOLDEN☆BEST  S.E.N.S.〜Singles Collection",
       "itunesTrackId": 1536735711,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -8096,7 +10160,13 @@
       "collectionName": "KO SHIBASAKI ALL TIME BEST 詩",
       "itunesTrackId": 1440903667,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -8117,7 +10187,11 @@
       "collectionName": "KiLLER BiSH",
       "itunesTrackId": 1147516283,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -8130,22 +10204,31 @@
     "title": "まちがいさがし",
     "artist": "菅田将暉",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2019-05-14",
+      "releaseYear": 2019,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 221,
+      "collectionName": "まちがいさがし - Single",
+      "itunesTrackId": 1536318304,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 2,
+      "candidateReleaseDates": [
+        "2019-05-14"
+      ],
+      "reviewReason": [
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:47:11+09:00"
+    "generatedAt": "2026-06-27T21:11:15+09:00"
   },
   {
     "title": "君に届け",
@@ -8159,7 +10242,11 @@
       "collectionName": "君に届け - Single",
       "itunesTrackId": 1838916920,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -8180,14 +10267,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:47:14+09:00"
+    "generatedAt": "2026-06-27T21:11:17+09:00"
   },
   {
     "title": "マイ バラード",
@@ -8201,14 +10294,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:47:15+09:00"
+    "generatedAt": "2026-06-27T21:11:19+09:00"
   },
   {
     "title": "証",
@@ -8222,7 +10321,13 @@
       "collectionName": "証 - EP",
       "itunesTrackId": 1838917016,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -8243,7 +10348,11 @@
       "collectionName": "南風 - Single",
       "itunesTrackId": 1857509722,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -8264,7 +10373,13 @@
       "collectionName": "ベスト・コンディション〜kinmokusei single collection〜",
       "itunesTrackId": 1535996759,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -8285,7 +10400,11 @@
       "collectionName": "イラつくときはいつだって",
       "itunesTrackId": 1559717561,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -8306,7 +10425,11 @@
       "collectionName": "カワキヲアメク - EP",
       "itunesTrackId": 1725802551,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -8327,7 +10450,11 @@
       "collectionName": "あんたなんて。 - Single",
       "itunesTrackId": 1770727505,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -8348,7 +10475,11 @@
       "collectionName": "なんでもないよ、 - Single",
       "itunesTrackId": 1591370660,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -8369,7 +10500,11 @@
       "collectionName": "Mind Travel",
       "itunesTrackId": 440112862,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -8390,7 +10525,11 @@
       "collectionName": "Street Story",
       "itunesTrackId": 297287194,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -8403,22 +10542,33 @@
     "title": "黒毛和牛上塩タン焼680円",
     "artist": "大塚愛",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2005-02-09",
+      "releaseYear": 2005,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 231,
+      "collectionName": "黒毛和牛上塩タン焼680円 - EP",
+      "itunesTrackId": 76679279,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 6,
+      "candidateReleaseDates": [
+        "2005-02-09",
+        "2019-01-01"
+      ],
+      "reviewReason": [
+        "multiple_release_dates",
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:47:29+09:00"
+    "generatedAt": "2026-06-27T21:11:20+09:00"
   },
   {
     "title": "夜空ノムコウ",
@@ -8432,14 +10582,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:47:30+09:00"
+    "generatedAt": "2026-06-27T21:11:22+09:00"
   },
   {
     "title": "想い出がいっぱい",
@@ -8453,7 +10609,11 @@
       "collectionName": "想い出がいっぱい - Single",
       "itunesTrackId": 1825777193,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -8474,7 +10634,11 @@
       "collectionName": "Your Best Friend - Single",
       "itunesTrackId": 470147829,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -8495,7 +10659,11 @@
       "collectionName": "ポケモンTVアニメ主題歌 BEST OF BEST 1997-2012",
       "itunesTrackId": 583838497,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -8516,7 +10684,11 @@
       "collectionName": "瞬く世界にiを揺らせ",
       "itunesTrackId": 1530015502,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -8529,22 +10701,31 @@
     "title": "パリは燃えているか",
     "artist": "加古隆",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2003-10-22",
+      "releaseYear": 2003,
+      "decade": "2000年代",
+      "genre": "インストゥルメンタル",
+      "durationSeconds": 318,
+      "collectionName": "アニヴァーサリー",
+      "itunesTrackId": 1689541963,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_exact",
+      "candidateCount": 3,
+      "candidateReleaseDates": [
+        "2003-10-22",
+        "2015-11-18"
+      ],
+      "reviewReason": [
+        "multiple_release_dates"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:47:38+09:00"
+    "generatedAt": "2026-06-27T21:11:23+09:00"
   },
   {
     "title": "木蘭の涙",
@@ -8558,35 +10739,50 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:47:39+09:00"
+    "generatedAt": "2026-06-27T21:11:26+09:00"
   },
   {
     "title": "夏の決心",
     "artist": "大江千里",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2011-02-23",
+      "releaseYear": 2011,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 307,
+      "collectionName": "GOLDEN☆BEST  大江千里",
+      "itunesTrackId": 1536733216,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 1,
+      "candidateReleaseDates": [
+        "2011-02-23"
+      ],
+      "reviewReason": [
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:47:40+09:00"
+    "generatedAt": "2026-06-27T21:11:26+09:00"
   },
   {
     "title": "未来へ",
@@ -8600,7 +10796,13 @@
       "collectionName": "キロロのいちばんイイ歌あつめました",
       "itunesTrackId": 156209828,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -8621,7 +10823,13 @@
       "collectionName": "Sunny Day Sunday - Single",
       "itunesTrackId": 1537228599,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -8642,7 +10850,11 @@
       "collectionName": "MIRACLE DIVING",
       "itunesTrackId": 1536206508,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -8663,7 +10875,13 @@
       "collectionName": "PORNO GRAFFITTI BEST RED'S",
       "itunesTrackId": 1537232075,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -8684,7 +10902,11 @@
       "collectionName": "1000000000000",
       "itunesTrackId": 1536230428,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -8705,7 +10927,11 @@
       "collectionName": "君の名は。",
       "itunesTrackId": 1440719636,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -8718,22 +10944,31 @@
     "title": "ガラモン・ソング",
     "artist": "蓜島邦明",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "1990-08-25",
+      "releaseYear": 1990,
+      "decade": "1990年代",
+      "genre": "サウンドトラック",
+      "durationSeconds": 36,
+      "collectionName": "「世にも奇妙な物語」オリジナル・サウンド・トラック",
+      "itunesTrackId": 1542228225,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 1,
+      "candidateReleaseDates": [
+        "1990-08-25"
+      ],
+      "reviewReason": [
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:47:59+09:00"
+    "generatedAt": "2026-06-27T21:11:27+09:00"
   },
   {
     "title": "Same Blue",
@@ -8747,7 +10982,11 @@
       "collectionName": "Same Blue - Single",
       "itunesTrackId": 1768218701,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -8768,7 +11007,11 @@
       "collectionName": "サザエさん - EP",
       "itunesTrackId": 829758742,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -8789,7 +11032,11 @@
       "collectionName": "サザエさん - EP",
       "itunesTrackId": 829758740,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -8810,7 +11057,13 @@
       "collectionName": "美里うたGolden BEST",
       "itunesTrackId": 1536269708,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -8831,7 +11084,11 @@
       "collectionName": "告白 - Confession - Single",
       "itunesTrackId": 1571628539,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -8852,7 +11109,13 @@
       "collectionName": "安全地帯Ⅱ",
       "itunesTrackId": 1443380310,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -8873,7 +11136,11 @@
       "collectionName": "This is 嵐",
       "itunesTrackId": 1541306821,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -8894,14 +11161,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:48:11+09:00"
+    "generatedAt": "2026-06-27T21:11:30+09:00"
   },
   {
     "title": "Hello, Again ～昔からある場所～",
@@ -8915,7 +11188,11 @@
       "collectionName": "re:evergreen",
       "itunesTrackId": 1050899149,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -8936,7 +11213,11 @@
       "collectionName": "星座になれたら - Single",
       "itunesTrackId": 1657316198,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -8957,14 +11238,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:48:15+09:00"
+    "generatedAt": "2026-06-27T21:11:32+09:00"
   },
   {
     "title": "花火",
@@ -8978,7 +11265,13 @@
       "collectionName": "桜の木の下",
       "itunesTrackId": 1109978628,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -8991,22 +11284,28 @@
     "title": "Top of the World",
     "artist": "カーペンターズ",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "1972-06-22",
+      "releaseYear": 1972,
+      "decade": "1970年代",
+      "genre": "サウンドトラック",
+      "durationSeconds": 180,
+      "collectionName": "Dark Shadows (Original Motion Picture Soundtrack)",
+      "itunesTrackId": 1454870809,
+      "matchStatus": "auto_matched",
+      "source": "itunes",
+      "matchStrategy": "primary_exact",
+      "candidateCount": 1,
+      "candidateReleaseDates": [
+        "1972-06-22"
+      ],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:48:18+09:00"
+    "generatedAt": "2026-06-27T21:11:33+09:00"
   },
   {
     "title": "青春の輝き(I Need to Be in Love)",
@@ -9020,14 +11319,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:48:19+09:00"
+    "generatedAt": "2026-06-27T21:11:35+09:00"
   },
   {
     "title": "Sing",
@@ -9041,14 +11346,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:48:20+09:00"
+    "generatedAt": "2026-06-27T21:11:37+09:00"
   },
   {
     "title": "365日の紙飛行機",
@@ -9062,7 +11373,11 @@
       "collectionName": "唇にBe My Baby (Type A) - EP",
       "itunesTrackId": 1062460737,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -9083,7 +11398,11 @@
       "collectionName": "DAHLIA",
       "itunesTrackId": 1886166660,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -9104,35 +11423,53 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:48:25+09:00"
+    "generatedAt": "2026-06-27T21:11:39+09:00"
   },
   {
     "title": "金魚花火",
     "artist": "大塚愛",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2004-08-18",
+      "releaseYear": 2004,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 273,
+      "collectionName": "Love Jam",
+      "itunesTrackId": 75634522,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 8,
+      "candidateReleaseDates": [
+        "2004-08-18",
+        "2018-02-07",
+        "2019-01-01"
+      ],
+      "reviewReason": [
+        "multiple_release_dates",
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:48:26+09:00"
+    "generatedAt": "2026-06-27T21:11:40+09:00"
   },
   {
     "title": "天使のくれた奇跡",
@@ -9146,14 +11483,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:48:27+09:00"
+    "generatedAt": "2026-06-27T21:11:42+09:00"
   },
   {
     "title": "唱",
@@ -9167,7 +11510,11 @@
       "collectionName": "唱 - Single",
       "itunesTrackId": 1704093812,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -9188,7 +11535,11 @@
       "collectionName": "うっせぇわ - Single",
       "itunesTrackId": 1535123742,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -9209,14 +11560,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:48:32+09:00"
+    "generatedAt": "2026-06-27T21:11:44+09:00"
   },
   {
     "title": "倍倍FIGHT!",
@@ -9230,7 +11587,11 @@
       "collectionName": "倍倍FIGHT! - Single",
       "itunesTrackId": 1807721854,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -9251,14 +11612,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:48:34+09:00"
+    "generatedAt": "2026-06-27T21:12:00+09:00"
   },
   {
     "title": "決意の朝に",
@@ -9272,7 +11639,13 @@
       "collectionName": "The BEST of Aqua Timez",
       "itunesTrackId": 1536259381,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -9293,7 +11666,11 @@
       "collectionName": "Leading role",
       "itunesTrackId": 1498022230,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -9314,7 +11691,11 @@
       "collectionName": "SPIRAL",
       "itunesTrackId": 1486799616,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -9335,7 +11716,11 @@
       "collectionName": "コトバアソビ",
       "itunesTrackId": 1579813840,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -9356,7 +11741,13 @@
       "collectionName": "KissHug - EP",
       "itunesTrackId": 1499615822,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -9377,7 +11768,11 @@
       "collectionName": "相思相愛 - Single",
       "itunesTrackId": 1737707213,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -9398,14 +11793,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:48:44+09:00"
+    "generatedAt": "2026-06-27T21:12:02+09:00"
   },
   {
     "title": "怪獣のバラード",
@@ -9419,14 +11820,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:48:45+09:00"
+    "generatedAt": "2026-06-27T21:12:04+09:00"
   },
   {
     "title": "愛のメモリー",
@@ -9440,7 +11847,13 @@
       "collectionName": "Time",
       "itunesTrackId": 720409949,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -9461,14 +11874,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:48:48+09:00"
+    "generatedAt": "2026-06-27T21:12:06+09:00"
   },
   {
     "title": "銀色飛行船",
@@ -9482,7 +11901,11 @@
       "collectionName": "銀色飛行船 - EP",
       "itunesTrackId": 1537455821,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -9503,14 +11926,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:48:51+09:00"
+    "generatedAt": "2026-06-27T21:12:08+09:00"
   },
   {
     "title": "ハナミズキ",
@@ -9524,7 +11953,13 @@
       "collectionName": "ハナミズキ - Single",
       "itunesTrackId": 157155289,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -9545,14 +11980,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:48:54+09:00"
+    "generatedAt": "2026-06-27T21:12:10+09:00"
   },
   {
     "title": "荒城の月",
@@ -9566,14 +12007,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:48:56+09:00"
+    "generatedAt": "2026-06-27T21:12:12+09:00"
   },
   {
     "title": "花",
@@ -9587,35 +12034,52 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:48:59+09:00"
+    "generatedAt": "2026-06-27T21:12:14+09:00"
   },
   {
     "title": "さくらんぼ",
     "artist": "大塚愛",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2003-12-17",
+      "releaseYear": 2003,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 234,
+      "collectionName": "Love Punch",
+      "itunesTrackId": 76106271,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 10,
+      "candidateReleaseDates": [
+        "2003-12-17",
+        "2018-12-02"
+      ],
+      "reviewReason": [
+        "multiple_release_dates",
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:49:01+09:00"
+    "generatedAt": "2026-06-27T21:12:15+09:00"
   },
   {
     "title": "夕焼小焼",
@@ -9629,14 +12093,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:49:02+09:00"
+    "generatedAt": "2026-06-27T21:12:17+09:00"
   },
   {
     "title": "故郷",
@@ -9650,14 +12120,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:49:04+09:00"
+    "generatedAt": "2026-06-27T21:12:19+09:00"
   },
   {
     "title": "おもちゃのチャチャチャ",
@@ -9671,14 +12147,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:49:05+09:00"
+    "generatedAt": "2026-06-27T21:12:21+09:00"
   },
   {
     "title": "魂のルフラン",
@@ -9692,7 +12174,13 @@
       "collectionName": "魂のルフラン/THANATOS-IF I CAN'T BE YOURS - EP",
       "itunesTrackId": 258926443,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -9713,7 +12201,11 @@
       "collectionName": "WONDERFUL FISH",
       "itunesTrackId": 1281427312,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -9734,7 +12226,11 @@
       "collectionName": "give it back - Single",
       "itunesTrackId": 1545881892,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -9755,7 +12251,11 @@
       "collectionName": "廻廻奇譚 - Single",
       "itunesTrackId": 1533208085,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -9776,7 +12276,11 @@
       "collectionName": "ALL TIME BEST",
       "itunesTrackId": 1440895683,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -9797,14 +12301,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:49:13+09:00"
+    "generatedAt": "2026-06-27T21:12:23+09:00"
   },
   {
     "title": "シーズン・イン・ザ・サン",
@@ -9818,7 +12328,13 @@
       "collectionName": "THE SEASON IN THE SUN",
       "itunesTrackId": 1535481261,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -9839,7 +12355,13 @@
       "collectionName": "サマータイムシンデレラ - EP",
       "itunesTrackId": 1697302630,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -9860,7 +12382,11 @@
       "collectionName": "めぐりあい - Single",
       "itunesTrackId": 1244018758,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -9881,14 +12407,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:49:19+09:00"
+    "generatedAt": "2026-06-27T21:12:25+09:00"
   },
   {
     "title": "ZOO",
@@ -9902,56 +12434,77 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:49:20+09:00"
+    "generatedAt": "2026-06-27T21:12:27+09:00"
   },
   {
     "title": "ゆずれない願い",
     "artist": "田村直美",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "1997-01-01",
+      "releaseYear": 1997,
+      "decade": "1990年代",
+      "genre": "ロック",
+      "durationSeconds": 232,
+      "collectionName": "Thanx a Million-The Singles of Naomi Tamura-",
+      "itunesTrackId": 1443114381,
+      "matchStatus": "auto_matched",
+      "source": "itunes",
+      "matchStrategy": "primary_exact",
+      "candidateCount": 1,
+      "candidateReleaseDates": [
+        "1997-01-01"
+      ],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:49:22+09:00"
+    "generatedAt": "2026-06-27T21:12:28+09:00"
   },
   {
     "title": "フォニイ",
     "artist": "ツミキ",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2021-11-24",
+      "releaseYear": 2021,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 190,
+      "collectionName": "KAF+YOU KAFU COMPILATION ALBUM シンメトリー",
+      "itunesTrackId": 1688513140,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 1,
+      "candidateReleaseDates": [
+        "2021-11-24"
+      ],
+      "reviewReason": [
+        "normalized_match",
+        "title_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:49:23+09:00"
+    "generatedAt": "2026-06-27T21:12:29+09:00"
   },
   {
     "title": "パプリカ",
@@ -9965,7 +12518,11 @@
       "collectionName": "パプリカ - Single",
       "itunesTrackId": 1537765262,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -9986,7 +12543,13 @@
       "collectionName": "君がいるから - EP",
       "itunesTrackId": 339961792,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -9999,22 +12562,32 @@
     "title": "できっこないを やらなくちゃ",
     "artist": "サンボマスター",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2010-02-24",
+      "releaseYear": 2010,
+      "decade": "2010年代",
+      "genre": "ロック",
+      "durationSeconds": 220,
+      "collectionName": "できっこないを やらなくちゃ - EP",
+      "itunesTrackId": 1537414939,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "title_fallback_exact",
+      "candidateCount": 5,
+      "candidateReleaseDates": [
+        "2010-02-24",
+        "2011-04-06",
+        "2018-08-15"
+      ],
+      "reviewReason": [
+        "multiple_release_dates"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:49:27+09:00"
+    "generatedAt": "2026-06-27T21:12:31+09:00"
   },
   {
     "title": "第ゼロ感",
@@ -10028,7 +12601,11 @@
       "collectionName": "第ゼロ感 - Single",
       "itunesTrackId": 1652587504,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -10049,7 +12626,11 @@
       "collectionName": "私を染めるiの歌",
       "itunesTrackId": 1537336376,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -10070,14 +12651,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:49:32+09:00"
+    "generatedAt": "2026-06-27T21:12:33+09:00"
   },
   {
     "title": "瞳を閉じて",
@@ -10091,119 +12678,172 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:49:33+09:00"
+    "generatedAt": "2026-06-27T21:12:35+09:00"
   },
   {
     "title": "トドカナイカラ",
     "artist": "平井堅",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2018-05-09",
+      "releaseYear": 2018,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 247,
+      "collectionName": "トドカナイカラ - EP",
+      "itunesTrackId": 1535981574,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 3,
+      "candidateReleaseDates": [
+        "2018-05-09"
+      ],
+      "reviewReason": [
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:49:34+09:00"
+    "generatedAt": "2026-06-27T21:12:36+09:00"
   },
   {
     "title": "また逢う日まで",
     "artist": "平井大",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2015-02-18",
+      "releaseYear": 2015,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 255,
+      "collectionName": "また逢う日まで - Single",
+      "itunesTrackId": 963992555,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 3,
+      "candidateReleaseDates": [
+        "2015-02-18",
+        "2015-05-06"
+      ],
+      "reviewReason": [
+        "multiple_release_dates",
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:49:36+09:00"
+    "generatedAt": "2026-06-27T21:12:37+09:00"
   },
   {
     "title": "Stand by me, Stand by you.",
     "artist": "平井大",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2020-09-09",
+      "releaseYear": 2020,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 193,
+      "collectionName": "Stand by me, Stand by you. - Single",
+      "itunesTrackId": 1529408164,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 2,
+      "candidateReleaseDates": [
+        "2020-09-09"
+      ],
+      "reviewReason": [
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:49:37+09:00"
+    "generatedAt": "2026-06-27T21:12:38+09:00"
   },
   {
     "title": "祈り花",
     "artist": "平井大",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2011-10-19",
+      "releaseYear": 2011,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 263,
+      "collectionName": "祈り花 - EP",
+      "itunesTrackId": 1400250753,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 2,
+      "candidateReleaseDates": [
+        "2011-10-19"
+      ],
+      "reviewReason": [
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:49:39+09:00"
+    "generatedAt": "2026-06-27T21:12:39+09:00"
   },
   {
     "title": "幸せのレシピ",
     "artist": "平井大",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2025-01-10",
+      "releaseYear": 2025,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 193,
+      "collectionName": "幸せのレシピ - Single",
+      "itunesTrackId": 1787228551,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 1,
+      "candidateReleaseDates": [
+        "2025-01-10"
+      ],
+      "reviewReason": [
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:49:40+09:00"
+    "generatedAt": "2026-06-27T21:12:59+09:00"
   },
   {
     "title": "アイコトバ",
@@ -10217,7 +12857,11 @@
       "collectionName": "アイコトバ - Single",
       "itunesTrackId": 1712079509,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -10238,7 +12882,11 @@
       "collectionName": "百花繚乱 - Single",
       "itunesTrackId": 1786972177,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -10259,7 +12907,11 @@
       "collectionName": "アンビバレント - Single",
       "itunesTrackId": 1723078323,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -10280,7 +12932,11 @@
       "collectionName": "ひとりごと - Single",
       "itunesTrackId": 1804611254,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -10301,7 +12957,11 @@
       "collectionName": "愛は薬 - Single",
       "itunesTrackId": 1721860959,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -10322,7 +12982,11 @@
       "collectionName": "めぐりあい - Single",
       "itunesTrackId": 1244018759,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -10343,7 +13007,11 @@
       "collectionName": "葛飾ラプソディー - Single",
       "itunesTrackId": 1525310841,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -10364,7 +13032,13 @@
       "collectionName": "ココロソマリ - Single",
       "itunesTrackId": 1494875710,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -10385,7 +13059,11 @@
       "collectionName": "オトナブルー - Single",
       "itunesTrackId": 1498880491,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -10406,7 +13084,11 @@
       "collectionName": "ウタの歌 ONE PIECE FILM RED",
       "itunesTrackId": 1636446959,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -10427,14 +13109,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:50:08+09:00"
+    "generatedAt": "2026-06-27T21:13:01+09:00"
   },
   {
     "title": "A列車で行こう",
@@ -10448,14 +13136,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:50:09+09:00"
+    "generatedAt": "2026-06-27T21:13:03+09:00"
   },
   {
     "title": "銀の龍の背に乗って",
@@ -10469,7 +13163,11 @@
       "collectionName": "恋文",
       "itunesTrackId": 118543010,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -10490,35 +13188,52 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:50:12+09:00"
+    "generatedAt": "2026-06-27T21:13:06+09:00"
   },
   {
     "title": "ワタリドリ",
     "artist": "Alexandros",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2015-03-18",
+      "releaseYear": 2015,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 252,
+      "collectionName": "ワタリドリ/Dracula La - Single",
+      "itunesTrackId": 1428703480,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 12,
+      "candidateReleaseDates": [
+        "2015-03-18",
+        "2021-03-17"
+      ],
+      "reviewReason": [
+        "multiple_release_dates",
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:50:13+09:00"
+    "generatedAt": "2026-06-27T21:13:07+09:00"
   },
   {
     "title": "手紙",
@@ -10532,7 +13247,11 @@
       "collectionName": "撫子の華",
       "itunesTrackId": 720355322,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -10545,22 +13264,28 @@
     "title": "手紙",
     "artist": "坂本真綾",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2011-01-12",
+      "releaseYear": 2011,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 140,
+      "collectionName": "You can't catch me",
+      "itunesTrackId": 416514146,
+      "matchStatus": "auto_matched",
+      "source": "itunes",
+      "matchStrategy": "primary_exact",
+      "candidateCount": 1,
+      "candidateReleaseDates": [
+        "2011-01-12"
+      ],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:50:16+09:00"
+    "generatedAt": "2026-06-27T21:13:08+09:00"
   },
   {
     "title": "手紙",
@@ -10574,7 +13299,11 @@
       "collectionName": "深海",
       "itunesTrackId": 1375009926,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -10595,7 +13324,11 @@
       "collectionName": "あなたに出会わなければ〜夏雪冬花〜 / 星屑ビーナス - Single",
       "itunesTrackId": 1536124176,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -10616,7 +13349,11 @@
       "collectionName": "Carrying Happiness - Single",
       "itunesTrackId": 1826924334,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -10637,7 +13374,13 @@
       "collectionName": "ラブソング - Single",
       "itunesTrackId": 1550243871,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -10658,14 +13401,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:50:23+09:00"
+    "generatedAt": "2026-06-27T21:13:10+09:00"
   },
   {
     "title": "紡ぐ",
@@ -10679,7 +13428,11 @@
       "collectionName": "紡ぐ - Single",
       "itunesTrackId": 1665555903,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -10700,7 +13453,13 @@
       "collectionName": "誘拐 / ランデヴー - Single",
       "itunesTrackId": 1684131728,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -10721,7 +13480,11 @@
       "collectionName": "香水 - Single",
       "itunesTrackId": 1524596325,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -10742,7 +13505,11 @@
       "collectionName": "Make you happy - EP",
       "itunesTrackId": 1538127026,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -10763,7 +13530,13 @@
       "collectionName": "恋するフォーチュンクッキー (Type A) - EP",
       "itunesTrackId": 681020904,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -10784,7 +13557,11 @@
       "collectionName": "夏の影 - Single",
       "itunesTrackId": 1831207784,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -10805,35 +13582,50 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:50:34+09:00"
+    "generatedAt": "2026-06-27T21:13:12+09:00"
   },
   {
     "title": "トウキョウ・シャンディ・ランデヴ",
     "artist": "MAISONdes",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2022-10-21",
+      "releaseYear": 2022,
+      "decade": "2020年代",
+      "genre": "オルタナティブ",
+      "durationSeconds": 185,
+      "collectionName": "トウキョウ・シャンディ・ランデヴ (feat. 花譜 & ツミキ) - Single",
+      "itunesTrackId": 1649923942,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 3,
+      "candidateReleaseDates": [
+        "2022-10-21"
+      ],
+      "reviewReason": [
+        "normalized_match",
+        "title_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:50:35+09:00"
+    "generatedAt": "2026-06-27T21:13:13+09:00"
   },
   {
     "title": "トリセツ",
@@ -10847,7 +13639,11 @@
       "collectionName": "トリセツ - Single",
       "itunesTrackId": 1537253742,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -10868,7 +13664,11 @@
       "collectionName": "会いたくて 会いたくて - Single",
       "itunesTrackId": 1537240509,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -10889,7 +13689,11 @@
       "collectionName": "Familia",
       "itunesTrackId": 1447923303,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -10902,22 +13706,28 @@
     "title": "愛燦燦",
     "artist": "美空ひばり",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "1986-05-29",
+      "releaseYear": 1986,
+      "decade": "1980年代",
+      "genre": "演歌",
+      "durationSeconds": 307,
+      "collectionName": "EVERGREEN☆HIBARI Deluxe",
+      "itunesTrackId": 1566820314,
+      "matchStatus": "auto_matched",
+      "source": "itunes",
+      "matchStrategy": "primary_exact",
+      "candidateCount": 1,
+      "candidateReleaseDates": [
+        "1986-05-29"
+      ],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:50:41+09:00"
+    "generatedAt": "2026-06-27T21:13:14+09:00"
   },
   {
     "title": "ハッピーラッキーチャッピー",
@@ -10931,7 +13741,11 @@
       "collectionName": "BONE BORN BOMB",
       "itunesTrackId": 1889741674,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -10952,14 +13766,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:50:44+09:00"
+    "generatedAt": "2026-06-27T21:13:16+09:00"
   },
   {
     "title": "恋風",
@@ -10973,7 +13793,11 @@
       "collectionName": "恋風 - Single",
       "itunesTrackId": 1805325622,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -10994,14 +13818,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:50:46+09:00"
+    "generatedAt": "2026-06-27T21:13:18+09:00"
   },
   {
     "title": "オリビアを聴きながら",
@@ -11015,7 +13845,13 @@
       "collectionName": "杏里-apricot jam-",
       "itunesTrackId": 838835291,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -11036,7 +13872,11 @@
       "collectionName": "レイジーサンデー",
       "itunesTrackId": 1839433876,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -11057,7 +13897,11 @@
       "collectionName": "三日月 - Single",
       "itunesTrackId": 193412328,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -11078,14 +13922,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:50:52+09:00"
+    "generatedAt": "2026-06-27T21:13:20+09:00"
   },
   {
     "title": "まっかな秋",
@@ -11099,14 +13949,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:50:54+09:00"
+    "generatedAt": "2026-06-27T21:13:22+09:00"
   },
   {
     "title": "もみじ",
@@ -11120,14 +13976,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:50:56+09:00"
+    "generatedAt": "2026-06-27T21:13:24+09:00"
   },
   {
     "title": "ツキミソウ",
@@ -11141,7 +14003,11 @@
       "collectionName": "ツキミソウ - Single",
       "itunesTrackId": 1542887040,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -11162,7 +14028,13 @@
       "collectionName": "コイスルオトメ - EP",
       "itunesTrackId": 1536231249,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -11183,14 +14055,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:51:00+09:00"
+    "generatedAt": "2026-06-27T21:13:26+09:00"
   },
   {
     "title": "スターライトパレード",
@@ -11204,7 +14082,13 @@
       "collectionName": "スターライトパレード - Single",
       "itunesTrackId": 984448550,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -11225,14 +14109,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:51:03+09:00"
+    "generatedAt": "2026-06-27T21:13:28+09:00"
   },
   {
     "title": "愛を伝えたいだとか",
@@ -11246,7 +14136,11 @@
       "collectionName": "愛を伝えたいだとか - EP",
       "itunesTrackId": 1218860394,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -11267,7 +14161,13 @@
       "collectionName": "MBS・TBS系TVアニメーション マクロスF(フロンティア) オリジナルサウンドトラック2 娘トラ☆",
       "itunesTrackId": 469329897,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -11288,7 +14188,11 @@
       "collectionName": "KING - Single",
       "itunesTrackId": 1525673476,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -11309,7 +14213,13 @@
       "collectionName": "明日晴れるかな - Single",
       "itunesTrackId": 1082738072,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -11330,7 +14240,11 @@
       "collectionName": "Traveler",
       "itunesTrackId": 1479397583,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -11351,7 +14265,13 @@
       "collectionName": "インフェルノ - Single",
       "itunesTrackId": 1471459432,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -11372,14 +14292,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:51:13+09:00"
+    "generatedAt": "2026-06-27T21:13:30+09:00"
   },
   {
     "title": "ぎゅっと。",
@@ -11393,7 +14319,11 @@
       "collectionName": "ぎゅっと。 - Single",
       "itunesTrackId": 1523598194,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -11414,7 +14344,11 @@
       "collectionName": "機動戦士ガンダムUC オリジナルサウンドトラック 1",
       "itunesTrackId": 1524640234,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -11435,7 +14369,13 @@
       "collectionName": "「医龍 Team Medical Dragon」オリジナルサウンドトラック",
       "itunesTrackId": 1443237459,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -11456,14 +14396,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:51:18+09:00"
+    "generatedAt": "2026-06-27T21:13:34+09:00"
   },
   {
     "title": "E0$-3:罪",
@@ -11477,7 +14423,11 @@
       "collectionName": "七つの大罪 オリジナル・サウンドトラック 2",
       "itunesTrackId": 1537791539,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -11498,7 +14448,13 @@
       "collectionName": "10月無口な君を忘れる - Single",
       "itunesTrackId": 1558400919,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -11511,22 +14467,31 @@
     "title": "Crazy Party Night ～ぱんぷきんの逆襲～",
     "artist": "きゃりーぱみゅぱみゅ",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2015-09-02",
+      "releaseYear": 2015,
+      "decade": "2010年代",
+      "genre": "エレクトロニック",
+      "durationSeconds": 254,
+      "collectionName": "Crazy Party Night 〜ぱんぷきんの逆襲〜",
+      "itunesTrackId": 1031470155,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 2,
+      "candidateReleaseDates": [
+        "2015-09-02"
+      ],
+      "reviewReason": [
+        "normalized_match",
+        "title_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:51:22+09:00"
+    "generatedAt": "2026-06-27T21:13:36+09:00"
   },
   {
     "title": "ハロウィン・ナイト",
@@ -11540,7 +14505,13 @@
       "collectionName": "ハロウィン・ナイト (Type A) - EP",
       "itunesTrackId": 1029291701,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -11561,14 +14532,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:51:25+09:00"
+    "generatedAt": "2026-06-27T21:13:37+09:00"
   },
   {
     "title": "IRIS OUT",
@@ -11582,7 +14559,11 @@
       "collectionName": "IRIS OUT - Single",
       "itunesTrackId": 1837658529,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -11603,14 +14584,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:51:28+09:00"
+    "generatedAt": "2026-06-27T21:13:39+09:00"
   },
   {
     "title": "ヴァンパイア",
@@ -11624,7 +14611,11 @@
       "collectionName": "ヴァンパイア - Single",
       "itunesTrackId": 1555448592,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -11645,7 +14636,11 @@
       "collectionName": "SURF & SNOW",
       "itunesTrackId": 1436009955,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -11666,7 +14661,11 @@
       "collectionName": "Nicheシンドローム",
       "itunesTrackId": 1838917139,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -11687,7 +14686,11 @@
       "collectionName": "スターマーカー - Single",
       "itunesTrackId": 1536466358,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -11708,7 +14711,11 @@
       "collectionName": "The Road To Yamazaki - The Best For Beginners (Standards)",
       "itunesTrackId": 1442902260,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -11729,7 +14736,11 @@
       "collectionName": "オールドファッション - EP",
       "itunesTrackId": 1441482867,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -11750,7 +14761,11 @@
       "collectionName": "石川さゆり45周年盤, Vol. I",
       "itunesTrackId": 1838960470,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -11771,7 +14786,11 @@
       "collectionName": "dream",
       "itunesTrackId": 1537293109,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -11792,7 +14811,13 @@
       "collectionName": "HARVEST -SINGLES 1992-1997-",
       "itunesTrackId": 1537347334,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -11813,7 +14838,11 @@
       "collectionName": "Overdose - Single",
       "itunesTrackId": 1640410315,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -11834,7 +14863,11 @@
       "collectionName": "ALL YOURS",
       "itunesTrackId": 1536254630,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -11855,7 +14888,11 @@
       "collectionName": "月灯りふんわり落ちてくる夜 - Single",
       "itunesTrackId": 1657418958,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -11876,35 +14913,50 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:51:47+09:00"
+    "generatedAt": "2026-06-27T21:14:01+09:00"
   },
   {
     "title": "さよならエレジー",
     "artist": "菅田将暉",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2018-01-07",
+      "releaseYear": 2018,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 259,
+      "collectionName": "さよならエレジー - Single",
+      "itunesTrackId": 1536317386,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 2,
+      "candidateReleaseDates": [
+        "2018-01-07"
+      ],
+      "reviewReason": [
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:51:48+09:00"
+    "generatedAt": "2026-06-27T21:14:02+09:00"
   },
   {
     "title": "サウダージ",
@@ -11918,7 +14970,13 @@
       "collectionName": "PORNO GRAFFITTI BEST RED'S",
       "itunesTrackId": 1537232408,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -11939,7 +14997,13 @@
       "collectionName": "恋人ごっこ - Single",
       "itunesTrackId": 1496731154,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -11960,7 +15024,11 @@
       "collectionName": "イケナイ太陽 - Single",
       "itunesTrackId": 1537392624,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -11981,7 +15049,11 @@
       "collectionName": "Best of WANDS: History",
       "itunesTrackId": 75465805,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -12002,7 +15074,11 @@
       "collectionName": "大阪LOVER - Single",
       "itunesTrackId": 1444614244,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -12023,7 +15099,13 @@
       "collectionName": "島人ぬ宝 - EP",
       "itunesTrackId": 1838699008,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -12044,7 +15126,13 @@
       "collectionName": "YASUSHI NAKANISHI SINGLE COLLECTION",
       "itunesTrackId": 470116064,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -12065,7 +15153,11 @@
       "collectionName": "シャ乱Qベスト 〜四半世紀伝説〜",
       "itunesTrackId": 1536777679,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -12086,7 +15178,11 @@
       "collectionName": "チャンカパーナ - EP",
       "itunesTrackId": 1765461309,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -12107,7 +15203,11 @@
       "collectionName": "気まぐれロマンティック - Single",
       "itunesTrackId": 1536256436,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -12128,7 +15228,11 @@
       "collectionName": "Blue Jeans - Single",
       "itunesTrackId": 1821849522,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -12149,7 +15253,11 @@
       "collectionName": "Bling-Bang-Bang-Born - Single",
       "itunesTrackId": 1720332181,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -12170,7 +15278,11 @@
       "collectionName": "ハレンチ",
       "itunesTrackId": 1585848051,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -12191,7 +15303,11 @@
       "collectionName": "39",
       "itunesTrackId": 1810382629,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -12204,22 +15320,31 @@
     "title": "旅路",
     "artist": "藤井風",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2021-03-01",
+      "releaseYear": 2021,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 277,
+      "collectionName": "旅路 - Single",
+      "itunesTrackId": 1555177261,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 2,
+      "candidateReleaseDates": [
+        "2021-03-01"
+      ],
+      "reviewReason": [
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:52:15+09:00"
+    "generatedAt": "2026-06-27T21:14:03+09:00"
   },
   {
     "title": "月光花",
@@ -12233,7 +15358,11 @@
       "collectionName": "JOKER",
       "itunesTrackId": 843626327,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -12254,7 +15383,11 @@
       "collectionName": "ANTI ANTI GENERATION",
       "itunesTrackId": 1518516333,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -12275,14 +15408,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:52:19+09:00"
+    "generatedAt": "2026-06-27T21:14:05+09:00"
   },
   {
     "title": "アイアイ",
@@ -12296,14 +15435,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:52:21+09:00"
+    "generatedAt": "2026-06-27T21:14:07+09:00"
   },
   {
     "title": "揺れる想い",
@@ -12317,7 +15462,11 @@
       "collectionName": "ZARD BLEND～SUN&STONE～",
       "itunesTrackId": 75712664,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -12338,7 +15487,13 @@
       "collectionName": "ザ・ゴールデンベスト~Pressure~",
       "itunesTrackId": 376156350,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -12359,7 +15514,11 @@
       "collectionName": "GAME",
       "itunesTrackId": 657666313,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -12380,7 +15539,11 @@
       "collectionName": "ホワイトキス - Single",
       "itunesTrackId": 1593497539,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -12393,22 +15556,33 @@
     "title": "め組のひと",
     "artist": "ラッツ&スター",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "1983-04-01",
+      "releaseYear": 1983,
+      "decade": "1980年代",
+      "genre": "J-Pop",
+      "durationSeconds": 207,
+      "collectionName": "BACK TO THE BASIC",
+      "itunesTrackId": 1536310759,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 7,
+      "candidateReleaseDates": [
+        "1983-04-01",
+        "2003-01-01"
+      ],
+      "reviewReason": [
+        "multiple_release_dates",
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:52:28+09:00"
+    "generatedAt": "2026-06-27T21:14:08+09:00"
   },
   {
     "title": "ノスタルジア",
@@ -12422,7 +15596,13 @@
       "collectionName": "ノスタルジア - EP",
       "itunesTrackId": 1536260454,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -12443,7 +15623,11 @@
       "collectionName": "笑顔 - EP",
       "itunesTrackId": 1536269605,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -12464,7 +15648,11 @@
       "collectionName": "メリーゴーランド - Single",
       "itunesTrackId": 1657348387,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -12485,14 +15673,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:52:33+09:00"
+    "generatedAt": "2026-06-27T21:14:10+09:00"
   },
   {
     "title": "さよならの夏",
@@ -12506,14 +15700,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:52:35+09:00"
+    "generatedAt": "2026-06-27T21:14:12+09:00"
   },
   {
     "title": "幸せならてをたたこう",
@@ -12527,14 +15727,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:52:36+09:00"
+    "generatedAt": "2026-06-27T21:14:14+09:00"
   },
   {
     "title": "マジンガーZ",
@@ -12548,7 +15754,11 @@
       "collectionName": "スーパーロボット魂 ボーカルベストセレクション",
       "itunesTrackId": 458237797,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -12569,7 +15779,11 @@
       "collectionName": "<戦後70年 歌のあゆみ> こどものうた ~とんがり帽子・みかんの花さく丘~",
       "itunesTrackId": 1018806356,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -12590,14 +15804,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:52:41+09:00"
+    "generatedAt": "2026-06-27T21:14:16+09:00"
   },
   {
     "title": "Flower Dance",
@@ -12611,7 +15831,11 @@
       "collectionName": "A Cup Of Coffee - Single",
       "itunesTrackId": 392228034,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -12632,7 +15856,13 @@
       "collectionName": "野球選手が夢だった",
       "itunesTrackId": 1443308178,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -12653,7 +15883,13 @@
       "collectionName": "もらい泣き - Single",
       "itunesTrackId": 157112134,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -12674,14 +15910,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:52:46+09:00"
+    "generatedAt": "2026-06-27T21:14:18+09:00"
   },
   {
     "title": "ロマンティックあげるよ",
@@ -12695,14 +15937,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:52:48+09:00"
+    "generatedAt": "2026-06-27T21:14:20+09:00"
   },
   {
     "title": "GO-GO たまごっち",
@@ -12716,35 +15964,50 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:52:59+09:00"
+    "generatedAt": "2026-06-27T21:14:22+09:00"
   },
   {
     "title": "PIANO*GIRL",
     "artist": "OSTER project",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2012-01-08",
+      "releaseYear": 2012,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 259,
+      "collectionName": "OSTERさんのベスト",
+      "itunesTrackId": 662012432,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 1,
+      "candidateReleaseDates": [
+        "2012-01-08"
+      ],
+      "reviewReason": [
+        "normalized_match",
+        "title_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:53:01+09:00"
+    "generatedAt": "2026-06-27T21:14:23+09:00"
   },
   {
     "title": "JANE DOE",
@@ -12758,14 +16021,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:53:02+09:00"
+    "generatedAt": "2026-06-27T21:14:25+09:00"
   },
   {
     "title": "ビンクスの酒",
@@ -12779,14 +16048,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:53:03+09:00"
+    "generatedAt": "2026-06-27T21:14:27+09:00"
   },
   {
     "title": "ウイスキーが、お好きでしょ",
@@ -12800,14 +16075,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:53:05+09:00"
+    "generatedAt": "2026-06-27T21:14:29+09:00"
   },
   {
     "title": "ファジーネーブル",
@@ -12821,7 +16102,11 @@
       "collectionName": "ファジーネーブル - Single",
       "itunesTrackId": 1681024620,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -12842,7 +16127,13 @@
       "collectionName": "BELOVED",
       "itunesTrackId": 989804527,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -12863,7 +16154,13 @@
       "collectionName": "美しき残酷な世界【通常盤】- EP",
       "itunesTrackId": 635819165,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -12884,7 +16181,11 @@
       "collectionName": "コントラスト - Single",
       "itunesTrackId": 1785578366,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -12897,22 +16198,31 @@
     "title": "Komm, susser Tod",
     "artist": "ARIANNE",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "1997-08-01",
+      "releaseYear": 1997,
+      "decade": "1990年代",
+      "genre": "アニメ",
+      "durationSeconds": 476,
+      "collectionName": "THANATOS-IF I CAN'T BE YOURS- EP",
+      "itunesTrackId": 258929655,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 1,
+      "candidateReleaseDates": [
+        "1997-08-01"
+      ],
+      "reviewReason": [
+        "normalized_match",
+        "title_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:53:12+09:00"
+    "generatedAt": "2026-06-27T21:14:30+09:00"
   },
   {
     "title": "カラフル",
@@ -12926,7 +16236,11 @@
       "collectionName": "カラフル - Single",
       "itunesTrackId": 1537263406,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -12947,14 +16261,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:53:15+09:00"
+    "generatedAt": "2026-06-27T21:14:32+09:00"
   },
   {
     "title": "森のくまさん",
@@ -12968,14 +16288,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:53:16+09:00"
+    "generatedAt": "2026-06-27T21:14:34+09:00"
   },
   {
     "title": "夜行",
@@ -12989,7 +16315,11 @@
       "collectionName": "夜行 - Single",
       "itunesTrackId": 1498698119,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -13010,7 +16340,11 @@
       "collectionName": "Morning Breeze - 朝に聴きたいJ-POP -",
       "itunesTrackId": 1644782351,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -13031,7 +16365,11 @@
       "collectionName": "光 - EP",
       "itunesTrackId": 1444860451,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -13052,7 +16390,13 @@
       "collectionName": "One Last Kiss",
       "itunesTrackId": 1542953977,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -13073,7 +16417,13 @@
       "collectionName": "TAKASHI UTSUNOMIYA THE BEST \"FILES\"",
       "itunesTrackId": 1537051814,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -13094,14 +16444,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:53:26+09:00"
+    "generatedAt": "2026-06-27T21:14:36+09:00"
   },
   {
     "title": "Happy Birthday to You",
@@ -13115,14 +16471,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:53:27+09:00"
+    "generatedAt": "2026-06-27T21:14:38+09:00"
   },
   {
     "title": "HAPPY HAPPY BIRTHDAY",
@@ -13136,7 +16498,11 @@
       "collectionName": "MAGIC",
       "itunesTrackId": 1536199616,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -13157,7 +16523,11 @@
       "collectionName": "Break Out / ようかい体操第一 - Single",
       "itunesTrackId": 857572447,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -13178,7 +16548,11 @@
       "collectionName": "愛のうた ~ ピクミンCMソング - Single",
       "itunesTrackId": 715708921,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -13199,7 +16573,11 @@
       "collectionName": "Assort",
       "itunesTrackId": 1617575013,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -13220,7 +16598,11 @@
       "collectionName": "Dynamite - EP",
       "itunesTrackId": 1528831888,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -13241,7 +16623,11 @@
       "collectionName": "いままでのA面、B面ですと!?",
       "itunesTrackId": 1440746860,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -13262,7 +16648,11 @@
       "collectionName": "イイじゃん - Single",
       "itunesTrackId": 1794499543,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -13283,7 +16673,11 @@
       "collectionName": "明日の私に幸あれ - Single",
       "itunesTrackId": 1787114805,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -13304,7 +16698,11 @@
       "collectionName": "手紙 - Single",
       "itunesTrackId": 1828857729,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -13317,22 +16715,34 @@
     "title": "君の好きなとこ",
     "artist": "平井堅",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2007-02-28",
+      "releaseYear": 2007,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 330,
+      "collectionName": "君の好きなとこ - EP",
+      "itunesTrackId": 1536148866,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 3,
+      "candidateReleaseDates": [
+        "2007-02-28",
+        "2008-03-12",
+        "2017-07-12"
+      ],
+      "reviewReason": [
+        "multiple_release_dates",
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:53:43+09:00"
+    "generatedAt": "2026-06-27T21:14:39+09:00"
   },
   {
     "title": "灯を護る",
@@ -13346,7 +16756,11 @@
       "collectionName": "灯を護る - Single",
       "itunesTrackId": 1841799445,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -13367,7 +16781,11 @@
       "collectionName": "flos - Single",
       "itunesTrackId": 1373125555,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -13388,7 +16806,11 @@
       "collectionName": "Because",
       "itunesTrackId": 1281425806,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -13409,7 +16831,13 @@
       "collectionName": "七夕夜想曲〜村下孝蔵最高選曲集 其の壱",
       "itunesTrackId": 1538456299,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -13430,7 +16858,11 @@
       "collectionName": "KINGDOM HEARTS - HD 2.5 ReMIX - (Original Soundtrack)",
       "itunesTrackId": 1669115108,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -13451,7 +16883,11 @@
       "collectionName": "プラットフォーム - Single",
       "itunesTrackId": 1843380734,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -13472,77 +16908,117 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:53:53+09:00"
+    "generatedAt": "2026-06-27T21:14:41+09:00"
   },
   {
     "title": "ノンフィクション",
     "artist": "平井堅",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2017-06-07",
+      "releaseYear": 2017,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 272,
+      "collectionName": "Ken Hirai  Singles Best Collection 歌バカ 2",
+      "itunesTrackId": 1538114935,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 3,
+      "candidateReleaseDates": [
+        "2017-06-07"
+      ],
+      "reviewReason": [
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:53:55+09:00"
+    "generatedAt": "2026-06-27T21:14:59+09:00"
   },
   {
     "title": "君は薔薇より美しい",
     "artist": "布施明",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "1978-01-17",
+      "releaseYear": 1978,
+      "decade": "1970年代",
+      "genre": "演歌",
+      "durationSeconds": 223,
+      "collectionName": "華麗なる \"布施明の世界\" ~愛の歌を今あなたに~ [",
+      "itunesTrackId": 384861567,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 12,
+      "candidateReleaseDates": [
+        "1978-01-17",
+        "1979-01-17",
+        "1979-07-05",
+        "2002-09-19",
+        "2015-03-25",
+        "2017-08-25",
+        "2021-09-01"
+      ],
+      "reviewReason": [
+        "multiple_release_dates",
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:53:56+09:00"
+    "generatedAt": "2026-06-27T21:15:00+09:00"
   },
   {
     "title": "冬が終わる前に",
     "artist": "清水翔太",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2011-12-21",
+      "releaseYear": 2011,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 321,
+      "collectionName": "冬が終わる前に - EP",
+      "itunesTrackId": 1537436336,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 3,
+      "candidateReleaseDates": [
+        "2011-12-21"
+      ],
+      "reviewReason": [
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:54:00+09:00"
+    "generatedAt": "2026-06-27T21:15:01+09:00"
   },
   {
     "title": "冬のうた",
@@ -13556,7 +17032,11 @@
       "collectionName": "Kiroroのうた ①",
       "itunesTrackId": 106845813,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -13577,7 +17057,13 @@
       "collectionName": "君は僕の宝物",
       "itunesTrackId": 284522066,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -13598,7 +17084,11 @@
       "collectionName": "冬と春 - Single",
       "itunesTrackId": 1723932449,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -13619,7 +17109,13 @@
       "collectionName": "冬のプレゼント - Single",
       "itunesTrackId": 1540891246,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -13640,7 +17136,11 @@
       "collectionName": "Candle Lights",
       "itunesTrackId": 1482063640,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -13653,22 +17153,31 @@
     "title": "あなたに出会わなければ～夏雪冬花～",
     "artist": "Aimer",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2012-07-27",
+      "releaseYear": 2012,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 363,
+      "collectionName": "あなたに出会わなければ〜夏雪冬花〜 / 星屑ビーナス - Single",
+      "itunesTrackId": 1536123755,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 3,
+      "candidateReleaseDates": [
+        "2012-07-27"
+      ],
+      "reviewReason": [
+        "normalized_match",
+        "title_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:54:08+09:00"
+    "generatedAt": "2026-06-27T21:15:02+09:00"
   },
   {
     "title": "蝶々結び",
@@ -13682,7 +17191,11 @@
       "collectionName": "蝶々結び - Single",
       "itunesTrackId": 1538258769,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -13703,14 +17216,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:54:11+09:00"
+    "generatedAt": "2026-06-27T21:15:04+09:00"
   },
   {
     "title": "朝ごはんの歌",
@@ -13724,7 +17243,11 @@
       "collectionName": "コクリコ坂から歌集",
       "itunesTrackId": 445827824,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -13745,7 +17268,11 @@
       "collectionName": "春よ、来い - Single",
       "itunesTrackId": 1436012884,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -13766,7 +17293,11 @@
       "collectionName": "AlwayS - Single",
       "itunesTrackId": 1780495330,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -13787,7 +17318,11 @@
       "collectionName": "ゆずイロハ1997-2017",
       "itunesTrackId": 1223976833,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -13800,43 +17335,67 @@
     "title": "赤いスイートピー",
     "artist": "松田聖子",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "1980-01-01",
+      "releaseYear": 1980,
+      "decade": "1980年代",
+      "genre": "J-Pop",
+      "durationSeconds": 220,
+      "collectionName": "BibleII",
+      "itunesTrackId": 1536877720,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 15,
+      "candidateReleaseDates": [
+        "1980-01-01",
+        "1982-01-21"
+      ],
+      "reviewReason": [
+        "multiple_release_dates",
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:54:18+09:00"
+    "generatedAt": "2026-06-27T21:15:05+09:00"
   },
   {
     "title": "青い珊瑚礁",
     "artist": "松田聖子",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "1980-01-01",
+      "releaseYear": 1980,
+      "decade": "1980年代",
+      "genre": "J-Pop",
+      "durationSeconds": 222,
+      "collectionName": "BibleII",
+      "itunesTrackId": 1536877719,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 11,
+      "candidateReleaseDates": [
+        "1980-01-01",
+        "1980-07-01",
+        "1987-11-21",
+        "2018-02-28"
+      ],
+      "reviewReason": [
+        "multiple_release_dates",
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:54:20+09:00"
+    "generatedAt": "2026-06-27T21:15:06+09:00"
   },
   {
     "title": "HAPPY BIRTHDAY",
@@ -13850,7 +17409,11 @@
       "collectionName": "HAPPY BIRTHDAY - EP",
       "itunesTrackId": 1452746756,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -13871,7 +17434,13 @@
       "collectionName": "My song  Your song",
       "itunesTrackId": 1536256938,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -13892,14 +17461,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:54:24+09:00"
+    "generatedAt": "2026-06-27T21:15:08+09:00"
   },
   {
     "title": "KICK BACK",
@@ -13913,7 +17488,11 @@
       "collectionName": "KICK BACK - Single",
       "itunesTrackId": 1648272180,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -13934,7 +17513,11 @@
       "collectionName": "とてと - Single",
       "itunesTrackId": 1821143767,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -13955,7 +17538,11 @@
       "collectionName": "1991 - Single",
       "itunesTrackId": 1844275014,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -13976,7 +17563,11 @@
       "collectionName": "BORDERLESS",
       "itunesTrackId": 853560905,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -13997,7 +17588,11 @@
       "collectionName": "ときめきルールブック",
       "itunesTrackId": 1780265107,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -14018,7 +17613,11 @@
       "collectionName": "はちゃめちゃわちゃライフ! / JAM - EP",
       "itunesTrackId": 1839369466,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -14039,14 +17638,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:54:34+09:00"
+    "generatedAt": "2026-06-27T21:15:10+09:00"
   },
   {
     "title": "プラチナ",
@@ -14060,7 +17665,13 @@
       "collectionName": "プラチナ - Single",
       "itunesTrackId": 543496280,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -14073,22 +17684,31 @@
     "title": "たしかなこと",
     "artist": "小田和正",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2005-05-25",
+      "releaseYear": 2005,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 302,
+      "collectionName": "たしかなこと - Single",
+      "itunesTrackId": 1536352756,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 4,
+      "candidateReleaseDates": [
+        "2005-05-25"
+      ],
+      "reviewReason": [
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:54:37+09:00"
+    "generatedAt": "2026-06-27T21:15:11+09:00"
   },
   {
     "title": "雨",
@@ -14102,7 +17722,13 @@
       "collectionName": "雨 - Single",
       "itunesTrackId": 528971992,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -14123,14 +17749,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:54:40+09:00"
+    "generatedAt": "2026-06-27T21:15:13+09:00"
   },
   {
     "title": "雨と僕の話",
@@ -14144,7 +17776,11 @@
       "collectionName": "MAGIC",
       "itunesTrackId": 1456063433,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -14165,7 +17801,11 @@
       "collectionName": "ファッションモンスター - Single",
       "itunesTrackId": 567017941,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -14186,7 +17826,13 @@
       "collectionName": "ALL TIME BEST 1998-2018",
       "itunesTrackId": 1441818357,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -14207,7 +17853,11 @@
       "collectionName": "ある未来より愛を込めて - Single",
       "itunesTrackId": 1820851477,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -14228,7 +17878,11 @@
       "collectionName": "Consolation",
       "itunesTrackId": 1537251340,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -14249,7 +17903,11 @@
       "collectionName": "総合",
       "itunesTrackId": 1594482567,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -14270,14 +17928,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:54:50+09:00"
+    "generatedAt": "2026-06-27T21:15:15+09:00"
   },
   {
     "title": "好きすぎて滅！",
@@ -14291,7 +17955,11 @@
       "collectionName": "好きすぎて滅! - Single",
       "itunesTrackId": 1846753946,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -14312,7 +17980,13 @@
       "collectionName": "Bon Appetit!",
       "itunesTrackId": 257401162,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -14333,14 +18007,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:54:54+09:00"
+    "generatedAt": "2026-06-27T21:15:17+09:00"
   },
   {
     "title": "Love me, Love you",
@@ -14354,7 +18034,11 @@
       "collectionName": "Love me, Love you - EP",
       "itunesTrackId": 1441018140,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -14375,7 +18059,11 @@
       "collectionName": "Forever Love - Single",
       "itunesTrackId": 1886167293,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -14396,14 +18084,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:55:00+09:00"
+    "generatedAt": "2026-06-27T21:15:19+09:00"
   },
   {
     "title": "恋人たちのクリスマス",
@@ -14417,14 +18111,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:55:02+09:00"
+    "generatedAt": "2026-06-27T21:15:21+09:00"
   },
   {
     "title": "クリスマス・イブ",
@@ -14438,7 +18138,11 @@
       "collectionName": "クリスマス・イブ (30th Anniversary Edition) - EP",
       "itunesTrackId": 1300670407,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -14459,14 +18163,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:55:05+09:00"
+    "generatedAt": "2026-06-27T21:15:24+09:00"
   },
   {
     "title": "サンタが街にやってくる",
@@ -14480,14 +18190,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:55:06+09:00"
+    "generatedAt": "2026-06-27T21:15:25+09:00"
   },
   {
     "title": "ジングルベル",
@@ -14501,14 +18217,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:55:08+09:00"
+    "generatedAt": "2026-06-27T21:15:27+09:00"
   },
   {
     "title": "きよしこの夜",
@@ -14522,14 +18244,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:55:09+09:00"
+    "generatedAt": "2026-06-27T21:15:30+09:00"
   },
   {
     "title": "もろびとこぞりて",
@@ -14543,14 +18271,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:55:10+09:00"
+    "generatedAt": "2026-06-27T21:15:32+09:00"
   },
   {
     "title": "Winter Bells",
@@ -14564,7 +18298,13 @@
       "collectionName": "Winter Bells - Single",
       "itunesTrackId": 1714221548,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -14585,7 +18325,11 @@
       "collectionName": "バニラ - Single",
       "itunesTrackId": 1611103469,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -14606,7 +18350,11 @@
       "collectionName": "恋をして - Single",
       "itunesTrackId": 1780907436,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -14627,7 +18375,13 @@
       "collectionName": "珠玉のインスト・クラシック ベストヒット35曲!〜Epic35〜",
       "itunesTrackId": 1536311937,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -14648,14 +18402,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:55:18+09:00"
+    "generatedAt": "2026-06-27T21:16:00+09:00"
   },
   {
     "title": "笑ったり転んだり",
@@ -14669,7 +18429,11 @@
       "collectionName": "笑ったり転んだり - Single",
       "itunesTrackId": 1834112550,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -14690,7 +18454,13 @@
       "collectionName": "愛の言霊(ことだま) ~Spiritual Message~ - Single",
       "itunesTrackId": 949251804,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -14711,7 +18481,11 @@
       "collectionName": "TSUNAMI - Single",
       "itunesTrackId": 949250892,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -14732,7 +18506,13 @@
       "collectionName": "TOMORROW / BLUE STAR - EP",
       "itunesTrackId": 291351980,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -14753,7 +18533,11 @@
       "collectionName": "Mr.Children 2005 - 2010 <macro>",
       "itunesTrackId": 1374993078,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -14774,7 +18558,11 @@
       "collectionName": "人間開花",
       "itunesTrackId": 1518844828,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -14795,7 +18583,11 @@
       "collectionName": "賜物 - Single",
       "itunesTrackId": 1805033133,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -14816,7 +18608,11 @@
       "collectionName": "エルマ",
       "itunesTrackId": 1474062410,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -14837,7 +18633,11 @@
       "collectionName": "Sugar Hunter 〜THE BEST LOVE SONGS OF CHARA〜",
       "itunesTrackId": 1536255283,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -14858,7 +18658,11 @@
       "collectionName": "最後の優しさ/SUNLIGHT - Single",
       "itunesTrackId": 303414186,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -14879,7 +18683,11 @@
       "collectionName": "ヒーロー/明日へ - Single",
       "itunesTrackId": 338515101,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -14900,7 +18708,13 @@
       "collectionName": "股旅",
       "itunesTrackId": 1537348515,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -14921,14 +18735,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:55:36+09:00"
+    "generatedAt": "2026-06-27T21:16:02+09:00"
   },
   {
     "title": "サクラウサギ",
@@ -14942,7 +18762,11 @@
       "collectionName": "サクラウサギ - Single",
       "itunesTrackId": 1546887855,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -14963,7 +18787,11 @@
       "collectionName": "女子、ジョーキョー。 - EP",
       "itunesTrackId": 1063702346,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -14984,7 +18812,13 @@
       "collectionName": "ミッドナイト・リフレクション - Single",
       "itunesTrackId": 1787659169,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -15005,7 +18839,11 @@
       "collectionName": "桜が降る夜は - Single",
       "itunesTrackId": 1551664064,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -15026,14 +18864,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:55:43+09:00"
+    "generatedAt": "2026-06-27T21:16:04+09:00"
   },
   {
     "title": "らしさ",
@@ -15047,7 +18891,11 @@
       "collectionName": "らしさ - Single",
       "itunesTrackId": 1826940240,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -15068,7 +18916,11 @@
       "collectionName": "HAPPY BIVOUAC",
       "itunesTrackId": 317681417,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -15089,7 +18941,13 @@
       "collectionName": "Share The World/ウィーアー! - EP",
       "itunesTrackId": 311618211,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -15110,14 +18968,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:56:01+09:00"
+    "generatedAt": "2026-06-27T21:16:06+09:00"
   },
   {
     "title": "Autumn Leaves",
@@ -15131,14 +18995,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:56:03+09:00"
+    "generatedAt": "2026-06-27T21:16:08+09:00"
   },
   {
     "title": "Moon River",
@@ -15152,7 +19022,13 @@
       "collectionName": "Breakfast At Tiffany's (Music from the Motion Picture) [Remastered]",
       "itunesTrackId": 306677750,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -15173,14 +19049,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:56:06+09:00"
+    "generatedAt": "2026-06-27T21:16:10+09:00"
   },
   {
     "title": "Misty",
@@ -15194,7 +19076,13 @@
       "collectionName": "The Original Misty",
       "itunesTrackId": 1443144347,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -15215,7 +19103,11 @@
       "collectionName": "美少女戦士セーラームーン ベスト",
       "itunesTrackId": 1542353773,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -15236,7 +19128,13 @@
       "collectionName": "空の飛び方",
       "itunesTrackId": 1440779327,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -15257,14 +19155,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:56:12+09:00"
+    "generatedAt": "2026-06-27T21:16:12+09:00"
   },
   {
     "title": "愛♡スクリ～ム！",
@@ -15278,7 +19182,11 @@
       "collectionName": "愛♡スクリ～ム! - EP",
       "itunesTrackId": 1785614776,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -15299,7 +19207,11 @@
       "collectionName": "呼び声 - Single",
       "itunesTrackId": 1859586540,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -15320,7 +19232,11 @@
       "collectionName": "アドレナ - Single",
       "itunesTrackId": 1861370949,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -15341,7 +19257,11 @@
       "collectionName": "失恋スクラップ",
       "itunesTrackId": 1490385560,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -15362,7 +19282,13 @@
       "collectionName": "pink - Single",
       "itunesTrackId": 1670931224,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -15383,7 +19309,11 @@
       "collectionName": "たんぽぽ/海賊船/其の拳 - EP",
       "itunesTrackId": 1537405046,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -15404,7 +19334,11 @@
       "collectionName": "Memories - Single",
       "itunesTrackId": 1537555916,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -15425,7 +19359,11 @@
       "collectionName": "これからもウォルピス社の提供でお送りします。",
       "itunesTrackId": 1446682679,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -15446,14 +19384,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:56:24+09:00"
+    "generatedAt": "2026-06-27T21:16:14+09:00"
   },
   {
     "title": "セロリ",
@@ -15467,7 +19411,11 @@
       "collectionName": "YAMAZAKI MASAYOSHI the BEST / BLUE PERIOD",
       "itunesTrackId": 1440883056,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -15488,7 +19436,13 @@
       "collectionName": "Buono! COMPLETE",
       "itunesTrackId": 1511117841,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -15509,7 +19463,13 @@
       "collectionName": "ギブス - Single",
       "itunesTrackId": 1384342132,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -15530,7 +19490,13 @@
       "collectionName": "Every Best Single ~COMPLETE~",
       "itunesTrackId": 1159580791,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -15551,7 +19517,11 @@
       "collectionName": "殿のスポットライト",
       "itunesTrackId": 877542049,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -15572,7 +19542,13 @@
       "collectionName": "ひとつ屋根の下 2",
       "itunesTrackId": 1445975705,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -15593,14 +19569,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:56:34+09:00"
+    "generatedAt": "2026-06-27T21:16:16+09:00"
   },
   {
     "title": "やぎさんゆうびん",
@@ -15614,14 +19596,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:56:36+09:00"
+    "generatedAt": "2026-06-27T21:16:18+09:00"
   },
   {
     "title": "おやすみ泣き声、さよなら歌姫",
@@ -15635,7 +19623,11 @@
       "collectionName": "おやすみ泣き声、さよなら歌姫 - Single",
       "itunesTrackId": 561857683,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -15656,7 +19648,11 @@
       "collectionName": "ミカヅキ-special edition - Single",
       "itunesTrackId": 1536015134,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -15677,7 +19673,11 @@
       "collectionName": "Fiction e.p",
       "itunesTrackId": 1537461096,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -15698,7 +19698,11 @@
       "collectionName": "Sun Dance",
       "itunesTrackId": 1538261229,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -15719,14 +19723,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:56:43+09:00"
+    "generatedAt": "2026-06-27T21:16:20+09:00"
   },
   {
     "title": "情熱大陸",
@@ -15740,7 +19750,13 @@
       "collectionName": "BEST of image",
       "itunesTrackId": 1537323110,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -15761,14 +19777,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:56:46+09:00"
+    "generatedAt": "2026-06-27T21:16:22+09:00"
   },
   {
     "title": "世界には愛しかない",
@@ -15782,7 +19804,11 @@
       "collectionName": "永遠より長い一瞬 ~あの頃、確かに存在した私たち~(Complete Edition)",
       "itunesTrackId": 1533414468,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -15795,22 +19821,31 @@
     "title": "海の声",
     "artist": "浦島太郎（桐谷健太）",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2015-12-02",
+      "releaseYear": 2015,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 226,
+      "collectionName": "香音-KANON- - EP",
+      "itunesTrackId": 1443183379,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 7,
+      "candidateReleaseDates": [
+        "2015-12-02"
+      ],
+      "reviewReason": [
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:56:49+09:00"
+    "generatedAt": "2026-06-27T21:16:23+09:00"
   },
   {
     "title": "ふたつ星",
@@ -15824,7 +19859,11 @@
       "collectionName": "THE COMPLETE COLLECTION OF I WiSH",
       "itunesTrackId": 1537055929,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -15845,7 +19884,13 @@
       "collectionName": "Greatest Hits 1991-2016 ~All Singles + ~",
       "itunesTrackId": 1490814556,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -15866,7 +19911,11 @@
       "collectionName": "昭和の童謡のあゆみ～キングレコード90周年を彩る100曲",
       "itunesTrackId": 1597901812,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -15887,7 +19936,11 @@
       "collectionName": "藤子・F・不二雄 生誕90周年 藤子・F・不二雄 TV MUSIC HISTORY II -藤子・F・不二雄作品集2-",
       "itunesTrackId": 1756878660,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -15908,7 +19961,13 @@
       "collectionName": "Every Best Single 2 ~middLe period~",
       "itunesTrackId": 1036794790,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -15929,7 +19988,11 @@
       "collectionName": "Around The World - EP",
       "itunesTrackId": 122899374,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -15950,14 +20013,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:56:58+09:00"
+    "generatedAt": "2026-06-27T21:16:25+09:00"
   },
   {
     "title": "lulu.",
@@ -15971,7 +20040,11 @@
       "collectionName": "lulu. - Single",
       "itunesTrackId": 1867354081,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -15992,7 +20065,11 @@
       "collectionName": "天気の子 (complete version) - EP",
       "itunesTrackId": 1518516241,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -16013,7 +20090,11 @@
       "collectionName": "火星人 - Single",
       "itunesTrackId": 1809266711,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -16034,7 +20115,11 @@
       "collectionName": "裸の勇者 - EP",
       "itunesTrackId": 1600223385,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -16055,7 +20140,11 @@
       "collectionName": "裸の心 - Single",
       "itunesTrackId": 1508133095,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -16076,7 +20165,11 @@
       "collectionName": "歌でおぼえる手話ソングブック ともだちになるために",
       "itunesTrackId": 1585757834,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -16097,7 +20190,11 @@
       "collectionName": "北島三郎芸道60周年 ～ファンと歩んだ永遠の輝き～ Ⅱ",
       "itunesTrackId": 1598600874,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -16110,22 +20207,31 @@
     "title": "あなたに逢いたくて～Missing You～",
     "artist": "松田聖子",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "1996-04-22",
+      "releaseYear": 1996,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 331,
+      "collectionName": "Vanity Fair",
+      "itunesTrackId": 1443556444,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 1,
+      "candidateReleaseDates": [
+        "1996-04-22"
+      ],
+      "reviewReason": [
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:57:10+09:00"
+    "generatedAt": "2026-06-27T21:16:26+09:00"
   },
   {
     "title": "あなた",
@@ -16139,7 +20245,11 @@
       "collectionName": "懐想",
       "itunesTrackId": 658255435,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -16160,7 +20270,11 @@
       "collectionName": "TRUNK",
       "itunesTrackId": 297289539,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -16173,22 +20287,31 @@
     "title": "まつり",
     "artist": "藤井風",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2022-03-18",
+      "releaseYear": 2022,
+      "decade": "2020年代",
+      "genre": "J-Pop",
+      "durationSeconds": 226,
+      "collectionName": "LOVE ALL SERVE ALL",
+      "itunesTrackId": 1611482688,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 10,
+      "candidateReleaseDates": [
+        "2022-03-18"
+      ],
+      "reviewReason": [
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:57:14+09:00"
+    "generatedAt": "2026-06-27T21:16:27+09:00"
   },
   {
     "title": "butterfly",
@@ -16202,7 +20325,11 @@
       "collectionName": "Butterfly - Single",
       "itunesTrackId": 317854200,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -16223,7 +20350,11 @@
       "collectionName": "どうしてもどうしても - Single",
       "itunesTrackId": 1860453512,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -16236,43 +20367,64 @@
     "title": "乾杯",
     "artist": "長渕剛",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "1980-09-05",
+      "releaseYear": 1980,
+      "decade": "1980年代",
+      "genre": "J-Pop",
+      "durationSeconds": 332,
+      "collectionName": "乾杯",
+      "itunesTrackId": 379011037,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 4,
+      "candidateReleaseDates": [
+        "1980-09-05",
+        "1983-08-25",
+        "1988-02-25"
+      ],
+      "reviewReason": [
+        "multiple_release_dates",
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:57:18+09:00"
+    "generatedAt": "2026-06-27T21:16:28+09:00"
   },
   {
     "title": "明日、春が来たら",
     "artist": "松たか子",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "1997-03-21",
+      "releaseYear": 1997,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 261,
+      "collectionName": "空の鏡",
+      "itunesTrackId": 1535989121,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 3,
+      "candidateReleaseDates": [
+        "1997-03-21"
+      ],
+      "reviewReason": [
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:57:20+09:00"
+    "generatedAt": "2026-06-27T21:16:29+09:00"
   },
   {
     "title": "タッチ",
@@ -16286,7 +20438,13 @@
       "collectionName": "タッチ",
       "itunesTrackId": 963626798,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -16307,7 +20465,11 @@
       "collectionName": "Love so sweet - Single",
       "itunesTrackId": 1485857408,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -16328,7 +20490,13 @@
       "collectionName": "ALL TIME BEST 1998-2018",
       "itunesTrackId": 1441818306,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -16341,22 +20509,31 @@
     "title": "桜",
     "artist": "清水翔太",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2010-03-03",
+      "releaseYear": 2010,
+      "decade": "2010年代",
+      "genre": "J-Pop",
+      "durationSeconds": 229,
+      "collectionName": "Journey",
+      "itunesTrackId": 1537415900,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 2,
+      "candidateReleaseDates": [
+        "2010-03-03"
+      ],
+      "reviewReason": [
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:57:26+09:00"
+    "generatedAt": "2026-06-27T21:16:30+09:00"
   },
   {
     "title": "さくらさくら",
@@ -16370,14 +20547,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:57:27+09:00"
+    "generatedAt": "2026-06-27T21:16:59+09:00"
   },
   {
     "title": "花は桜 君は美し",
@@ -16391,7 +20574,11 @@
       "collectionName": "花は桜 君は美し - Single",
       "itunesTrackId": 1536255265,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -16412,7 +20599,11 @@
       "collectionName": "桜晴 - Single",
       "itunesTrackId": 1551902206,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -16433,7 +20624,11 @@
       "collectionName": "STARS FROM DECADE〜輝ける星たち〜",
       "itunesTrackId": 73284488,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -16454,7 +20649,13 @@
       "collectionName": "大切なもの - Single",
       "itunesTrackId": 164812481,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -16475,7 +20676,11 @@
       "collectionName": "招き猫 / エジソン - Single",
       "itunesTrackId": 1607835071,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -16496,7 +20701,11 @@
       "collectionName": "daydream",
       "itunesTrackId": 1538259004,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -16517,14 +20726,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:57:37+09:00"
+    "generatedAt": "2026-06-27T21:17:02+09:00"
   },
   {
     "title": "オー・シャンゼリゼ",
@@ -16538,14 +20753,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:57:38+09:00"
+    "generatedAt": "2026-06-27T21:17:03+09:00"
   },
   {
     "title": "青春の影",
@@ -16559,14 +20780,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:57:40+09:00"
+    "generatedAt": "2026-06-27T21:17:05+09:00"
   },
   {
     "title": "虹とスニーカーの頃",
@@ -16580,14 +20807,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:57:41+09:00"
+    "generatedAt": "2026-06-27T21:17:07+09:00"
   },
   {
     "title": "Honto",
@@ -16601,7 +20834,11 @@
       "collectionName": "Honto - Single",
       "itunesTrackId": 1868974829,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -16622,7 +20859,11 @@
       "collectionName": "拝啓、少年よ",
       "itunesTrackId": 1395024580,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -16643,7 +20884,11 @@
       "collectionName": "Happiness - Single",
       "itunesTrackId": 1485847849,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -16664,7 +20909,13 @@
       "collectionName": "曇天 - Single",
       "itunesTrackId": 1536371431,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -16685,7 +20936,11 @@
       "collectionName": "とくべチュ、して - Single",
       "itunesTrackId": 1794066813,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -16706,7 +20961,11 @@
       "collectionName": "YELL/じょいふる - EP",
       "itunesTrackId": 1536258194,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -16727,7 +20986,13 @@
       "collectionName": "52nd Street",
       "itunesTrackId": 259573440,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -16748,14 +21013,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:58:08+09:00"
+    "generatedAt": "2026-06-27T21:17:09+09:00"
   },
   {
     "title": "爆裂愛してる",
@@ -16769,7 +21040,11 @@
       "collectionName": "爆裂愛してる / 好きすぎて滅! - EP",
       "itunesTrackId": 1869537742,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -16790,7 +21065,11 @@
       "collectionName": "Everybody!!",
       "itunesTrackId": 1319369442,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -16811,7 +21090,11 @@
       "collectionName": "スーパースター",
       "itunesTrackId": 1451570485,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -16832,7 +21115,11 @@
       "collectionName": "サボテンの花 ~ grown up",
       "itunesTrackId": 348065491,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -16853,7 +21140,11 @@
       "collectionName": "Again - Single",
       "itunesTrackId": 1861663797,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -16874,7 +21165,11 @@
       "collectionName": "Sunny!!",
       "itunesTrackId": 1556015464,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -16895,7 +21190,11 @@
       "collectionName": "Dr.Izzy",
       "itunesTrackId": 1128654736,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -16916,7 +21215,11 @@
       "collectionName": "MIMI 10th Anniversary Album",
       "itunesTrackId": 6775758408,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -16937,7 +21240,11 @@
       "collectionName": "SAKURAドロップス - EP",
       "itunesTrackId": 1444862816,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -16958,7 +21265,11 @@
       "collectionName": "サクラ咲ケ - Single",
       "itunesTrackId": 1485848978,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -16979,7 +21290,11 @@
       "collectionName": "Grower",
       "itunesTrackId": 1548406507,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -17000,7 +21315,11 @@
       "collectionName": "パラボラ - Single",
       "itunesTrackId": 1505478865,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -17021,7 +21340,11 @@
       "collectionName": "エルダーフラワー - Single",
       "itunesTrackId": 1883590250,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -17042,7 +21365,11 @@
       "collectionName": "GOOD DAY - Single",
       "itunesTrackId": 1841344390,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -17063,7 +21390,11 @@
       "collectionName": "桜恋 - Single",
       "itunesTrackId": 1553708900,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -17084,7 +21415,11 @@
       "collectionName": "君は僕の宝物",
       "itunesTrackId": 284522040,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -17105,7 +21440,11 @@
       "collectionName": "melt bitter - Single",
       "itunesTrackId": 1490118581,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -17126,7 +21465,11 @@
       "collectionName": "WE",
       "itunesTrackId": 1124863474,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -17147,7 +21490,11 @@
       "collectionName": "Sincerely - Single",
       "itunesTrackId": 1486980090,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -17168,7 +21515,11 @@
       "collectionName": "瞬き - EP",
       "itunesTrackId": 1440902624,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -17189,14 +21540,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:58:39+09:00"
+    "generatedAt": "2026-06-27T21:17:11+09:00"
   },
   {
     "title": "PRIDE",
@@ -17210,7 +21567,13 @@
       "collectionName": "PRIDE - Single",
       "itunesTrackId": 142415286,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -17231,7 +21594,11 @@
       "collectionName": "HANDS ON",
       "itunesTrackId": 1828852045,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -17252,7 +21619,11 @@
       "collectionName": "SINGLES+",
       "itunesTrackId": 887388931,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -17273,14 +21644,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:58:45+09:00"
+    "generatedAt": "2026-06-27T21:17:13+09:00"
   },
   {
     "title": "おどるポンポコリン",
@@ -17294,7 +21671,11 @@
       "collectionName": "おどるポンポコリン - Single",
       "itunesTrackId": 1893019546,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -17315,7 +21696,13 @@
       "collectionName": "S・P・O・R・T・S",
       "itunesTrackId": 1538800833,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -17336,7 +21723,11 @@
       "collectionName": "アイデア - Single",
       "itunesTrackId": 1417065830,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -17357,7 +21748,11 @@
       "collectionName": "ウタの歌 ONE PIECE FILM RED",
       "itunesTrackId": 1636447280,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -17378,7 +21773,11 @@
       "collectionName": "元彼女のみなさまへ - Single",
       "itunesTrackId": 1763577076,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -17399,7 +21798,11 @@
       "collectionName": "Every Best Single 2 ~laTe period~",
       "itunesTrackId": 1036800906,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -17420,7 +21823,11 @@
       "collectionName": "FINAL FANTASY X Original Soundtrack",
       "itunesTrackId": 62445434,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -17441,7 +21848,11 @@
       "collectionName": "ハルノヒ - Single",
       "itunesTrackId": 1455341000,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -17462,7 +21873,11 @@
       "collectionName": "レミオベスト",
       "itunesTrackId": 1857511993,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -17483,7 +21898,11 @@
       "collectionName": "Oz. - Single",
       "itunesTrackId": 1589026080,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -17504,7 +21923,13 @@
       "collectionName": "GOLDEN☆BEST 村下孝蔵ベスト・セレクト・ソングズ",
       "itunesTrackId": 1536742023,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -17517,22 +21942,31 @@
     "title": "愛が生まれた日",
     "artist": "藤谷美和子・大内義昭",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "1994-02-21",
+      "releaseYear": 1994,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": 321,
+      "collectionName": "愛が生まれた日 - Single",
+      "itunesTrackId": 1712831431,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 1,
+      "candidateReleaseDates": [
+        "1994-02-21"
+      ],
+      "reviewReason": [
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:59:11+09:00"
+    "generatedAt": "2026-06-27T21:17:15+09:00"
   },
   {
     "title": "100万回の「I love you」",
@@ -17546,7 +21980,11 @@
       "collectionName": "100万回の「I love you」 - EP",
       "itunesTrackId": 1535810514,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -17567,7 +22005,11 @@
       "collectionName": "Kido I Raku",
       "itunesTrackId": 1443277802,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -17588,7 +22030,11 @@
       "collectionName": "映画『さよならの朝に約束の花をかざろう』オリジナルサウンドトラック",
       "itunesTrackId": 1857550678,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -17609,7 +22055,11 @@
       "collectionName": "WONDERLAND",
       "itunesTrackId": 1509874088,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -17630,7 +22080,11 @@
       "collectionName": "今日という日を - Single",
       "itunesTrackId": 1871116827,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -17651,7 +22105,11 @@
       "collectionName": "YELL/じょいふる - EP",
       "itunesTrackId": 1536258195,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -17672,7 +22130,13 @@
       "collectionName": "テレサ・テン 40/40 ~ベスト・セレクション",
       "itunesTrackId": 1440657324,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -17693,7 +22157,11 @@
       "collectionName": "I ♥ U",
       "itunesTrackId": 1374928853,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -17714,7 +22182,11 @@
       "collectionName": "ごはん食べヨ - Single",
       "itunesTrackId": 1843292478,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -17735,14 +22207,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:59:26+09:00"
+    "generatedAt": "2026-06-27T21:17:16+09:00"
   },
   {
     "title": "ray",
@@ -17756,7 +22234,11 @@
       "collectionName": "RAY",
       "itunesTrackId": 1464635122,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -17777,7 +22259,11 @@
       "collectionName": "「勇者王ガオガイガー」オープニングテーマ 勇者王誕生! - Single",
       "itunesTrackId": 1535175166,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -17798,7 +22284,11 @@
       "collectionName": "Utada Hikaru Single Collection Vol.2 (2014 Remastered)",
       "itunesTrackId": 1440747562,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -17819,7 +22309,13 @@
       "collectionName": "SINGLES & MORE",
       "itunesTrackId": 1835392997,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -17840,14 +22336,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:59:33+09:00"
+    "generatedAt": "2026-06-27T21:17:18+09:00"
   },
   {
     "title": "15の夜",
@@ -17861,7 +22363,13 @@
       "collectionName": "SATURDAY〜ROCK'N'ROLL BEST OF YUTAKA OZAKI",
       "itunesTrackId": 1537396266,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -17882,14 +22390,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:59:36+09:00"
+    "generatedAt": "2026-06-27T21:17:20+09:00"
   },
   {
     "title": "桜流し",
@@ -17903,7 +22417,11 @@
       "collectionName": "Fantôme",
       "itunesTrackId": 1428769931,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -17924,7 +22442,13 @@
       "collectionName": "TOMORROW - Single",
       "itunesTrackId": 1506752177,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -17945,7 +22469,13 @@
       "collectionName": "海のYeah!!",
       "itunesTrackId": 949272139,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -17966,14 +22496,20 @@
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:59:42+09:00"
+    "generatedAt": "2026-06-27T21:17:22+09:00"
   },
   {
     "title": "バレッタ",
@@ -17987,7 +22523,11 @@
       "collectionName": "バレッタ TypeA - EP",
       "itunesTrackId": 1537524739,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -18008,7 +22548,11 @@
       "collectionName": "ENTERTAINMENT",
       "itunesTrackId": 984426760,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -18029,7 +22573,11 @@
       "collectionName": "逆光で見えない",
       "itunesTrackId": 1564444819,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -18050,7 +22598,13 @@
       "collectionName": "The Birthday ~Ti Amo~",
       "itunesTrackId": 1014857750,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -18071,7 +22625,13 @@
       "collectionName": "思秋期 (Original Cover Art) - Single",
       "itunesTrackId": 219108110,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -18084,22 +22644,28 @@
     "title": "また君に恋してる",
     "artist": "ビリーバンバン / 坂本冬美(Cover)",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
+      "releaseDate": "2009-01-07",
+      "releaseYear": 2009,
+      "decade": "2000年代",
+      "genre": "J-Pop",
       "durationSeconds": null,
-      "collectionName": null,
+      "collectionName": "また君に恋してる/アジアの海賊",
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T19:59:51+09:00"
+    "generatedAt": "2026-06-27T21:17:24+09:00"
   },
   {
     "title": "まなざしは光",
@@ -18113,7 +22679,11 @@
       "collectionName": "まなざしは光 - Single",
       "itunesTrackId": 1822254657,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -18134,7 +22704,11 @@
       "collectionName": "名前のない怪物",
       "itunesTrackId": 1537444998,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -18155,7 +22729,11 @@
       "collectionName": "テレサ・テン 40/40 ~ベスト・セレクション",
       "itunesTrackId": 1440657322,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -18176,7 +22754,11 @@
       "collectionName": "怪物 - Single",
       "itunesTrackId": 1544083979,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -18197,7 +22779,11 @@
       "collectionName": "infinite synthesis",
       "itunesTrackId": 1804662307,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -18218,7 +22804,11 @@
       "collectionName": "甲賀忍法帖 - Single",
       "itunesTrackId": 537847103,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -18239,7 +22829,13 @@
       "collectionName": "宝箱 -TREASURE BOX-",
       "itunesTrackId": 270010825,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -18260,7 +22856,13 @@
       "collectionName": "1/6の夢旅人2002",
       "itunesTrackId": 261733307,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -18273,43 +22875,62 @@
     "title": "思いがかさなるその前に…",
     "artist": "平井堅",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2004-10-04",
+      "releaseYear": 2004,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 337,
+      "collectionName": "Ken Hirai 10th Anniversary Complete Single Collection '95-'05 歌バカ",
+      "itunesTrackId": 1536106344,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 3,
+      "candidateReleaseDates": [
+        "2004-10-04",
+        "2004-10-06",
+        "2004-11-24"
+      ],
+      "reviewReason": [
+        "multiple_release_dates",
+        "normalized_match",
+        "title_not_exact",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T20:00:08+09:00"
+    "generatedAt": "2026-06-27T21:17:25+09:00"
   },
   {
     "title": "AXIA～ダイスキでダイキライ～",
     "artist": "ワルキューレ",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
+      "releaseDate": "2016-07-06",
+      "releaseYear": 2016,
+      "decade": "2010年代",
+      "genre": "アニメ",
       "durationSeconds": null,
-      "collectionName": null,
+      "collectionName": "TVアニメーション「マクロスΔ」ボーカルアルバム　Walkure Attack!",
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T20:00:09+09:00"
+    "generatedAt": "2026-06-27T21:17:27+09:00"
   },
   {
     "title": "愛の讃歌",
@@ -18323,7 +22944,13 @@
       "collectionName": "ベスト・オブ・シャンソン ~ばら色の人生~",
       "itunesTrackId": 793704774,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -18336,22 +22963,33 @@
     "title": "Good-bye days",
     "artist": "YUI for 雨音薫",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2006-06-14",
+      "releaseYear": 2006,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 277,
+      "collectionName": "GREEN GARDEN POP",
+      "itunesTrackId": 1537445927,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 3,
+      "candidateReleaseDates": [
+        "2006-06-14",
+        "2007-04-04"
+      ],
+      "reviewReason": [
+        "multiple_release_dates",
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T20:00:12+09:00"
+    "generatedAt": "2026-06-27T21:17:29+09:00"
   },
   {
     "title": "冬の花",
@@ -18365,7 +23003,13 @@
       "collectionName": "冬の花 - Single",
       "itunesTrackId": 1451684198,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -18386,7 +23030,13 @@
       "collectionName": "夜の踊り子",
       "itunesTrackId": 552294051,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -18407,7 +23057,11 @@
       "collectionName": "Tree",
       "itunesTrackId": 955796432,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -18420,22 +23074,34 @@
     "title": "異邦人",
     "artist": "久保田早紀",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "2002-01-01",
+      "releaseYear": 2002,
+      "decade": "2000年代",
+      "genre": "J-Pop",
+      "durationSeconds": 226,
+      "collectionName": "GOLDEN☆BEST / 久保田早紀",
+      "itunesTrackId": 1538962468,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 4,
+      "candidateReleaseDates": [
+        "2002-01-01",
+        "2007-11-28",
+        "2013-07-24"
+      ],
+      "reviewReason": [
+        "multiple_release_dates",
+        "normalized_match",
+        "artist_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T20:00:18+09:00"
+    "generatedAt": "2026-06-27T21:17:29+09:00"
   },
   {
     "title": "サヨナラバス",
@@ -18449,7 +23115,11 @@
       "collectionName": "ゆずえん",
       "itunesTrackId": 422248325,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -18470,7 +23140,11 @@
       "collectionName": "紫陽花 - Single",
       "itunesTrackId": 1629869309,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -18491,7 +23165,11 @@
       "collectionName": "道 ~デラックス盤~",
       "itunesTrackId": 1439283144,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -18512,7 +23190,11 @@
       "collectionName": "RADWIMPS 4 ~おかずのごはん~",
       "itunesTrackId": 1511080485,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -18525,22 +23207,35 @@
     "title": "いい日旅立ち",
     "artist": "山口百恵",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
-      "durationSeconds": null,
-      "collectionName": null,
-      "itunesTrackId": null,
-      "matchStatus": "not_found",
-      "source": "itunes"
+      "releaseDate": "1978-11-21",
+      "releaseYear": 1978,
+      "decade": "1970年代",
+      "genre": "歌謡曲",
+      "durationSeconds": 259,
+      "collectionName": "GOLDEN☆BEST  山口百恵 コンプリート・シングルコレクション",
+      "itunesTrackId": 1536726130,
+      "matchStatus": "needs_review",
+      "source": "itunes",
+      "matchStrategy": "primary_normalized",
+      "candidateCount": 7,
+      "candidateReleaseDates": [
+        "1978-11-21",
+        "1979-11-21",
+        "1980-11-19",
+        "1992-11-21"
+      ],
+      "reviewReason": [
+        "multiple_release_dates",
+        "normalized_match",
+        "title_not_exact"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T20:00:25+09:00"
+    "generatedAt": "2026-06-27T21:17:31+09:00"
   },
   {
     "title": "Five",
@@ -18554,7 +23249,11 @@
       "collectionName": "Five - Single",
       "itunesTrackId": 1879525016,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -18575,7 +23274,11 @@
       "collectionName": "AKINA BOX",
       "itunesTrackId": 256803586,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -18596,7 +23299,13 @@
       "collectionName": "カーテンコールが止む前に",
       "itunesTrackId": 1672217866,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -18617,7 +23326,13 @@
       "collectionName": "朝顔 - EP",
       "itunesTrackId": 1554822811,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -18638,7 +23353,11 @@
       "collectionName": "Tree",
       "itunesTrackId": 955796412,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -18659,7 +23378,11 @@
       "collectionName": "Tree",
       "itunesTrackId": 955796389,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -18680,7 +23403,13 @@
       "collectionName": "Habit - Single",
       "itunesTrackId": 1618345214,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -18701,7 +23430,11 @@
       "collectionName": "EARTH",
       "itunesTrackId": 1447614089,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -18722,7 +23455,11 @@
       "collectionName": "風と町 - Single",
       "itunesTrackId": 1891943326,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -18743,7 +23480,11 @@
       "collectionName": "ビーナスベルト - EP",
       "itunesTrackId": 1838374870,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -18764,7 +23505,11 @@
       "collectionName": "Tomorrow never knows - Single",
       "itunesTrackId": 1374950946,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -18785,7 +23530,13 @@
       "collectionName": "秒針を噛む - Single",
       "itunesTrackId": 1428083880,
       "matchStatus": "needs_review",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "legacy_result_requires_review"
+      ]
     },
     "tags": {
       "themeTags": [],
@@ -18806,7 +23557,11 @@
       "collectionName": "ぼくたちの失敗 森田童子ベストコレクション",
       "itunesTrackId": 1439290787,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -18827,7 +23582,11 @@
       "collectionName": "ピタゴラスイッチ うたのCD",
       "itunesTrackId": 939159964,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -18848,7 +23607,11 @@
       "collectionName": "RE:I AM EP",
       "itunesTrackId": 1536126125,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -18869,7 +23632,11 @@
       "collectionName": "BRIDGE -RAMAR THE BEST!!-",
       "itunesTrackId": 345885292,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -18882,22 +23649,28 @@
     "title": "涙そうそう",
     "artist": "森山良子 / 夏川りみ(Cover)",
     "metadata": {
-      "releaseDate": null,
-      "releaseYear": null,
-      "decade": null,
-      "genre": null,
+      "releaseDate": "2001-03-23",
+      "releaseYear": 2001,
+      "decade": "2000年代",
+      "genre": "J-Pop",
       "durationSeconds": null,
       "collectionName": null,
       "itunesTrackId": null,
       "matchStatus": "not_found",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ]
     },
     "tags": {
       "themeTags": [],
       "moodTags": [],
       "tieUps": []
     },
-    "generatedAt": "2026-06-27T20:00:50+09:00"
+    "generatedAt": "2026-06-27T21:17:33+09:00"
   },
   {
     "title": "春に舞う",
@@ -18911,7 +23684,11 @@
       "collectionName": "春に舞う - Single",
       "itunesTrackId": 6766202664,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -18932,7 +23709,11 @@
       "collectionName": "パッパパラダイス - Single",
       "itunesTrackId": 1886240225,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -18953,7 +23734,11 @@
       "collectionName": "あぶく - Single",
       "itunesTrackId": 1889425904,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -18974,7 +23759,11 @@
       "collectionName": "アイドルパワー - Single",
       "itunesTrackId": 6762737233,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -18995,7 +23784,11 @@
       "collectionName": "スターダスト - Single",
       "itunesTrackId": 1887793931,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -19016,7 +23809,11 @@
       "collectionName": "One Love - Single",
       "itunesTrackId": 1485847813,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -19037,7 +23834,11 @@
       "collectionName": "果てない空 - Single",
       "itunesTrackId": 1485849202,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -19058,7 +23859,11 @@
       "collectionName": "装甲騎兵ボトムズ TV版 オリジナル・サウンドトラック 総音楽集",
       "itunesTrackId": 1554454566,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -19079,7 +23884,11 @@
       "collectionName": "Who What Who What - Single",
       "itunesTrackId": 1535617938,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -19100,7 +23909,11 @@
       "collectionName": "Utada Hikaru Single Collection Vol.2 (2014 Remastered)",
       "itunesTrackId": 1440747924,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -19121,7 +23934,11 @@
       "collectionName": "いきどまり - Single",
       "itunesTrackId": 1851939757,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -19142,7 +23959,11 @@
       "collectionName": "巡ループ - Single",
       "itunesTrackId": 1823905372,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -19163,7 +23984,11 @@
       "collectionName": "Unity - EP",
       "itunesTrackId": 1627629634,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -19184,7 +24009,11 @@
       "collectionName": "プレゼント - Single",
       "itunesTrackId": 1767743853,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -19205,7 +24034,11 @@
       "collectionName": "ラブソング - Single",
       "itunesTrackId": 1706253735,
       "matchStatus": "auto_matched",
-      "source": "itunes"
+      "source": "itunes",
+      "matchStrategy": "legacy_exact",
+      "candidateCount": null,
+      "candidateReleaseDates": [],
+      "reviewReason": []
     },
     "tags": {
       "themeTags": [],
@@ -19213,5 +24046,32 @@
       "tieUps": []
     },
     "generatedAt": "2026-06-27T20:01:18+09:00"
+  },
+  {
+    "title": "ありがとう",
+    "artist": "井上陽水、奥田民生",
+    "metadata": {
+      "releaseDate": "1997-11-15",
+      "releaseYear": 1997,
+      "decade": "1990年代",
+      "genre": "J-Pop",
+      "durationSeconds": null,
+      "collectionName": "ショッピング",
+      "itunesTrackId": null,
+      "matchStatus": "not_found",
+      "matchStrategy": "not_found",
+      "candidateCount": 0,
+      "candidateReleaseDates": [],
+      "reviewReason": [
+        "not_found"
+      ],
+      "source": "itunes"
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "tieUps": []
+    },
+    "generatedAt": "2026-06-27T21:10:06+09:00"
   }
 ]

--- a/nemupipiano-musiclist-search/data/dictionary/search-overrides.json
+++ b/nemupipiano-musiclist-search/data/dictionary/search-overrides.json
@@ -1,0 +1,48 @@
+{
+  "songOverrides": {
+    "点描の唄|Mrs. GREEN APPLE": {
+      "title": "点描の唄 (feat. 井上苑子)",
+      "artist": "Mrs. GREEN APPLE"
+    },
+    "DANDAN心惹かれてく|FIELD OF VIEW": {
+      "title": "DAN DAN 心魅かれてく",
+      "artist": "FIELD OF VIEW"
+    },
+    "小さな恋の歌|MONGOL800": {
+      "title": "小さな恋のうた",
+      "artist": "MONGOL800"
+    },
+    "竈門炭治郎のうた|椎名豪featuring中川奈美": {
+      "title": "竈門炭治郎のうた (feat. 中川奈美)",
+      "artist": "椎名 豪"
+    },
+    "再会|LiSA×Uru": {
+      "title": "再会 (produced by Ayase)",
+      "artist": "LiSA & Uru"
+    },
+    "God knows...|涼宮ハルヒ(CV.平野 綾)": {
+      "title": "God knows...",
+      "artist": "涼宮ハルヒ (CV.平野 綾)"
+    },
+    "Driver's High|L'Arc～en～Ciel": {
+      "title": "Driver's High",
+      "artist": "L'Arc-en-Ciel"
+    },
+    "ワタリドリ|Alexandros": {
+      "title": "ワタリドリ",
+      "artist": "[Alexandros]"
+    },
+    "ninelie|imer with chelly(EGOIST)": {
+      "title": "ninelie",
+      "artist": "Aimer with chelly (EGOIST)"
+    },
+    "Good-bye days|YUI for 雨音薫": {
+      "title": "Good-bye days",
+      "artist": "YUI"
+    },
+    "海の声|浦島太郎（桐谷健太）": {
+      "title": "海の声",
+      "artist": "桐谷健太"
+    }
+  }
+}

--- a/scripts/fetch_music_metadata.py
+++ b/scripts/fetch_music_metadata.py
@@ -1,0 +1,585 @@
+import argparse
+import json
+import os
+import re
+import tempfile
+import time
+import unicodedata
+from datetime import datetime, timedelta, timezone
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+
+ITUNES_SEARCH_URL = "https://itunes.apple.com/search"
+DEFAULT_MUSICLIST_PATH = "nemupipiano-musiclist-search/data/musiclist.json"
+DEFAULT_METADATA_PATH = (
+    "nemupipiano-musiclist-search/data/dictionary/music_metadata.json"
+)
+DEFAULT_OVERRIDES_PATH = (
+    "nemupipiano-musiclist-search/data/dictionary/search-overrides.json"
+)
+REQUEST_INTERVAL_SECONDS = 1.0
+MAX_RETRIES = 4
+RETRYABLE_HTTP_STATUSES = {429, 500, 502, 503, 504}
+REFRESH_STATUSES = ("not_found", "needs_review")
+JST = timezone(timedelta(hours=9))
+
+FEATURE_CLAUSE_PATTERN = re.compile(
+    r"\s*[\(\[（【]\s*(?:feat(?:uring)?\.?|with)\b.*?[\)\]）】]\s*$",
+    re.IGNORECASE,
+)
+ALTERNATE_VERSION_PATTERNS = (
+    re.compile(r"\binstrumental\b", re.IGNORECASE),
+    re.compile(r"\boff[\s_-]*vocal\b", re.IGNORECASE),
+    re.compile(r"\bkaraoke\b", re.IGNORECASE),
+    re.compile(r"\blive\b", re.IGNORECASE),
+    re.compile(r"\bremix(?:ed)?\b", re.IGNORECASE),
+    re.compile(r"\bremaster(?:ed)?\b", re.IGNORECASE),
+    re.compile(r"\bcover\b", re.IGNORECASE),
+    re.compile(r"\btv[\s_-]*size\b", re.IGNORECASE),
+    re.compile(r"\bshort[\s_-]*(?:ver(?:sion)?\.?)\b", re.IGNORECASE),
+    re.compile(r"\bacoustic\b", re.IGNORECASE),
+    re.compile(r"\bpiano[\s_-]*(?:ver(?:sion)?\.?)\b", re.IGNORECASE),
+    re.compile(r"(?<!\d)(?:19|20)\d{2}(?!\d)", re.IGNORECASE),
+)
+
+
+def normalize_match_text(value):
+    text = unicodedata.normalize("NFKC", str(value or ""))
+    return " ".join(text.strip().split()).casefold()
+
+
+def normalize_variant_text(value, *, title=False):
+    text = unicodedata.normalize("NFKC", str(value or "")).casefold().strip()
+    if title:
+        text = FEATURE_CLAUSE_PATTERN.sub("", text)
+    text = re.sub(r"\b(?:feat(?:uring)?\.?|with)\b", "", text)
+    text = re.sub(r"[&×・/／+＋,，:：;；'\"`´’‘“”._\-‐‑‒–—―~〜～]", "", text)
+    text = re.sub(r"[\s\(\)\[\]{}（）【】「」『』]+", "", text)
+    return text
+
+
+def metadata_key(title, artist):
+    return normalize_match_text(title), normalize_match_text(artist)
+
+
+def parse_release_date(value):
+    text = str(value or "").strip()
+    return text[:10] if len(text) >= 10 else None
+
+
+def alternate_version_markers(value):
+    text = unicodedata.normalize("NFKC", str(value or ""))
+    return {
+        pattern.pattern
+        for pattern in ALTERNATE_VERSION_PATTERNS
+        if pattern.search(text)
+    }
+
+
+def is_unrequested_alternate_version(candidate_title, requested_title):
+    return bool(alternate_version_markers(candidate_title) - alternate_version_markers(requested_title))
+
+
+def empty_metadata(
+    match_status,
+    match_strategy="not_found",
+    candidate_count=0,
+    candidate_release_dates=None,
+    review_reasons=None,
+):
+    return {
+        "releaseDate": None,
+        "releaseYear": None,
+        "decade": None,
+        "genre": None,
+        "durationSeconds": None,
+        "collectionName": None,
+        "itunesTrackId": None,
+        "matchStatus": match_status,
+        "matchStrategy": match_strategy,
+        "candidateCount": candidate_count,
+        "candidateReleaseDates": candidate_release_dates or [],
+        "reviewReason": review_reasons or [],
+        "source": "itunes",
+    }
+
+
+def metadata_from_candidate(
+    candidate,
+    match_status,
+    match_strategy,
+    candidate_count,
+    candidate_release_dates,
+    review_reasons,
+):
+    # iTunes releaseDate may describe a reissue or compilation, not the song's first release.
+    release_date = parse_release_date(candidate.get("releaseDate"))
+    release_year = int(release_date[:4]) if release_date else None
+    duration_millis = candidate.get("trackTimeMillis")
+    duration_seconds = (
+        int(round(float(duration_millis) / 1000))
+        if isinstance(duration_millis, (int, float))
+        else None
+    )
+
+    metadata = empty_metadata(
+        match_status,
+        match_strategy,
+        candidate_count,
+        candidate_release_dates,
+        review_reasons,
+    )
+    metadata.update(
+        {
+            "releaseDate": release_date,
+            "releaseYear": release_year,
+            "decade": f"{release_year // 10 * 10}年代" if release_year else None,
+            "genre": candidate.get("primaryGenreName") or None,
+            "durationSeconds": duration_seconds,
+            "collectionName": candidate.get("collectionName") or None,
+            "itunesTrackId": candidate.get("trackId"),
+        }
+    )
+    return metadata
+
+
+def deduplicate_results(results):
+    deduplicated = []
+    seen = set()
+    for result in results:
+        if not isinstance(result, dict):
+            continue
+        track_id = result.get("trackId")
+        key = (
+            ("trackId", track_id)
+            if track_id is not None
+            else (
+                "fields",
+                normalize_match_text(result.get("trackName")),
+                normalize_match_text(result.get("artistName")),
+                normalize_match_text(result.get("collectionName")),
+                parse_release_date(result.get("releaseDate")),
+                result.get("kind"),
+            )
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        deduplicated.append(result)
+    return deduplicated
+
+
+def _candidate_sort_key(candidate):
+    return (
+        parse_release_date(candidate.get("releaseDate")) or "9999-99-99",
+        candidate.get("trackId") or 0,
+    )
+
+
+def _selection_metadata(matches, title, artist, strategy, normalized, override_used):
+    matches.sort(key=_candidate_sort_key)
+    selected = matches[0]
+    release_dates_with_missing = [
+        parse_release_date(candidate.get("releaseDate")) for candidate in matches
+    ]
+    candidate_release_dates = sorted(
+        {release_date for release_date in release_dates_with_missing if release_date}
+    )
+    review_reasons = []
+
+    if len(candidate_release_dates) > 1:
+        review_reasons.append("multiple_release_dates")
+    if any(release_date is None for release_date in release_dates_with_missing):
+        review_reasons.append("missing_release_date")
+    if normalized:
+        review_reasons.append("normalized_match")
+        if normalize_match_text(selected.get("trackName")) != normalize_match_text(title):
+            review_reasons.append("title_not_exact")
+        if normalize_match_text(selected.get("artistName")) != normalize_match_text(artist):
+            review_reasons.append("artist_not_exact")
+    if override_used:
+        review_reasons.append("search_override_used")
+
+    match_status = "needs_review" if review_reasons else "auto_matched"
+    return metadata_from_candidate(
+        selected,
+        match_status,
+        strategy,
+        len(matches),
+        candidate_release_dates,
+        review_reasons,
+    )
+
+
+def match_candidates(results, title, artist, strategy_prefix, override_used=False):
+    songs = [
+        result
+        for result in deduplicate_results(results)
+        if result.get("kind") == "song"
+        and not is_unrequested_alternate_version(result.get("trackName"), title)
+    ]
+    exact_matches = [
+        result
+        for result in songs
+        if normalize_match_text(result.get("trackName")) == normalize_match_text(title)
+        and normalize_match_text(result.get("artistName")) == normalize_match_text(artist)
+    ]
+    if exact_matches:
+        strategy = "override_exact" if override_used else f"{strategy_prefix}_exact"
+        return _selection_metadata(
+            exact_matches,
+            title,
+            artist,
+            strategy,
+            normalized=False,
+            override_used=override_used,
+        )
+
+    normalized_matches = [
+        result
+        for result in songs
+        if normalize_variant_text(result.get("trackName"), title=True)
+        == normalize_variant_text(title, title=True)
+        and normalize_variant_text(result.get("artistName"))
+        == normalize_variant_text(artist)
+    ]
+    if normalized_matches:
+        strategy = "override_normalized" if override_used else f"{strategy_prefix}_normalized"
+        return _selection_metadata(
+            normalized_matches,
+            title,
+            artist,
+            strategy,
+            normalized=True,
+            override_used=override_used,
+        )
+
+    return None
+
+
+class ITunesSearchClient:
+    def __init__(
+        self,
+        opener=urlopen,
+        sleep=time.sleep,
+        monotonic=time.monotonic,
+        request_interval=REQUEST_INTERVAL_SECONDS,
+        max_retries=MAX_RETRIES,
+    ):
+        self.opener = opener
+        self.sleep = sleep
+        self.monotonic = monotonic
+        self.request_interval = request_interval
+        self.max_retries = max_retries
+        self.last_request_at = None
+
+    def search(self, term, attribute=None):
+        parameters = {
+            "term": term,
+            "country": "JP",
+            "media": "music",
+            "entity": "musicTrack",
+            "limit": 25,
+        }
+        if attribute:
+            parameters["attribute"] = attribute
+        request = Request(
+            f"{ITUNES_SEARCH_URL}?{urlencode(parameters)}",
+            headers={"User-Agent": "nemupipiano-musiclist-search/1.0"},
+        )
+
+        for attempt in range(self.max_retries + 1):
+            try:
+                self._wait_for_request_interval()
+                with self.opener(request, timeout=30) as response:
+                    payload = json.loads(response.read().decode("utf-8"))
+                results = payload.get("results", [])
+                return deduplicate_results(results if isinstance(results, list) else [])
+            except HTTPError as error:
+                if error.code not in RETRYABLE_HTTP_STATUSES or attempt >= self.max_retries:
+                    raise
+                retry_after = error.headers.get("Retry-After") if error.headers else None
+                self.sleep(self._retry_delay(attempt, retry_after))
+            except URLError:
+                if attempt >= self.max_retries:
+                    raise
+                self.sleep(self._retry_delay(attempt))
+
+        return []
+
+    def _wait_for_request_interval(self):
+        now = self.monotonic()
+        if self.last_request_at is not None:
+            remaining = self.request_interval - (now - self.last_request_at)
+            if remaining > 0:
+                self.sleep(remaining)
+        self.last_request_at = self.monotonic()
+
+    @staticmethod
+    def _retry_delay(attempt, retry_after=None):
+        try:
+            server_delay = float(retry_after) if retry_after is not None else 0
+        except (TypeError, ValueError):
+            server_delay = 0
+        return max(2**attempt, server_delay)
+
+
+def search_song(client, title, artist, override=None):
+    search_steps = [
+        (f"{artist} {title}", None, title, artist, "primary", False),
+        (title, "songTerm", title, artist, "title_fallback", False),
+    ]
+    if override:
+        override_title = override["title"]
+        override_artist = override["artist"]
+        search_steps.extend(
+            [
+                (
+                    f"{override_artist} {override_title}",
+                    None,
+                    override_title,
+                    override_artist,
+                    "override",
+                    True,
+                ),
+                (
+                    override_title,
+                    "songTerm",
+                    override_title,
+                    override_artist,
+                    "override",
+                    True,
+                ),
+            ]
+        )
+
+    for term, attribute, match_title, match_artist, strategy, override_used in search_steps:
+        results = client.search(term, attribute=attribute)
+        metadata = match_candidates(
+            results,
+            match_title,
+            match_artist,
+            strategy,
+            override_used=override_used,
+        )
+        if metadata is not None:
+            return metadata
+
+    return empty_metadata("not_found", review_reasons=["not_found"])
+
+
+def load_json(path, default):
+    if not os.path.exists(path):
+        return default
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def load_search_overrides(path):
+    if not os.path.exists(path):
+        return {}
+    try:
+        data = load_json(path, {})
+    except json.JSONDecodeError as error:
+        raise ValueError(f"Invalid JSON in search overrides: {path}: {error}") from error
+
+    if not isinstance(data, dict) or not isinstance(data.get("songOverrides"), dict):
+        raise ValueError("search-overrides.json must contain a songOverrides object")
+
+    overrides = {}
+    for raw_key, value in data["songOverrides"].items():
+        if not isinstance(raw_key, str) or "|" not in raw_key:
+            raise ValueError("Each search override key must use '<title>|<artist>' format")
+        if not isinstance(value, dict) or set(value) != {"title", "artist"}:
+            raise ValueError("Each search override must contain only title and artist")
+        if not isinstance(value["title"], str) or not isinstance(value["artist"], str):
+            raise ValueError("Search override title and artist must be strings")
+        if not value["title"].strip() or not value["artist"].strip():
+            raise ValueError("Search override title and artist must not be empty")
+        title, artist = raw_key.split("|", 1)
+        key = metadata_key(title, artist)
+        if key in overrides:
+            raise ValueError(f"Duplicate normalized search override key: {raw_key}")
+        overrides[key] = {
+            "title": value["title"].strip(),
+            "artist": value["artist"].strip(),
+        }
+    return overrides
+
+
+def save_json_atomic(path, data):
+    directory = os.path.dirname(path) or "."
+    os.makedirs(directory, exist_ok=True)
+    temporary_path = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=directory,
+            prefix=f".{os.path.basename(path)}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temporary_file:
+            temporary_path = temporary_file.name
+            json.dump(data, temporary_file, ensure_ascii=False, indent=2)
+            temporary_file.write("\n")
+            temporary_file.flush()
+            os.fsync(temporary_file.fileno())
+        os.replace(temporary_path, path)
+    finally:
+        if temporary_path and os.path.exists(temporary_path):
+            os.unlink(temporary_path)
+
+
+def load_metadata_records(path):
+    data = load_json(path, [])
+    if not isinstance(data, list):
+        raise ValueError(f"Metadata file must contain a JSON array: {path}")
+    return [record for record in data if isinstance(record, dict)]
+
+
+def musiclist_pairs(path):
+    data = load_json(path, [])
+    if not isinstance(data, list):
+        raise ValueError(f"Music list must contain a JSON array: {path}")
+
+    pairs = []
+    seen = set()
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        title = str(item.get("displayTitle") or item.get("sourceTitle") or "").strip()
+        artist = str(item.get("displayArtist") or item.get("sourceArtist") or "").strip()
+        if (not title or not artist) and isinstance(item.get("songKey"), str):
+            title, separator, artist = item["songKey"].partition("|")
+            if not separator:
+                artist = ""
+        if not title or not artist:
+            continue
+        key = metadata_key(title, artist)
+        if key in seen:
+            continue
+        seen.add(key)
+        pairs.append((title, artist))
+    return pairs
+
+
+def build_record(title, artist, metadata, existing_record=None, now=None):
+    existing_record = existing_record if isinstance(existing_record, dict) else {}
+    existing_metadata = existing_record.get("metadata")
+    existing_metadata = existing_metadata if isinstance(existing_metadata, dict) else {}
+    existing_tags = existing_record.get("tags")
+    tags = existing_tags if isinstance(existing_tags, dict) else {}
+    tags = {
+        **tags,
+        "themeTags": tags.get("themeTags", []),
+        "moodTags": tags.get("moodTags", []),
+        "tieUps": tags.get("tieUps", []),
+    }
+    generated_at = (now or datetime.now(JST)).astimezone(JST).isoformat(timespec="seconds")
+    return {
+        **existing_record,
+        "title": title,
+        "artist": artist,
+        "metadata": {**existing_metadata, **metadata},
+        "tags": tags,
+        "generatedAt": generated_at,
+    }
+
+
+def update_metadata(
+    pairs,
+    metadata_path,
+    client,
+    overrides=None,
+    refresh=False,
+    refresh_status=None,
+    now=None,
+):
+    records = load_metadata_records(metadata_path)
+    index = {
+        metadata_key(record.get("title"), record.get("artist")): position
+        for position, record in enumerate(records)
+    }
+    overrides = overrides or {}
+    requested = 0
+    skipped = 0
+
+    for title, artist in pairs:
+        key = metadata_key(title, artist)
+        existing_position = index.get(key)
+        existing_record = records[existing_position] if existing_position is not None else None
+        existing_status = (
+            existing_record.get("metadata", {}).get("matchStatus")
+            if isinstance(existing_record, dict)
+            and isinstance(existing_record.get("metadata"), dict)
+            else None
+        )
+        if refresh_status:
+            should_fetch = existing_position is not None and existing_status == refresh_status
+        else:
+            should_fetch = refresh or existing_position is None
+        if not should_fetch:
+            skipped += 1
+            continue
+
+        metadata = search_song(client, title, artist, overrides.get(key))
+        record = build_record(title, artist, metadata, existing_record, now=now)
+        if existing_position is None:
+            index[key] = len(records)
+            records.append(record)
+        else:
+            records[existing_position] = record
+        save_json_atomic(metadata_path, records)
+        requested += 1
+
+    return requested, skipped
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Fetch song metadata from the iTunes Search API."
+    )
+    parser.add_argument("--title", help="Song title")
+    parser.add_argument("--artist", help="Artist name")
+    refresh_group = parser.add_mutually_exclusive_group()
+    refresh_group.add_argument(
+        "--refresh",
+        action="store_true",
+        help="Fetch metadata again even when a cached record exists.",
+    )
+    refresh_group.add_argument(
+        "--refresh-status",
+        choices=REFRESH_STATUSES,
+        help="Fetch cached records again only when matchStatus has this value.",
+    )
+    args = parser.parse_args(argv)
+    if bool(args.title) != bool(args.artist):
+        parser.error("--title and --artist must be specified together")
+    return args
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    pairs = (
+        [(args.title.strip(), args.artist.strip())]
+        if args.title and args.artist
+        else musiclist_pairs(DEFAULT_MUSICLIST_PATH)
+    )
+    overrides = load_search_overrides(DEFAULT_OVERRIDES_PATH)
+    client = ITunesSearchClient()
+    requested, skipped = update_metadata(
+        pairs,
+        DEFAULT_METADATA_PATH,
+        client,
+        overrides=overrides,
+        refresh=args.refresh,
+        refresh_status=args.refresh_status,
+    )
+    print(f"Fetched {requested} records. Skipped {skipped} cached records.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fetch_music_metadata.py
+++ b/scripts/fetch_music_metadata.py
@@ -23,6 +23,7 @@ REQUEST_INTERVAL_SECONDS = 1.0
 MAX_RETRIES = 4
 RETRYABLE_HTTP_STATUSES = {429, 500, 502, 503, 504}
 REFRESH_STATUSES = ("not_found", "needs_review")
+MANUAL_MATCH_STATUS = "manual"
 JST = timezone(timedelta(hours=9))
 
 FEATURE_CLAUSE_PATTERN = re.compile(
@@ -517,7 +518,9 @@ def update_metadata(
             and isinstance(existing_record.get("metadata"), dict)
             else None
         )
-        if refresh_status:
+        if existing_status == MANUAL_MATCH_STATUS:
+            should_fetch = False
+        elif refresh_status:
             should_fetch = existing_position is not None and existing_status == refresh_status
         else:
             should_fetch = refresh or existing_position is None

--- a/tests/test_fetch_music_metadata.py
+++ b/tests/test_fetch_music_metadata.py
@@ -1,0 +1,407 @@
+import json
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import Mock
+from urllib.parse import parse_qs, urlparse
+
+from scripts.fetch_music_metadata import (
+    ITunesSearchClient,
+    build_record,
+    empty_metadata,
+    load_search_overrides,
+    match_candidates,
+    parse_args,
+    search_song,
+    update_metadata,
+)
+
+
+JST = timezone(timedelta(hours=9))
+FIXED_NOW = datetime(2026, 6, 27, 12, 0, 0, tzinfo=JST)
+
+
+def candidate(track_id, release_date="2012-02-01T12:00:00Z", **overrides):
+    result = {
+        "kind": "song",
+        "artistName": "ClariS",
+        "trackName": "ナイショの話",
+        "releaseDate": release_date,
+        "primaryGenreName": "Anime",
+        "trackTimeMillis": 261000,
+        "collectionName": "ナイショの話 - EP",
+        "trackId": track_id,
+    }
+    result.update(overrides)
+    return result
+
+
+class FakeClient:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = []
+
+    def search(self, term, attribute=None):
+        self.calls.append((term, attribute))
+        return self.responses.pop(0)
+
+
+class CandidateMatchingTests(unittest.TestCase):
+    def test_single_exact_match(self):
+        metadata = match_candidates(
+            [candidate(1)], "ナイショの話", "ClariS", "primary"
+        )
+        self.assertEqual(metadata["matchStatus"], "auto_matched")
+        self.assertEqual(metadata["matchStrategy"], "primary_exact")
+        self.assertEqual(metadata["durationSeconds"], 261)
+
+    def test_multiple_exact_matches_with_same_release_date(self):
+        metadata = match_candidates(
+            [candidate(2), candidate(1)], "ナイショの話", "ClariS", "primary"
+        )
+        self.assertEqual(metadata["matchStatus"], "auto_matched")
+        self.assertEqual(metadata["candidateCount"], 2)
+        self.assertEqual(metadata["itunesTrackId"], 1)
+
+    def test_different_release_dates_need_review_and_use_oldest(self):
+        metadata = match_candidates(
+            [candidate(2, "2015-01-01T00:00:00Z"), candidate(1)],
+            "ナイショの話",
+            "ClariS",
+            "primary",
+        )
+        self.assertEqual(metadata["matchStatus"], "needs_review")
+        self.assertIn("multiple_release_dates", metadata["reviewReason"])
+        self.assertEqual(metadata["releaseDate"], "2012-02-01")
+
+    def test_missing_release_date_needs_review(self):
+        metadata = match_candidates(
+            [candidate(1), candidate(2, None)], "ナイショの話", "ClariS", "primary"
+        )
+        self.assertEqual(metadata["matchStatus"], "needs_review")
+        self.assertIn("missing_release_date", metadata["reviewReason"])
+
+    def test_artist_join_notation_difference_needs_review(self):
+        metadata = match_candidates(
+            [candidate(1, artistName="LiSA & Uru", trackName="再会")],
+            "再会",
+            "LiSA×Uru",
+            "primary",
+        )
+        self.assertEqual(metadata["matchStatus"], "needs_review")
+        self.assertEqual(metadata["matchStrategy"], "primary_normalized")
+        self.assertIn("artist_not_exact", metadata["reviewReason"])
+
+    def test_trailing_feature_difference_needs_review(self):
+        metadata = match_candidates(
+            [candidate(1, trackName="点描の唄 (feat. 井上苑子)", artistName="Mrs. GREEN APPLE")],
+            "点描の唄",
+            "Mrs. GREEN APPLE",
+            "title_fallback",
+        )
+        self.assertEqual(metadata["matchStatus"], "needs_review")
+        self.assertIn("title_not_exact", metadata["reviewReason"])
+
+    def test_unrequested_alternate_version_is_not_selected(self):
+        metadata = match_candidates(
+            [candidate(1, trackName="ナイショの話 (Live)")],
+            "ナイショの話",
+            "ClariS",
+            "primary",
+        )
+        self.assertIsNone(metadata)
+
+    def test_duplicate_track_ids_are_removed(self):
+        metadata = match_candidates(
+            [candidate(1), candidate(1)], "ナイショの話", "ClariS", "primary"
+        )
+        self.assertEqual(metadata["candidateCount"], 1)
+
+    def test_duplicate_fallback_fields_are_removed_without_track_id(self):
+        first = candidate(None)
+        second = dict(first)
+        metadata = match_candidates(
+            [first, second], "ナイショの話", "ClariS", "primary"
+        )
+        self.assertEqual(metadata["candidateCount"], 1)
+
+
+class SearchStrategyTests(unittest.TestCase):
+    def test_primary_match_stops_following_searches(self):
+        client = FakeClient([[candidate(1)]])
+        metadata = search_song(client, "ナイショの話", "ClariS")
+        self.assertEqual(metadata["matchStrategy"], "primary_exact")
+        self.assertEqual(client.calls, [("ClariS ナイショの話", None)])
+
+    def test_title_fallback_runs_after_primary_miss(self):
+        client = FakeClient([[], [candidate(1)]])
+        metadata = search_song(client, "ナイショの話", "ClariS")
+        self.assertEqual(metadata["matchStrategy"], "title_fallback_exact")
+        self.assertEqual(
+            client.calls,
+            [("ClariS ナイショの話", None), ("ナイショの話", "songTerm")],
+        )
+
+    def test_override_runs_only_after_normal_searches_miss(self):
+        override_candidate = candidate(
+            3,
+            trackName="再会 (produced by Ayase)",
+            artistName="LiSA & Uru",
+        )
+        override = {"title": "再会 (produced by Ayase)", "artist": "LiSA & Uru"}
+        client = FakeClient([[], [], [override_candidate]])
+        metadata = search_song(client, "再会", "LiSA×Uru", override)
+        self.assertEqual(metadata["matchStatus"], "needs_review")
+        self.assertEqual(metadata["matchStrategy"], "override_exact")
+        self.assertIn("search_override_used", metadata["reviewReason"])
+        self.assertEqual(len(client.calls), 3)
+
+    def test_override_fallback_stops_when_match_found(self):
+        override_candidate = candidate(
+            3,
+            trackName="再会 (produced by Ayase)",
+            artistName="LiSA & Uru",
+        )
+        override = {"title": "再会 (produced by Ayase)", "artist": "LiSA & Uru"}
+        client = FakeClient([[], [], [], [override_candidate]])
+        metadata = search_song(client, "再会", "LiSA×Uru", override)
+        self.assertEqual(metadata["matchStrategy"], "override_exact")
+        self.assertEqual(len(client.calls), 4)
+
+    def test_no_override_does_not_run_override_search(self):
+        client = FakeClient([[], []])
+        metadata = search_song(client, "unknown", "unknown")
+        self.assertEqual(metadata["matchStatus"], "not_found")
+        self.assertEqual(metadata["matchStrategy"], "not_found")
+        self.assertEqual(len(client.calls), 2)
+
+
+class RequestParameterTests(unittest.TestCase):
+    def test_request_parameters(self):
+        requests = []
+
+        class Response:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_):
+                return None
+
+            def read(self):
+                return b'{"results": []}'
+
+        def opener(request, timeout):
+            requests.append((request, timeout))
+            return Response()
+
+        client = ITunesSearchClient(
+            opener=opener,
+            sleep=lambda _: None,
+            request_interval=0,
+        )
+        client.search("ClariS ナイショの話")
+        client.search("ナイショの話", attribute="songTerm")
+        primary = parse_qs(urlparse(requests[0][0].full_url).query)
+        fallback = parse_qs(urlparse(requests[1][0].full_url).query)
+        self.assertNotIn("attribute", primary)
+        self.assertEqual(fallback["attribute"], ["songTerm"])
+        self.assertEqual(primary["limit"], ["25"])
+        self.assertEqual(fallback["limit"], ["25"])
+
+
+class OverrideLoadingTests(unittest.TestCase):
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()
+        self.path = Path(self.directory.name) / "search-overrides.json"
+
+    def tearDown(self):
+        self.directory.cleanup()
+
+    def test_missing_file_returns_empty_mapping(self):
+        self.assertEqual(load_search_overrides(str(self.path)), {})
+
+    def test_loads_override_by_normalized_original_names(self):
+        self.path.write_text(
+            json.dumps(
+                {
+                    "songOverrides": {
+                        "再会|LiSA×Uru": {
+                            "title": "再会 (produced by Ayase)",
+                            "artist": "LiSA & Uru",
+                        }
+                    }
+                },
+                ensure_ascii=False,
+            ),
+            encoding="utf-8",
+        )
+        overrides = load_search_overrides(str(self.path))
+        self.assertIn(("再会", "lisa×uru"), overrides)
+
+    def test_invalid_structure_raises_clear_error(self):
+        self.path.write_text("[]", encoding="utf-8")
+        with self.assertRaisesRegex(ValueError, "songOverrides object"):
+            load_search_overrides(str(self.path))
+
+    def test_invalid_json_raises_clear_error(self):
+        self.path.write_text("{", encoding="utf-8")
+        with self.assertRaisesRegex(ValueError, "Invalid JSON in search overrides"):
+            load_search_overrides(str(self.path))
+
+    def test_array_override_value_is_rejected(self):
+        self.path.write_text(
+            json.dumps({"songOverrides": {"a|b": [{"title": "a", "artist": "b"}]}}),
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(ValueError, "only title and artist"):
+            load_search_overrides(str(self.path))
+
+
+class CacheAndRefreshTests(unittest.TestCase):
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()
+        self.metadata_path = Path(self.directory.name) / "music_metadata.json"
+        metadata = empty_metadata("not_found", review_reasons=["not_found"])
+        self.existing = build_record("ナイショの話", "ClariS", metadata, now=FIXED_NOW)
+        self.metadata_path.write_text(
+            json.dumps([self.existing], ensure_ascii=False), encoding="utf-8"
+        )
+
+    def tearDown(self):
+        self.directory.cleanup()
+
+    def test_existing_record_does_not_call_api(self):
+        client = FakeClient([])
+        requested, skipped = update_metadata(
+            [("ナイショの話", "ClariS")], str(self.metadata_path), client
+        )
+        self.assertEqual((requested, skipped), (0, 1))
+        self.assertEqual(client.calls, [])
+
+    def test_refresh_status_not_found_only_refreshes_not_found(self):
+        client = FakeClient([[candidate(1)]])
+        requested, skipped = update_metadata(
+            [("ナイショの話", "ClariS")],
+            str(self.metadata_path),
+            client,
+            refresh_status="not_found",
+            now=FIXED_NOW,
+        )
+        self.assertEqual((requested, skipped), (1, 0))
+        saved = json.loads(self.metadata_path.read_text(encoding="utf-8"))[0]
+        self.assertEqual(saved["metadata"]["matchStatus"], "auto_matched")
+
+    def test_refresh_status_needs_review_only_refreshes_needs_review(self):
+        self.existing["metadata"]["matchStatus"] = "needs_review"
+        self.metadata_path.write_text(
+            json.dumps([self.existing], ensure_ascii=False), encoding="utf-8"
+        )
+        client = FakeClient([[candidate(1)]])
+        requested, skipped = update_metadata(
+            [("ナイショの話", "ClariS")],
+            str(self.metadata_path),
+            client,
+            refresh_status="needs_review",
+            now=FIXED_NOW,
+        )
+        self.assertEqual((requested, skipped), (1, 0))
+
+    def test_refresh_status_skips_non_matching_status(self):
+        client = FakeClient([])
+        requested, skipped = update_metadata(
+            [("ナイショの話", "ClariS")],
+            str(self.metadata_path),
+            client,
+            refresh_status="needs_review",
+        )
+        self.assertEqual((requested, skipped), (0, 1))
+
+    def test_refresh_preserves_manual_tags_and_unknown_fields(self):
+        self.existing["tags"] = {
+            "themeTags": ["冬"],
+            "moodTags": ["明るい"],
+            "tieUps": ["アニメ"],
+            "customTags": ["手動"],
+        }
+        self.existing["manualNote"] = "keep"
+        self.existing["metadata"]["manualReleaseMemo"] = "keep"
+        self.metadata_path.write_text(
+            json.dumps([self.existing], ensure_ascii=False), encoding="utf-8"
+        )
+        client = FakeClient([[candidate(1)]])
+        update_metadata(
+            [("ナイショの話", "ClariS")],
+            str(self.metadata_path),
+            client,
+            refresh=True,
+            now=FIXED_NOW,
+        )
+        saved = json.loads(self.metadata_path.read_text(encoding="utf-8"))[0]
+        self.assertEqual(saved["tags"], self.existing["tags"])
+        self.assertEqual(saved["manualNote"], "keep")
+        self.assertEqual(saved["metadata"]["manualReleaseMemo"], "keep")
+        self.assertEqual(saved["title"], "ナイショの話")
+        self.assertEqual(saved["artist"], "ClariS")
+
+    def test_override_refresh_keeps_original_title_and_artist(self):
+        override_candidate = candidate(
+            3,
+            trackName="再会 (produced by Ayase)",
+            artistName="LiSA & Uru",
+        )
+        existing = build_record(
+            "再会",
+            "LiSA×Uru",
+            empty_metadata("not_found", review_reasons=["not_found"]),
+            now=FIXED_NOW,
+        )
+        self.metadata_path.write_text(
+            json.dumps([existing], ensure_ascii=False), encoding="utf-8"
+        )
+        client = FakeClient([[], [], [override_candidate]])
+        overrides = {
+            ("再会", "lisa×uru"): {
+                "title": "再会 (produced by Ayase)",
+                "artist": "LiSA & Uru",
+            }
+        }
+        update_metadata(
+            [("再会", "LiSA×Uru")],
+            str(self.metadata_path),
+            client,
+            overrides=overrides,
+            refresh_status="not_found",
+            now=FIXED_NOW,
+        )
+        saved = json.loads(self.metadata_path.read_text(encoding="utf-8"))[0]
+        self.assertEqual(saved["title"], "再会")
+        self.assertEqual(saved["artist"], "LiSA×Uru")
+        self.assertEqual(saved["metadata"]["matchStrategy"], "override_exact")
+
+
+class ArgumentTests(unittest.TestCase):
+    def test_refresh_and_refresh_status_are_mutually_exclusive(self):
+        with self.assertRaises(SystemExit):
+            parse_args(["--refresh", "--refresh-status", "not_found"])
+
+    def test_invalid_refresh_status_is_rejected(self):
+        with self.assertRaises(SystemExit):
+            parse_args(["--refresh-status", "auto_matched"])
+
+    def test_title_and_artist_can_be_filtered_by_refresh_status(self):
+        args = parse_args(
+            [
+                "--title",
+                "ナイショの話",
+                "--artist",
+                "ClariS",
+                "--refresh-status",
+                "not_found",
+            ]
+        )
+        self.assertEqual(args.refresh_status, "not_found")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_fetch_music_metadata.py
+++ b/tests/test_fetch_music_metadata.py
@@ -317,6 +317,40 @@ class CacheAndRefreshTests(unittest.TestCase):
         )
         self.assertEqual((requested, skipped), (0, 1))
 
+    def test_refresh_does_not_overwrite_manual_record(self):
+        self.existing["metadata"]["matchStatus"] = "manual"
+        self.existing["metadata"]["manualValue"] = "keep"
+        self.metadata_path.write_text(
+            json.dumps([self.existing], ensure_ascii=False), encoding="utf-8"
+        )
+        client = FakeClient([])
+        requested, skipped = update_metadata(
+            [("ナイショの話", "ClariS")],
+            str(self.metadata_path),
+            client,
+            refresh=True,
+        )
+        saved = json.loads(self.metadata_path.read_text(encoding="utf-8"))[0]
+        self.assertEqual((requested, skipped), (0, 1))
+        self.assertEqual(client.calls, [])
+        self.assertEqual(saved["metadata"]["matchStatus"], "manual")
+        self.assertEqual(saved["metadata"]["manualValue"], "keep")
+
+    def test_refresh_status_does_not_overwrite_manual_record(self):
+        self.existing["metadata"]["matchStatus"] = "manual"
+        self.metadata_path.write_text(
+            json.dumps([self.existing], ensure_ascii=False), encoding="utf-8"
+        )
+        client = FakeClient([])
+        requested, skipped = update_metadata(
+            [("ナイショの話", "ClariS")],
+            str(self.metadata_path),
+            client,
+            refresh_status="not_found",
+        )
+        self.assertEqual((requested, skipped), (0, 1))
+        self.assertEqual(client.calls, [])
+
     def test_refresh_preserves_manual_tags_and_unknown_fields(self):
         self.existing["tags"] = {
             "themeTags": ["冬"],


### PR DESCRIPTION
## PR #34 修正内容

- iTunes Search APIから取得した楽曲情報を`music_metadata.json`へ保存
- 以下の多段階検索を実装
  1. アーティスト名＋曲名
  2. 曲名のみ
  3. 上書き後のアーティスト名＋曲名
  4. 上書き後の曲名のみ
- `search-overrides.json`による検索条件の上書きに対応
- 完全一致および安全な表記差一致による候補判定を実装
- 別バージョンやmusic videoを自動採用対象から除外
- 複数候補の発売日を比較し、`auto_matched`または`needs_review`を判定
- 以下のマッチング状態に対応
  - `auto_matched`
  - `needs_review`
  - `not_found`
  - `manual`
- `metadata`へ以下の確認用情報を追加
  - `matchStrategy`
  - `candidateCount`
  - `candidateReleaseDates`
  - `reviewReason`
- API検索結果を`trackId`などで重複排除
- APIリクエスト間隔と一時エラー時のリトライ処理を実装
- `manual`のレコードは通常実行・全件再取得・ステータス別再取得の対象外
- 再取得時も手動タグと未知の追加項目を保持
- 元の曲名・アーティスト名を維持したまま上書き条件で検索
- JSONファイルをアトミックに更新