### PR TITLE
メタ辞書更新

### DIFF
--- a/nemupipiano-musiclist-search/data/dictionary/music_metadata.json
+++ b/nemupipiano-musiclist-search/data/dictionary/music_metadata.json
@@ -22351,20 +22351,44 @@
       "collectionName": "銀色飛行船 - EP"
     },
     "classification": {
-      "genres": [],
-      "subgenres": [],
+      "genres": [
+        "J-POP"
+      ],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [
         "アニメ"
       ],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "青春",
+        "記憶",
+        "祈り"
+      ],
+      "moodTags": [
+        "切ない",
+        "透明感",
+        "壮大"
+      ],
+      "motifTags": [
+        "空",
+        "光",
+        "翼"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "ねらわれた学園",
+        "series": "ねらわれた学園",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1537455821
@@ -22382,18 +22406,40 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "ジャズ"
+      ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "希望",
+        "日常"
+      ],
+      "moodTags": [
+        "明るい",
+        "楽しい",
+        "おしゃれ"
+      ],
+      "motifTags": [
+        "雨",
+        "街"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "雨に唄えば",
+        "series": "雨に唄えば",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -22414,14 +22460,28 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "祈り",
+        "家族"
+      ],
+      "moodTags": [
+        "優しい",
+        "泣ける"
+      ],
+      "motifTags": [
+        "花",
+        "春"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -22442,16 +22502,34 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
-      "subgenres": [],
+      "genres": [
+        "ポップス"
+      ],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
-      "eventTags": []
+      "themeTags": [
+        "希望",
+        "旅立ち",
+        "成長"
+      ],
+      "moodTags": [
+        "優しい",
+        "壮大"
+      ],
+      "motifTags": [
+        "空",
+        "光"
+      ],
+      "eventTags": [
+        "卒業"
+      ]
     },
     "tieUps": [],
     "source": {
@@ -22471,15 +22549,29 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "クラシック"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "インスト"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "記憶",
+        "喪失"
+      ],
+      "moodTags": [
+        "荘厳",
+        "ノスタルジック",
+        "儚い"
+      ],
+      "motifTags": [
+        "月",
+        "夜"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -22500,15 +22592,29 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "クラシック"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "インスト"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常",
+        "希望"
+      ],
+      "moodTags": [
+        "穏やか",
+        "優しい"
+      ],
+      "motifTags": [
+        "花",
+        "春",
+        "川"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -22534,12 +22640,23 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "青春"
+      ],
+      "moodTags": [
+        "かわいい",
+        "元気",
+        "楽しい"
+      ],
+      "motifTags": [
+        "笑顔"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -22560,15 +22677,28 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "キッズ"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常",
+        "記憶"
+      ],
+      "moodTags": [
+        "穏やか",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "夕暮れ",
+        "帰り道"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -22589,15 +22719,28 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "歌謡曲"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "家族",
+        "記憶"
+      ],
+      "moodTags": [
+        "ノスタルジック",
+        "穏やか"
+      ],
+      "motifTags": [
+        "旅路",
+        "川"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -22618,15 +22761,28 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "キッズ"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常"
+      ],
+      "moodTags": [
+        "かわいい",
+        "楽しい",
+        "コミカル"
+      ],
+      "motifTags": [
+        "夜",
+        "音楽"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -22647,20 +22803,41 @@
       "collectionName": "魂のルフラン/THANATOS-IF I CAN'T BE YOURS - EP"
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "J-POP"
+      ],
       "subgenres": [],
       "sourceCategories": [
         "アニメ"
       ],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "再会",
+        "祈り",
+        "戦い"
+      ],
+      "moodTags": [
+        "壮大",
+        "荘厳",
+        "緊張感"
+      ],
+      "motifTags": [
+        "光",
+        "翼"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "新世紀エヴァンゲリオン劇場版 シト新生",
+        "series": "新世紀エヴァンゲリオン",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 258926443
@@ -22683,12 +22860,25 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常",
+        "自由",
+        "希望"
+      ],
+      "moodTags": [
+        "元気",
+        "楽しい",
+        "爽やか"
+      ],
+      "motifTags": [
+        "帰り道",
+        "道"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -22713,16 +22903,37 @@
         "ロック"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "喪失",
+        "祈り",
+        "絆"
+      ],
+      "moodTags": [
+        "切ない",
+        "ダーク",
+        "壮大"
+      ],
+      "motifTags": [
+        "手",
+        "影"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "呪術廻戦",
+        "series": "呪術廻戦",
+        "role": "ED"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1545881892
@@ -22744,16 +22955,37 @@
         "J-POP"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "戦い",
+        "葛藤"
+      ],
+      "moodTags": [
+        "かっこいい",
+        "緊張感",
+        "ダーク",
+        "疾走感"
+      ],
+      "motifTags": [
+        "影",
+        "炎"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "呪術廻戦",
+        "series": "呪術廻戦",
+        "role": "OP"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1533208085
@@ -22774,14 +23006,30 @@
       "genres": [
         "歌謡曲"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル",
+        "デュエット"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "記憶"
+      ],
+      "moodTags": [
+        "切ない",
+        "ノスタルジック",
+        "優しい"
+      ],
+      "motifTags": [
+        "夏",
+        "夕暮れ",
+        "音楽"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -22802,15 +23050,29 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "歌謡曲"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "記憶",
+        "家族"
+      ],
+      "moodTags": [
+        "ノスタルジック",
+        "優しい"
+      ],
+      "motifTags": [
+        "夕暮れ",
+        "秋",
+        "帰り道"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -22836,13 +23098,28 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
-      "eventTags": []
+      "themeTags": [
+        "恋愛",
+        "青春"
+      ],
+      "moodTags": [
+        "爽やか",
+        "元気",
+        "明るい"
+      ],
+      "motifTags": [
+        "夏",
+        "海",
+        "太陽"
+      ],
+      "eventTags": [
+        "夏休み"
+      ]
     },
     "tieUps": [],
     "source": {
@@ -22866,16 +23143,38 @@
         "J-POP"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "ドラマ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
-      "eventTags": []
+      "themeTags": [
+        "恋愛",
+        "青春"
+      ],
+      "moodTags": [
+        "爽やか",
+        "明るい",
+        "疾走感"
+      ],
+      "motifTags": [
+        "夏",
+        "海"
+      ],
+      "eventTags": [
+        "夏休み"
+      ]
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "真夏のシンデレラ",
+        "series": "真夏のシンデレラ",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1697302630
@@ -22893,20 +23192,42 @@
       "collectionName": "めぐりあい - Single"
     },
     "classification": {
-      "genres": [],
-      "subgenres": [],
+      "genres": [
+        "J-POP"
+      ],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [
         "アニメ"
       ],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "再会",
+        "戦い",
+        "祈り"
+      ],
+      "moodTags": [
+        "壮大",
+        "泣ける"
+      ],
+      "motifTags": [
+        "星",
+        "空"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "機動戦士ガンダムIII めぐりあい宇宙編",
+        "series": "機動戦士ガンダム",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1244018758
@@ -22924,18 +23245,42 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "J-POP"
+      ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "ゲーム",
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル",
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "戦い",
+        "絆"
+      ],
+      "moodTags": [
+        "熱い",
+        "楽しい",
+        "壮大"
+      ],
+      "motifTags": [
+        "花",
+        "舞台"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "サクラ大戦",
+        "series": "サクラ大戦",
+        "role": "OP"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -22953,15 +23298,28 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "ロック"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "孤独",
+        "自由",
+        "日常"
+      ],
+      "moodTags": [
+        "ノスタルジック",
+        "切ない"
+      ],
+      "motifTags": [
+        "街"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -22986,16 +23344,36 @@
         "ロック"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "希望",
+        "戦い",
+        "成長"
+      ],
+      "moodTags": [
+        "熱い",
+        "疾走感",
+        "かっこいい"
+      ],
+      "motifTags": [
+        "光"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "魔法騎士レイアース",
+        "series": "魔法騎士レイアース",
+        "role": "OP"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1443114381
@@ -23016,14 +23394,31 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "エレクトロポップ"
+      ],
+      "sourceCategories": [
+        "ボカロ"
+      ],
+      "vocalTypes": [
+        "VOCALOID"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "秘密",
+        "葛藤",
+        "孤独"
+      ],
+      "moodTags": [
+        "ミステリアス",
+        "疾走感",
+        "かっこいい"
+      ],
+      "motifTags": [
+        "花",
+        "影"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -23045,16 +23440,29 @@
     },
     "classification": {
       "genres": [
-        "J-POP"
+        "キッズ"
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "希望",
+        "日常",
+        "友情"
+      ],
+      "moodTags": [
+        "明るい",
+        "元気",
+        "楽しい"
+      ],
+      "motifTags": [
+        "花",
+        "晴れ"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -23078,17 +23486,39 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "ゲーム"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "絆",
+        "希望"
+      ],
+      "moodTags": [
+        "優しい",
+        "壮大",
+        "泣ける"
+      ],
+      "motifTags": [
+        "光"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "FINAL FANTASY XIII",
+        "series": "FINAL FANTASY",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 339961792
@@ -23111,12 +23541,24 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "応援",
+        "希望",
+        "成長"
+      ],
+      "moodTags": [
+        "熱い",
+        "元気",
+        "かっこいい"
+      ],
+      "motifTags": [
+        "道"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -23141,16 +23583,36 @@
         "ロック"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画",
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "戦い",
+        "青春"
+      ],
+      "moodTags": [
+        "熱い",
+        "疾走感",
+        "かっこいい"
+      ],
+      "motifTags": [
+        "道"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "THE FIRST SLAM DUNK",
+        "series": "SLAM DUNK",
+        "role": "エンディング主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1652587504
@@ -23168,20 +23630,40 @@
       "collectionName": "私を染めるiの歌"
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "J-POP"
+      ],
       "subgenres": [],
       "sourceCategories": [
         "アニメ"
       ],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "青春",
+        "片想い"
+      ],
+      "moodTags": [
+        "爽やか",
+        "切ない",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "雨"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "恋は雨上がりのように",
+        "series": "恋は雨上がりのように",
+        "role": "OP"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1537336376
@@ -23199,14 +23681,27 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
-      "subgenres": [],
+      "genres": [
+        "ロック"
+      ],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
+      "themeTags": [
+        "恋愛",
+        "再会",
+        "約束"
+      ],
+      "moodTags": [
+        "切ない",
+        "優しい"
+      ],
       "motifTags": [],
       "eventTags": []
     },
@@ -23228,18 +23723,42 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "genres": [
+        "J-POP"
+      ],
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "喪失",
+        "記憶",
+        "恋愛"
+      ],
+      "moodTags": [
+        "泣ける",
+        "切ない",
+        "優しい"
+      ],
+      "motifTags": [
+        "涙"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "世界の中心で、愛をさけぶ",
+        "series": "世界の中心で、愛をさけぶ",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -23260,17 +23779,38 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "片想い",
+        "記憶"
+      ],
+      "moodTags": [
+        "切ない",
+        "優しい"
+      ],
+      "motifTags": [
+        "声"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "50回目のファーストキス",
+        "series": "50回目のファーストキス",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1535981574
@@ -23291,14 +23831,28 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "別れ",
+        "再会",
+        "記憶"
+      ],
+      "moodTags": [
+        "優しい",
+        "切ない",
+        "爽やか"
+      ],
+      "motifTags": [
+        "海"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -23322,15 +23876,30 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
-      "eventTags": []
+      "themeTags": [
+        "恋愛",
+        "約束",
+        "家族"
+      ],
+      "moodTags": [
+        "優しい",
+        "穏やか"
+      ],
+      "motifTags": [
+        "海"
+      ],
+      "eventTags": [
+        "結婚"
+      ]
     },
     "tieUps": [],
     "source": {
@@ -23353,14 +23922,28 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "祈り",
+        "家族",
+        "記憶"
+      ],
+      "moodTags": [
+        "泣ける",
+        "優しい",
+        "癒し"
+      ],
+      "motifTags": [
+        "花"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -23386,13 +23969,26 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
-      "eventTags": []
+      "themeTags": [
+        "恋愛",
+        "日常",
+        "家族"
+      ],
+      "moodTags": [
+        "優しい",
+        "明るい"
+      ],
+      "motifTags": [
+        "笑顔"
+      ],
+      "eventTags": [
+        "結婚"
+      ]
     },
     "tieUps": [],
     "source": {
@@ -23416,16 +24012,36 @@
         "J-POP"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "秘密",
+        "絆"
+      ],
+      "moodTags": [
+        "切ない",
+        "ミステリアス",
+        "優しい"
+      ],
+      "motifTags": [
+        "手"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "薬屋のひとりごと",
+        "series": "薬屋のひとりごと",
+        "role": "ED"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1712079509
@@ -23447,16 +24063,36 @@
         "J-POP"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "自由",
+        "成長",
+        "戦い"
+      ],
+      "moodTags": [
+        "かっこいい",
+        "疾走感",
+        "明るい"
+      ],
+      "motifTags": [
+        "花"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "薬屋のひとりごと",
+        "series": "薬屋のひとりごと",
+        "role": "OP"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1786972177
@@ -23478,16 +24114,35 @@
         "J-POP"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "葛藤",
+        "恋愛",
+        "秘密"
+      ],
+      "moodTags": [
+        "ミステリアス",
+        "切ない"
+      ],
+      "motifTags": [
+        "影"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "薬屋のひとりごと",
+        "series": "薬屋のひとりごと",
+        "role": "OP"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1723078323
@@ -23509,16 +24164,35 @@
         "J-POP"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "孤独",
+        "秘密"
+      ],
+      "moodTags": [
+        "切ない",
+        "優しい"
+      ],
+      "motifTags": [
+        "声"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "薬屋のひとりごと",
+        "series": "薬屋のひとりごと",
+        "role": "ED"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1804611254
@@ -23539,17 +24213,38 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "祈り",
+        "絆"
+      ],
+      "moodTags": [
+        "優しい",
+        "癒し"
+      ],
+      "motifTags": [
+        "手"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "薬屋のひとりごと",
+        "series": "薬屋のひとりごと",
+        "role": "ED"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1721860959
@@ -23567,20 +24262,40 @@
       "collectionName": "めぐりあい - Single"
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "J-POP"
+      ],
       "subgenres": [],
       "sourceCategories": [
         "アニメ"
       ],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "希望",
+        "戦い",
+        "旅立ち"
+      ],
+      "moodTags": [
+        "壮大",
+        "熱い"
+      ],
+      "motifTags": [
+        "空",
+        "星"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "機動戦士ガンダムIII めぐりあい宇宙編",
+        "series": "機動戦士ガンダム",
+        "role": "挿入歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1244018759
@@ -23602,16 +24317,35 @@
         "J-POP"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常",
+        "家族"
+      ],
+      "moodTags": [
+        "楽しい",
+        "ノスタルジック",
+        "穏やか"
+      ],
+      "motifTags": [
+        "街"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "こちら葛飾区亀有公園前派出所",
+        "series": "こちら葛飾区亀有公園前派出所",
+        "role": "OP"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1525310841
@@ -23629,20 +24363,41 @@
       "collectionName": "ココロソマリ - Single"
     },
     "classification": {
-      "genres": [],
-      "subgenres": [],
+      "genres": [
+        "J-POP"
+      ],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [
         "アニメ"
       ],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "家族",
+        "祈り",
+        "絆"
+      ],
+      "moodTags": [
+        "優しい",
+        "癒し"
+      ],
+      "motifTags": [
+        "花"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "ソマリと森の神様",
+        "series": "ソマリと森の神様",
+        "role": "ED"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1494875710
@@ -23665,12 +24420,24 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "成長",
+        "自由",
+        "憧れ"
+      ],
+      "moodTags": [
+        "かっこいい",
+        "コミカル",
+        "おしゃれ"
+      ],
+      "motifTags": [
+        "舞台"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -23695,16 +24462,38 @@
         "J-POP"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画",
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "自由",
+        "希望",
+        "成長"
+      ],
+      "moodTags": [
+        "熱い",
+        "壮大",
+        "元気"
+      ],
+      "motifTags": [
+        "音楽",
+        "光"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "ONE PIECE FILM RED",
+        "series": "ONE PIECE",
+        "role": "劇中歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1636446959
@@ -23722,18 +24511,38 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "キッズ"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "冒険",
+        "日常"
+      ],
+      "moodTags": [
+        "楽しい",
+        "元気",
+        "コミカル"
+      ],
+      "motifTags": [
+        "旅路",
+        "音楽"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "きかんしゃトーマス",
+        "series": "きかんしゃトーマス",
+        "role": "テーマ曲"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -23751,15 +24560,27 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "ジャズ"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "インスト"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常"
+      ],
+      "moodTags": [
+        "おしゃれ",
+        "楽しい"
+      ],
+      "motifTags": [
+        "街",
+        "旅路"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -23783,17 +24604,39 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "ドラマ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "祈り",
+        "希望",
+        "戦い"
+      ],
+      "moodTags": [
+        "壮大",
+        "泣ける"
+      ],
+      "motifTags": [
+        "翼",
+        "旅路"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "Dr.コトー診療所",
+        "series": "Dr.コトー診療所",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 118543010
@@ -23811,18 +24654,40 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "ロック"
+      ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "冒険",
+        "戦い"
+      ],
+      "moodTags": [
+        "疾走感",
+        "かっこいい",
+        "緊張感"
+      ],
+      "motifTags": [
+        "空",
+        "炎"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "トップガン",
+        "series": "トップガン",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -23841,16 +24706,30 @@
     },
     "classification": {
       "genres": [
-        "J-POP"
+        "ロック"
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "旅立ち",
+        "自由",
+        "希望"
+      ],
+      "moodTags": [
+        "爽やか",
+        "疾走感",
+        "壮大"
+      ],
+      "motifTags": [
+        "空",
+        "翼",
+        "旅路"
+      ],
       "eventTags": []
     },
     "tieUps": [],

--- a/nemupipiano-musiclist-search/data/dictionary/music_metadata.json
+++ b/nemupipiano-musiclist-search/data/dictionary/music_metadata.json
@@ -34171,16 +34171,37 @@
         "J-POP"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "ドラマ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "希望",
+        "応援",
+        "成長"
+      ],
+      "moodTags": [
+        "明るい",
+        "元気",
+        "優しい"
+      ],
+      "motifTags": [
+        "涙",
+        "光"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "セカンド・チャンス",
+        "series": "セカンド・チャンス",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 291351980
@@ -34201,14 +34222,28 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "約束",
+        "祈り"
+      ],
+      "moodTags": [
+        "優しい",
+        "泣ける"
+      ],
+      "motifTags": [
+        "光",
+        "手"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -34233,16 +34268,38 @@
         "ロック"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画",
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "再会",
+        "冒険"
+      ],
+      "moodTags": [
+        "疾走感",
+        "爽やか",
+        "壮大"
+      ],
+      "motifTags": [
+        "空",
+        "光"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "君の名は。",
+        "series": "君の名は。",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1518844828
@@ -34263,14 +34320,27 @@
       "genres": [
         "ロック"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "希望",
+        "祈り",
+        "絆"
+      ],
+      "moodTags": [
+        "優しい",
+        "壮大"
+      ],
+      "motifTags": [
+        "光"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -34294,14 +34364,29 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "喪失",
+        "記憶",
+        "祈り"
+      ],
+      "moodTags": [
+        "切ない",
+        "透明感",
+        "儚い"
+      ],
+      "motifTags": [
+        "海",
+        "夜"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -34327,12 +34412,25 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "日常",
+        "希望"
+      ],
+      "moodTags": [
+        "優しい",
+        "かわいい",
+        "穏やか"
+      ],
+      "motifTags": [
+        "手",
+        "笑顔"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -34356,14 +34454,27 @@
       "genres": [
         "R&B／ソウル"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "別れ",
+        "祈り"
+      ],
+      "moodTags": [
+        "切ない",
+        "泣ける"
+      ],
+      "motifTags": [
+        "涙"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -34389,12 +34500,24 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "家族",
+        "応援",
+        "希望"
+      ],
+      "moodTags": [
+        "元気",
+        "優しい",
+        "泣ける"
+      ],
+      "motifTags": [
+        "笑顔"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -34420,12 +34543,24 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "自由",
+        "旅立ち",
+        "日常"
+      ],
+      "moodTags": [
+        "爽やか",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "旅路",
+        "道"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -34446,20 +34581,42 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "ジャズ"
+      ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "家族",
+        "記憶"
+      ],
+      "moodTags": [
+        "優しい",
+        "穏やか",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "冬",
+        "夜"
+      ],
       "eventTags": [
         "クリスマス"
       ]
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "若草の頃",
+        "series": "若草の頃",
+        "role": "劇中歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -34480,14 +34637,29 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "別れ",
+        "記憶"
+      ],
+      "moodTags": [
+        "切ない",
+        "優しい"
+      ],
+      "motifTags": [
+        "桜",
+        "春",
+        "うさぎ"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -34513,12 +34685,24 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "自由",
+        "日常"
+      ],
+      "moodTags": [
+        "かわいい",
+        "コミカル",
+        "楽しい"
+      ],
+      "motifTags": [
+        "声"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -34542,14 +34726,29 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "エレクトロポップ"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "孤独",
+        "葛藤",
+        "記憶"
+      ],
+      "moodTags": [
+        "ミステリアス",
+        "おしゃれ",
+        "ダーク"
+      ],
+      "motifTags": [
+        "夜",
+        "光"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -34573,14 +34772,29 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "片想い",
+        "記憶"
+      ],
+      "moodTags": [
+        "切ない",
+        "優しい"
+      ],
+      "motifTags": [
+        "桜",
+        "春",
+        "夜"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -34601,15 +34815,29 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "キッズ"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常",
+        "希望"
+      ],
+      "moodTags": [
+        "明るい",
+        "元気",
+        "楽しい"
+      ],
+      "motifTags": [
+        "手",
+        "太陽"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -34634,16 +34862,37 @@
         "J-POP"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画",
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "自由",
+        "成長",
+        "応援"
+      ],
+      "moodTags": [
+        "爽やか",
+        "明るい",
+        "元気"
+      ],
+      "motifTags": [
+        "光"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "ひゃくえむ。",
+        "series": "ひゃくえむ。",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1826940240
@@ -34666,12 +34915,25 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "応援",
+        "希望",
+        "自由"
+      ],
+      "moodTags": [
+        "元気",
+        "爽やか",
+        "かっこいい"
+      ],
+      "motifTags": [
+        "うさぎ",
+        "光"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -34696,16 +34958,38 @@
         "ポップス"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル",
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "冒険",
+        "友情",
+        "自由"
+      ],
+      "moodTags": [
+        "爽やか",
+        "元気",
+        "壮大"
+      ],
+      "motifTags": [
+        "海",
+        "船"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "ONE PIECE",
+        "series": "ONE PIECE",
+        "role": "OP"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 311618211
@@ -34723,16 +35007,33 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "クラシック"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
-      "eventTags": []
+      "themeTags": [
+        "別れ",
+        "記憶",
+        "旅立ち"
+      ],
+      "moodTags": [
+        "切ない",
+        "荘厳",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "蛍",
+        "光"
+      ],
+      "eventTags": [
+        "卒業"
+      ]
     },
     "tieUps": [],
     "source": {
@@ -34752,15 +35053,30 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "ジャズ"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "インスト"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "別れ",
+        "記憶"
+      ],
+      "moodTags": [
+        "切ない",
+        "おしゃれ",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "秋",
+        "風"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -34785,16 +35101,37 @@
         "劇伴音楽"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "インスト"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "夢",
+        "旅立ち",
+        "自由"
+      ],
+      "moodTags": [
+        "優しい",
+        "幻想的",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "月",
+        "川"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "ティファニーで朝食を",
+        "series": "ティファニーで朝食を",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 306677750
@@ -34812,15 +35149,29 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "ジャズ"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "インスト"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "自由"
+      ],
+      "moodTags": [
+        "おしゃれ",
+        "幻想的",
+        "優しい"
+      ],
+      "motifTags": [
+        "月",
+        "空"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -34846,12 +35197,23 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "インスト"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "記憶"
+      ],
+      "moodTags": [
+        "おしゃれ",
+        "ミステリアス",
+        "穏やか"
+      ],
+      "motifTags": [
+        "夜"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -34872,20 +35234,41 @@
       "collectionName": "美少女戦士セーラームーン ベスト"
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "J-POP"
+      ],
       "subgenres": [],
       "sourceCategories": [
         "アニメ"
       ],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "戦い",
+        "友情"
+      ],
+      "moodTags": [
+        "かわいい",
+        "熱い",
+        "元気"
+      ],
+      "motifTags": [
+        "月",
+        "光"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "美少女戦士セーラームーン",
+        "series": "美少女戦士セーラームーン",
+        "role": "OP"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1542353773
@@ -34906,14 +35289,29 @@
       "genres": [
         "ロック"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "ポップロック"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "自由",
+        "青春"
+      ],
+      "moodTags": [
+        "爽やか",
+        "疾走感",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "海",
+        "風"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -34934,18 +35332,44 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "genres": [
+        "J-POP"
+      ],
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "映画",
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "冒険",
+        "友情",
+        "旅立ち"
+      ],
+      "moodTags": [
+        "優しい",
+        "泣ける",
+        "壮大"
+      ],
+      "motifTags": [
+        "風",
+        "旅路"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "劇場版ポケットモンスター ミュウツーの逆襲",
+        "series": "ポケットモンスター",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -34963,20 +35387,43 @@
       "collectionName": "愛♡スクリ～ム! - EP"
     },
     "classification": {
-      "genres": [],
-      "subgenres": [],
+      "genres": [
+        "J-POP"
+      ],
+      "subgenres": [
+        "アイドルポップ"
+      ],
       "sourceCategories": [
         "アニメ"
       ],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル",
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "友情",
+        "日常"
+      ],
+      "moodTags": [
+        "かわいい",
+        "楽しい",
+        "元気"
+      ],
+      "motifTags": [
+        "笑顔"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "ラブライブ！シリーズ",
+        "series": "ラブライブ！",
+        "role": "キャラクターソング"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1785614776
@@ -34998,16 +35445,38 @@
         "ロック"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画",
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "冒険",
+        "絆",
+        "戦い"
+      ],
+      "moodTags": [
+        "かっこいい",
+        "壮大",
+        "緊張感"
+      ],
+      "motifTags": [
+        "声",
+        "旅路"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "劇場版 チェンソーマン レゼ篇",
+        "series": "チェンソーマン",
+        "role": "ED"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1859586540
@@ -35030,12 +35499,24 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "成長",
+        "自由",
+        "希望"
+      ],
+      "moodTags": [
+        "かっこいい",
+        "疾走感",
+        "元気"
+      ],
+      "motifTags": [
+        "光"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -35059,14 +35540,27 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "片想い",
+        "別れ"
+      ],
+      "moodTags": [
+        "切ない",
+        "泣ける"
+      ],
+      "motifTags": [
+        "涙"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -35090,14 +35584,27 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "記憶",
+        "葛藤"
+      ],
+      "moodTags": [
+        "切ない",
+        "おしゃれ"
+      ],
+      "motifTags": [
+        "夜"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -35123,12 +35630,24 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "応援",
+        "希望",
+        "日常"
+      ],
+      "moodTags": [
+        "明るい",
+        "優しい",
+        "元気"
+      ],
+      "motifTags": [
+        "花"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -35154,12 +35673,24 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "記憶",
+        "友情",
+        "希望"
+      ],
+      "moodTags": [
+        "爽やか",
+        "疾走感",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "光"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -35183,14 +35714,31 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "ボカロ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "葛藤",
+        "希望",
+        "祈り"
+      ],
+      "moodTags": [
+        "切ない",
+        "泣ける",
+        "壮大"
+      ],
+      "motifTags": [
+        "花",
+        "光"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -35211,15 +35759,28 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "R&B／ソウル"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "記憶",
+        "別れ",
+        "葛藤"
+      ],
+      "moodTags": [
+        "切ない",
+        "おしゃれ"
+      ],
+      "motifTags": [
+        "手紙"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -35245,12 +35806,24 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "日常",
+        "自由"
+      ],
+      "moodTags": [
+        "コミカル",
+        "優しい",
+        "楽しい"
+      ],
+      "motifTags": [
+        "笑顔"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -35274,14 +35847,29 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "アイドルポップ"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル",
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "青春",
+        "希望"
+      ],
+      "moodTags": [
+        "かわいい",
+        "元気",
+        "爽やか"
+      ],
+      "motifTags": [
+        "光"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -35305,14 +35893,27 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "約束",
+        "葛藤"
+      ],
+      "moodTags": [
+        "切ない",
+        "ダーク"
+      ],
+      "motifTags": [
+        "手"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -35336,17 +35937,38 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "ドラマ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "絆",
+        "祈り"
+      ],
+      "moodTags": [
+        "優しい",
+        "泣ける"
+      ],
+      "motifTags": [
+        "手"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "あいのり",
+        "series": "あいのり",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1159580791
@@ -35365,16 +35987,27 @@
     },
     "classification": {
       "genres": [
-        "演歌"
+        "歌謡曲"
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "別れ",
+        "記憶"
+      ],
+      "moodTags": [
+        "切ない",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "街"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -35396,19 +36029,42 @@
     },
     "classification": {
       "genres": [
-        "劇伴音楽"
+        "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "ドラマ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル",
+        "男性ボーカル",
+        "デュエット"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "家族",
+        "祈り"
+      ],
+      "moodTags": [
+        "優しい",
+        "泣ける"
+      ],
+      "motifTags": [
+        "光"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "ひとつ屋根の下2",
+        "series": "ひとつ屋根の下",
+        "role": "挿入歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1445975705
@@ -35426,18 +36082,43 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "genres": [
+        "J-POP"
+      ],
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "自由",
+        "祈り"
+      ],
+      "moodTags": [
+        "切ない",
+        "壮大",
+        "透明感"
+      ],
+      "motifTags": [
+        "蝶",
+        "空"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "スワロウテイル",
+        "series": "スワロウテイル",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -35455,15 +36136,26 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "キッズ"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常"
+      ],
+      "moodTags": [
+        "かわいい",
+        "コミカル"
+      ],
+      "motifTags": [
+        "手紙"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -35489,12 +36181,24 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "別れ",
+        "記憶",
+        "喪失"
+      ],
+      "moodTags": [
+        "切ない",
+        "ダーク"
+      ],
+      "motifTags": [
+        "夜",
+        "声"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -35518,17 +36222,40 @@
       "genres": [
         "ロック"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "孤独",
+        "葛藤",
+        "希望"
+      ],
+      "moodTags": [
+        "切ない",
+        "ダーク",
+        "疾走感"
+      ],
+      "motifTags": [
+        "月",
+        "夜"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "乱歩奇譚 Game of Laplace",
+        "series": "乱歩奇譚",
+        "role": "ED"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1536015134
@@ -35549,17 +36276,39 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "ポップロック"
+      ],
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常",
+        "自由",
+        "青春"
+      ],
+      "moodTags": [
+        "明るい",
+        "楽しい",
+        "爽やか"
+      ],
+      "motifTags": [
+        "音楽"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "ヲタクに恋は難しい",
+        "series": "ヲタクに恋は難しい",
+        "role": "OP"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1537461096
@@ -35580,17 +36329,38 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "ドラマ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "片想い",
+        "葛藤"
+      ],
+      "moodTags": [
+        "切ない",
+        "優しい"
+      ],
+      "motifTags": [
+        "声"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "白衣の戦士！",
+        "series": "白衣の戦士！",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1538261229
@@ -35608,15 +36378,29 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "ヒップホップ／ラップ"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "喪失",
+        "葛藤"
+      ],
+      "moodTags": [
+        "切ない",
+        "ダーク",
+        "おしゃれ"
+      ],
+      "motifTags": [
+        "涙"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -35642,12 +36426,23 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "インスト"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "冒険",
+        "成長"
+      ],
+      "moodTags": [
+        "熱い",
+        "壮大",
+        "疾走感"
+      ],
+      "motifTags": [
+        "旅路"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -35668,18 +36463,41 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "劇伴音楽"
+      ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "夢",
+        "希望",
+        "自由"
+      ],
+      "moodTags": [
+        "明るい",
+        "楽しい",
+        "おしゃれ"
+      ],
+      "motifTags": [
+        "朝",
+        "街"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "ラ・ラ・ランド",
+        "series": "ラ・ラ・ランド",
+        "role": "劇中歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null

--- a/nemupipiano-musiclist-search/data/dictionary/music_metadata.json
+++ b/nemupipiano-musiclist-search/data/dictionary/music_metadata.json
@@ -31835,14 +31835,29 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "絆",
+        "約束"
+      ],
+      "moodTags": [
+        "優しい",
+        "切ない",
+        "透明感"
+      ],
+      "motifTags": [
+        "蝶",
+        "手"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -31863,14 +31878,24 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "クラシック"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "インスト"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
+      "themeTags": [
+        "夢",
+        "日常"
+      ],
+      "moodTags": [
+        "かわいい",
+        "穏やか"
+      ],
       "motifTags": [],
       "eventTags": []
     },
@@ -31892,18 +31917,40 @@
       "collectionName": "コクリコ坂から歌集"
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "J-POP"
+      ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画",
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常",
+        "家族"
+      ],
+      "moodTags": [
+        "優しい",
+        "穏やか",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "朝"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "コクリコ坂から",
+        "series": "コクリコ坂から",
+        "role": "挿入歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 445827824
@@ -31924,14 +31971,29 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "再会",
+        "祈り",
+        "希望"
+      ],
+      "moodTags": [
+        "優しい",
+        "泣ける",
+        "壮大"
+      ],
+      "motifTags": [
+        "春",
+        "桜"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -31955,17 +32017,40 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "アイドルポップ"
+      ],
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "女性ボーカル",
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "約束",
+        "希望"
+      ],
+      "moodTags": [
+        "明るい",
+        "優しい",
+        "爽やか"
+      ],
+      "motifTags": [
+        "光"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "野生の島のロズ",
+        "series": "野生の島のロズ",
+        "role": "日本版スペシャルソング"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1780495330
@@ -31986,14 +32071,28 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "友情",
+        "旅立ち",
+        "希望"
+      ],
+      "moodTags": [
+        "優しい",
+        "泣ける",
+        "壮大"
+      ],
+      "motifTags": [
+        "道"
+      ],
       "eventTags": [
         "卒業"
       ]
@@ -32019,14 +32118,29 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "アイドルポップ"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "青春",
+        "旅立ち"
+      ],
+      "moodTags": [
+        "かわいい",
+        "爽やか",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "花",
+        "春"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -32050,15 +32164,32 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "アイドルポップ"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
-      "eventTags": []
+      "themeTags": [
+        "恋愛",
+        "青春",
+        "憧れ"
+      ],
+      "moodTags": [
+        "爽やか",
+        "明るい",
+        "元気"
+      ],
+      "motifTags": [
+        "海",
+        "夏"
+      ],
+      "eventTags": [
+        "夏休み"
+      ]
     },
     "tieUps": [],
     "source": {
@@ -32081,19 +32212,38 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "ドラマ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
+      "themeTags": [
+        "恋愛",
+        "片想い",
+        "孤独"
+      ],
+      "moodTags": [
+        "切ない",
+        "泣ける"
+      ],
       "motifTags": [],
       "eventTags": [
         "誕生日"
       ]
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "初めて恋をした日に読む話",
+        "series": "初めて恋をした日に読む話",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1452746756
@@ -32114,17 +32264,38 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "家族",
+        "記憶",
+        "再会"
+      ],
+      "moodTags": [
+        "優しい",
+        "泣ける"
+      ],
+      "motifTags": [
+        "帰り道"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "砂時計",
+        "series": "砂時計",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1536256938
@@ -32142,15 +32313,27 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "キッズ"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常"
+      ],
+      "moodTags": [
+        "かわいい",
+        "明るい"
+      ],
+      "motifTags": [
+        "蝶",
+        "花"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -32175,16 +32358,36 @@
         "J-POP"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "戦い",
+        "葛藤",
+        "自由"
+      ],
+      "moodTags": [
+        "かっこいい",
+        "疾走感",
+        "ダーク"
+      ],
+      "motifTags": [
+        "炎"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "チェンソーマン",
+        "series": "チェンソーマン",
+        "role": "OP"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1648272180
@@ -32207,12 +32410,23 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常",
+        "自由"
+      ],
+      "moodTags": [
+        "コミカル",
+        "楽しい",
+        "かわいい"
+      ],
+      "motifTags": [
+        "音楽"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -32237,16 +32451,36 @@
         "J-POP"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "記憶",
+        "葛藤",
+        "成長"
+      ],
+      "moodTags": [
+        "切ない",
+        "ミステリアス",
+        "壮大"
+      ],
+      "motifTags": [
+        "影"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "ラストマイル",
+        "series": "ラストマイル",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1844275014
@@ -32267,17 +32501,40 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "ドラマ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "希望",
+        "再会"
+      ],
+      "moodTags": [
+        "優しい",
+        "泣ける",
+        "爽やか"
+      ],
+      "motifTags": [
+        "春",
+        "風"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "僕のいた時間",
+        "series": "僕のいた時間",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 853560905
@@ -32298,14 +32555,29 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "アイドルポップ"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル",
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "応援",
+        "希望",
+        "自由"
+      ],
+      "moodTags": [
+        "元気",
+        "かわいい",
+        "楽しい"
+      ],
+      "motifTags": [
+        "光"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -32329,14 +32601,29 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "アイドルポップ"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル",
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常",
+        "友情",
+        "自由"
+      ],
+      "moodTags": [
+        "かわいい",
+        "楽しい",
+        "元気"
+      ],
+      "motifTags": [
+        "笑顔"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -32357,18 +32644,40 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "ポップス"
+      ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "祈り",
+        "希望",
+        "記憶"
+      ],
+      "moodTags": [
+        "優しい",
+        "穏やか"
+      ],
+      "motifTags": [
+        "花",
+        "雪"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "サウンド・オブ・ミュージック",
+        "series": "サウンド・オブ・ミュージック",
+        "role": "劇中歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -32386,20 +32695,41 @@
       "collectionName": "プラチナ - Single"
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "J-POP"
+      ],
       "subgenres": [],
       "sourceCategories": [
         "アニメ"
       ],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "夢",
+        "希望",
+        "成長"
+      ],
+      "moodTags": [
+        "爽やか",
+        "明るい",
+        "透明感"
+      ],
+      "motifTags": [
+        "光",
+        "空"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "カードキャプターさくら",
+        "series": "カードキャプターさくら",
+        "role": "OP"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 543496280
@@ -32420,14 +32750,27 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "家族",
+        "絆",
+        "祈り"
+      ],
+      "moodTags": [
+        "優しい",
+        "泣ける"
+      ],
+      "motifTags": [
+        "手"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -32451,14 +32794,27 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "別れ",
+        "記憶"
+      ],
+      "moodTags": [
+        "切ない",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "雨"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -32479,15 +32835,27 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "キッズ"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常",
+        "記憶"
+      ],
+      "moodTags": [
+        "穏やか",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "雨"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -32511,14 +32879,27 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "別れ",
+        "記憶"
+      ],
+      "moodTags": [
+        "切ない",
+        "泣ける"
+      ],
+      "motifTags": [
+        "雨"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -32542,15 +32923,30 @@
       "genres": [
         "エレクトロニック"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "エレクトロポップ"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
-      "eventTags": []
+      "themeTags": [
+        "自由",
+        "日常"
+      ],
+      "moodTags": [
+        "かわいい",
+        "コミカル",
+        "楽しい"
+      ],
+      "motifTags": [
+        "舞台"
+      ],
+      "eventTags": [
+        "ハロウィン"
+      ]
     },
     "tieUps": [],
     "source": {
@@ -32573,17 +32969,40 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "映画",
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "希望",
+        "約束"
+      ],
+      "moodTags": [
+        "優しい",
+        "泣ける",
+        "壮大"
+      ],
+      "motifTags": [
+        "光"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "orange",
+        "series": "orange",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1441818357
@@ -32604,15 +33023,30 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
-      "eventTags": []
+      "themeTags": [
+        "恋愛",
+        "家族",
+        "希望"
+      ],
+      "moodTags": [
+        "優しい",
+        "泣ける"
+      ],
+      "motifTags": [
+        "手紙"
+      ],
+      "eventTags": [
+        "結婚"
+      ]
     },
     "tieUps": [],
     "source": {
@@ -32632,20 +33066,43 @@
       "collectionName": "Consolation"
     },
     "classification": {
-      "genres": [],
-      "subgenres": [],
+      "genres": [
+        "J-POP"
+      ],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [
         "アニメ"
       ],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル",
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "希望",
+        "祈り",
+        "記憶"
+      ],
+      "moodTags": [
+        "優しい",
+        "泣ける",
+        "壮大"
+      ],
+      "motifTags": [
+        "光"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "劇場版 魔法少女まどか☆マギカ［前編］始まりの物語",
+        "series": "魔法少女まどか☆マギカ",
+        "role": "挿入歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1537251340
@@ -32666,14 +33123,28 @@
       "genres": [
         "ロック"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "ポップロック"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "自由",
+        "孤独",
+        "日常"
+      ],
+      "moodTags": [
+        "おしゃれ",
+        "爽やか",
+        "かっこいい"
+      ],
+      "motifTags": [
+        "街"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -32694,16 +33165,35 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "J-POP"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル",
+        "男性ボーカル",
+        "デュエット"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
-      "eventTags": []
+      "themeTags": [
+        "恋愛",
+        "自由",
+        "日常"
+      ],
+      "moodTags": [
+        "おしゃれ",
+        "楽しい",
+        "ミステリアス"
+      ],
+      "motifTags": [
+        "夏",
+        "夜"
+      ],
+      "eventTags": [
+        "夏祭り"
+      ]
     },
     "tieUps": [],
     "source": {
@@ -32726,14 +33216,28 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "アイドルポップ"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル",
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "自由"
+      ],
+      "moodTags": [
+        "楽しい",
+        "元気",
+        "コミカル"
+      ],
+      "motifTags": [
+        "炎"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -32759,12 +33263,25 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常",
+        "家族",
+        "希望"
+      ],
+      "moodTags": [
+        "明るい",
+        "楽しい",
+        "優しい"
+      ],
+      "motifTags": [
+        "冬",
+        "笑顔"
+      ],
       "eventTags": [
         "クリスマス"
       ]
@@ -32787,15 +33304,32 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
-      "subgenres": [],
+      "genres": [
+        "ポップス"
+      ],
+      "subgenres": [
+        "シティポップ"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "秘密",
+        "孤独"
+      ],
+      "moodTags": [
+        "おしゃれ",
+        "切ない",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "街",
+        "夜"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -32819,14 +33353,28 @@
       "genres": [
         "ロック"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "ポップロック"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "友情",
+        "日常"
+      ],
+      "moodTags": [
+        "明るい",
+        "楽しい",
+        "爽やか"
+      ],
+      "motifTags": [
+        "笑顔"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -32850,17 +33398,41 @@
       "genres": [
         "ロック"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
-      "eventTags": []
+      "themeTags": [
+        "恋愛",
+        "祈り",
+        "約束"
+      ],
+      "moodTags": [
+        "泣ける",
+        "壮大",
+        "切ない"
+      ],
+      "motifTags": [
+        "光"
+      ],
+      "eventTags": [
+        "結婚"
+      ]
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "X",
+        "series": "X",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1886167293
@@ -32878,15 +33450,29 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "ジャズ"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常",
+        "家族"
+      ],
+      "moodTags": [
+        "優しい",
+        "おしゃれ",
+        "穏やか"
+      ],
+      "motifTags": [
+        "冬",
+        "雪"
+      ],
       "eventTags": [
         "クリスマス"
       ]
@@ -32909,15 +33495,29 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "ポップス"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル",
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "約束"
+      ],
+      "moodTags": [
+        "明るい",
+        "楽しい",
+        "かわいい"
+      ],
+      "motifTags": [
+        "冬"
+      ],
       "eventTags": [
         "クリスマス"
       ]
@@ -32943,14 +33543,29 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "別れ",
+        "記憶"
+      ],
+      "moodTags": [
+        "切ない",
+        "ノスタルジック",
+        "優しい"
+      ],
+      "motifTags": [
+        "冬",
+        "雪"
+      ],
       "eventTags": [
         "クリスマス"
       ]
@@ -32973,15 +33588,28 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "キッズ"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常",
+        "希望"
+      ],
+      "moodTags": [
+        "かわいい",
+        "楽しい",
+        "コミカル"
+      ],
+      "motifTags": [
+        "冬"
+      ],
       "eventTags": [
         "クリスマス"
       ]
@@ -33004,15 +33632,28 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "ポップス"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常",
+        "希望"
+      ],
+      "moodTags": [
+        "明るい",
+        "楽しい"
+      ],
+      "motifTags": [
+        "街",
+        "冬"
+      ],
       "eventTags": [
         "クリスマス"
       ]
@@ -33035,15 +33676,27 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "ポップス"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常"
+      ],
+      "moodTags": [
+        "明るい",
+        "楽しい"
+      ],
+      "motifTags": [
+        "雪",
+        "冬"
+      ],
       "eventTags": [
         "クリスマス"
       ]
@@ -33066,15 +33719,28 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "クラシック"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "祈り",
+        "希望"
+      ],
+      "moodTags": [
+        "穏やか",
+        "荘厳"
+      ],
+      "motifTags": [
+        "夜",
+        "冬"
+      ],
       "eventTags": [
         "クリスマス"
       ]
@@ -33097,15 +33763,27 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "クラシック"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "祈り",
+        "希望"
+      ],
+      "moodTags": [
+        "荘厳",
+        "明るい"
+      ],
+      "motifTags": [
+        "光"
+      ],
       "eventTags": [
         "クリスマス"
       ]
@@ -33132,18 +33810,38 @@
         "J-POP"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "希望",
+        "再会"
+      ],
+      "moodTags": [
+        "明るい",
+        "爽やか"
+      ],
+      "motifTags": [
+        "冬",
+        "光"
+      ],
       "eventTags": [
         "クリスマス"
       ]
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "名探偵コナン",
+        "series": "名探偵コナン",
+        "role": "OP"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1714221548
@@ -33164,14 +33862,27 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "片想い",
+        "祈り"
+      ],
+      "moodTags": [
+        "切ない",
+        "優しい"
+      ],
+      "motifTags": [
+        "声"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -33195,14 +33906,29 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル",
+        "男性ボーカル",
+        "デュエット"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "約束",
+        "日常"
+      ],
+      "moodTags": [
+        "優しい",
+        "明るい"
+      ],
+      "motifTags": [
+        "笑顔"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -33228,12 +33954,23 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "インスト"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常",
+        "希望"
+      ],
+      "moodTags": [
+        "穏やか",
+        "優しい",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "光"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -33254,15 +33991,27 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "ポップス"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常",
+        "希望"
+      ],
+      "moodTags": [
+        "明るい",
+        "楽しい"
+      ],
+      "motifTags": [
+        "笑顔"
+      ],
       "eventTags": [
         "クリスマス"
       ]
@@ -33290,12 +34039,26 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル",
+        "女性ボーカル",
+        "デュエット"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常",
+        "家族",
+        "希望"
+      ],
+      "moodTags": [
+        "優しい",
+        "穏やか"
+      ],
+      "motifTags": [
+        "笑顔",
+        "道"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -33321,12 +34084,24 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "祈り",
+        "自由"
+      ],
+      "moodTags": [
+        "ミステリアス",
+        "おしゃれ",
+        "熱い"
+      ],
+      "motifTags": [
+        "声"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -33350,14 +34125,28 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "別れ",
+        "記憶"
+      ],
+      "moodTags": [
+        "切ない",
+        "泣ける"
+      ],
+      "motifTags": [
+        "海",
+        "涙"
+      ],
       "eventTags": []
     },
     "tieUps": [],

--- a/nemupipiano-musiclist-search/data/dictionary/music_metadata.json
+++ b/nemupipiano-musiclist-search/data/dictionary/music_metadata.json
@@ -43676,12 +43676,23 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常",
+        "自由"
+      ],
+      "moodTags": [
+        "明るい",
+        "楽しい",
+        "コミカル"
+      ],
+      "motifTags": [
+        "音楽"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -43707,12 +43718,25 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "喪失",
+        "記憶",
+        "孤独"
+      ],
+      "moodTags": [
+        "切ない",
+        "儚い",
+        "透明感"
+      ],
+      "motifTags": [
+        "海",
+        "幻"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -43736,14 +43760,27 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "アイドルポップ"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "応援",
+        "憧れ"
+      ],
+      "moodTags": [
+        "元気",
+        "楽しい",
+        "かわいい"
+      ],
+      "motifTags": [
+        "舞台"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -43767,14 +43804,28 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "ポップロック"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "希望",
+        "夢"
+      ],
+      "moodTags": [
+        "爽やか",
+        "壮大"
+      ],
+      "motifTags": [
+        "星",
+        "空",
+        "光"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -43798,17 +43849,38 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "アイドルポップ"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
-      "eventTags": []
+      "themeTags": [
+        "恋愛",
+        "約束",
+        "絆"
+      ],
+      "moodTags": [
+        "優しい",
+        "明るい"
+      ],
+      "motifTags": [
+        "花"
+      ],
+      "eventTags": [
+        "結婚"
+      ]
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "花より男子",
+        "workTitle": "花より男子F",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1485847813
@@ -43829,17 +43901,39 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "アイドルポップ"
+      ],
+      "sourceCategories": [
+        "ドラマ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "希望",
+        "応援",
+        "成長"
+      ],
+      "moodTags": [
+        "爽やか",
+        "壮大"
+      ],
+      "motifTags": [
+        "空",
+        "光"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "フリーター、家を買う。",
+        "workTitle": "フリーター、家を買う。",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1485849202
@@ -43858,19 +43952,38 @@
     },
     "classification": {
       "genres": [
-        "劇伴音楽"
+        "ロック"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "戦い",
+        "葛藤"
+      ],
+      "moodTags": [
+        "熱い",
+        "緊張感",
+        "ダーク"
+      ],
+      "motifTags": [
+        "炎"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "装甲騎兵ボトムズ",
+        "workTitle": "装甲騎兵ボトムズ",
+        "role": "OP"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1554454566
@@ -43892,16 +44005,36 @@
         "ロック"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "葛藤",
+        "戦い"
+      ],
+      "moodTags": [
+        "緊張感",
+        "ダーク",
+        "疾走感",
+        "不穏"
+      ],
+      "motifTags": [
+        "影"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "PSYCHO-PASS サイコパス",
+        "workTitle": "劇場版 PSYCHO-PASS サイコパス",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1535617938
@@ -43922,17 +44055,39 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "祈り",
+        "喪失",
+        "恋愛"
+      ],
+      "moodTags": [
+        "切ない",
+        "泣ける",
+        "荘厳"
+      ],
+      "motifTags": [
+        "涙"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "CASSHERN",
+        "workTitle": "CASSHERN",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1440747924
@@ -43955,12 +44110,23 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "葛藤",
+        "孤独"
+      ],
+      "moodTags": [
+        "切ない",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "街",
+        "道"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -43984,14 +44150,27 @@
       "genres": [
         "エレクトロニック"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "エレクトロポップ"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "再会"
+      ],
+      "moodTags": [
+        "おしゃれ",
+        "かわいい",
+        "疾走感"
+      ],
+      "motifTags": [
+        "音楽"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -44015,14 +44194,28 @@
       "genres": [
         "ロック"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "ポップロック"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "成長",
+        "自由",
+        "葛藤"
+      ],
+      "moodTags": [
+        "熱い",
+        "壮大",
+        "疾走感"
+      ],
+      "motifTags": [
+        "光"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -44046,14 +44239,26 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "約束"
+      ],
+      "moodTags": [
+        "優しい",
+        "切ない"
+      ],
+      "motifTags": [
+        "手紙"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -44077,14 +44282,26 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "片想い"
+      ],
+      "moodTags": [
+        "切ない",
+        "優しい"
+      ],
+      "motifTags": [
+        "声"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -44110,12 +44327,23 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "デュエット",
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "絆",
+        "日常"
+      ],
+      "moodTags": [
+        "明るい",
+        "優しい"
+      ],
+      "motifTags": [
+        "笑顔"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -44139,14 +44367,28 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "別れ",
+        "記憶"
+      ],
+      "moodTags": [
+        "切ない",
+        "泣ける",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "声"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -44167,18 +44409,41 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "J-POP"
+      ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "デュエット",
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "戦い",
+        "絆"
+      ],
+      "moodTags": [
+        "熱い",
+        "疾走感",
+        "壮大"
+      ],
+      "motifTags": [
+        "星",
+        "空"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "マクロス",
+        "workTitle": "マクロスF",
+        "role": "OP"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -44200,16 +44465,37 @@
         "劇伴音楽"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "ドラマ"
+      ],
+      "vocalTypes": [
+        "インスト"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "冒険",
+        "戦い",
+        "絆"
+      ],
+      "moodTags": [
+        "壮大",
+        "緊張感",
+        "荘厳"
+      ],
+      "motifTags": [
+        "星",
+        "旅路"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "スター・ウォーズ",
+        "workTitle": "マンダロリアン",
+        "role": "劇伴"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 6768789728
@@ -44227,15 +44513,30 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
-      "subgenres": [],
+      "genres": [
+        "J-POP"
+      ],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "希望",
+        "成長"
+      ],
+      "moodTags": [
+        "爽やか",
+        "熱い"
+      ],
+      "motifTags": [
+        "声"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -44259,14 +44560,27 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "喪失",
+        "記憶",
+        "別れ"
+      ],
+      "moodTags": [
+        "切ない",
+        "泣ける"
+      ],
+      "motifTags": [
+        "涙"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -44291,13 +44605,26 @@
         "J-POP"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "ボカロ"
+      ],
+      "vocalTypes": [
+        "VOCALOID"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "成長",
+        "自由",
+        "応援"
+      ],
+      "moodTags": [
+        "元気",
+        "切ない"
+      ],
+      "motifTags": [
+        "道"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -44321,17 +44648,38 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "祈り",
+        "絆"
+      ],
+      "moodTags": [
+        "切ない",
+        "壮大"
+      ],
+      "motifTags": [
+        "光"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "犬夜叉",
+        "workTitle": "犬夜叉",
+        "role": "ED"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 289409456
@@ -44354,13 +44702,26 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
-      "eventTags": []
+      "themeTags": [
+        "恋愛"
+      ],
+      "moodTags": [
+        "爽やか",
+        "明るい"
+      ],
+      "motifTags": [
+        "夏",
+        "海",
+        "太陽"
+      ],
+      "eventTags": [
+        "夏休み"
+      ]
     },
     "tieUps": [],
     "source": {
@@ -44385,12 +44746,24 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "別れ",
+        "孤独"
+      ],
+      "moodTags": [
+        "切ない",
+        "おしゃれ"
+      ],
+      "motifTags": [
+        "夜",
+        "街"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -44416,12 +44789,24 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "デュエット"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "友情",
+        "再会",
+        "絆"
+      ],
+      "moodTags": [
+        "明るい",
+        "爽やか"
+      ],
+      "motifTags": [
+        "虹",
+        "光"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -44447,12 +44832,23 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "葛藤",
+        "孤独",
+        "青春"
+      ],
+      "moodTags": [
+        "切ない",
+        "不穏"
+      ],
+      "motifTags": [
+        "雨"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -44478,12 +44874,23 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "孤独",
+        "希望"
+      ],
+      "moodTags": [
+        "切ない",
+        "透明感"
+      ],
+      "motifTags": [
+        "夜",
+        "朝"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -44504,20 +44911,43 @@
       "collectionName": "Departures 〜あなたにおくるアイの歌〜"
     },
     "classification": {
-      "genres": [],
-      "subgenres": [],
+      "genres": [
+        "J-POP"
+      ],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [
         "アニメ"
       ],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "別れ",
+        "祈り",
+        "恋愛"
+      ],
+      "moodTags": [
+        "切ない",
+        "泣ける",
+        "壮大"
+      ],
+      "motifTags": [
+        "手",
+        "声"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ギルティクラウン",
+        "workTitle": "ギルティクラウン",
+        "role": "ED"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1537785429
@@ -44535,15 +44965,26 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "ロック"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "秘密"
+      ],
+      "moodTags": [
+        "コミカル",
+        "ミステリアス"
+      ],
+      "motifTags": [
+        "舞台"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -44567,17 +45008,38 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "ドラマ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "希望",
+        "祈り"
+      ],
+      "moodTags": [
+        "優しい",
+        "壮大"
+      ],
+      "motifTags": [
+        "光"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "末っ子長男姉三人",
+        "workTitle": "末っ子長男姉三人",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1537230356
@@ -44598,14 +45060,27 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "別れ",
+        "記憶"
+      ],
+      "moodTags": [
+        "切ない",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "声"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -44626,18 +45101,43 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "genres": [
+        "ポップス"
+      ],
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "デュエット"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "希望",
+        "自由"
+      ],
+      "moodTags": [
+        "幻想的",
+        "壮大",
+        "優しい"
+      ],
+      "motifTags": [
+        "光",
+        "星"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ディズニー",
+        "workTitle": "塔の上のラプンツェル",
+        "role": "劇中歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -44655,18 +45155,42 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "genres": [
+        "ポップス"
+      ],
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "憧れ",
+        "自由",
+        "冒険"
+      ],
+      "moodTags": [
+        "優しい",
+        "壮大"
+      ],
+      "motifTags": [
+        "海",
+        "声"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ディズニー",
+        "workTitle": "リトル・マーメイド",
+        "role": "劇中歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -44684,18 +45208,40 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "キッズ"
+      ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "家族",
+        "孤独",
+        "再会"
+      ],
+      "moodTags": [
+        "かわいい",
+        "切ない"
+      ],
+      "motifTags": [
+        "雪",
+        "冬"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "アナと雪の女王",
+        "workTitle": "アナと雪の女王",
+        "role": "劇中歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -44713,18 +45259,43 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "genres": [
+        "ポップス"
+      ],
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "デュエット"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "冒険",
+        "自由"
+      ],
+      "moodTags": [
+        "壮大",
+        "幻想的"
+      ],
+      "motifTags": [
+        "空",
+        "星",
+        "旅路"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ディズニー",
+        "workTitle": "アラジン",
+        "role": "劇中歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -44743,19 +45314,41 @@
     },
     "classification": {
       "genres": [
-        "ミュージカル"
+        "ポップス"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "自由",
+        "成長",
+        "孤独"
+      ],
+      "moodTags": [
+        "壮大",
+        "熱い"
+      ],
+      "motifTags": [
+        "雪",
+        "冬"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "アナと雪の女王",
+        "workTitle": "アナと雪の女王",
+        "role": "劇中歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1440618281
@@ -44773,18 +45366,36 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "キッズ"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "絆",
+        "友情"
+      ],
+      "moodTags": [
+        "明るい",
+        "楽しい"
+      ],
+      "motifTags": [
+        "船"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ディズニー",
+        "workTitle": "イッツ・ア・スモールワールド",
+        "role": "テーマ曲"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -44802,18 +45413,40 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "genres": [
+        "ポップス"
+      ],
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "デュエット"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "成長"
+      ],
+      "moodTags": [
+        "優しい",
+        "幻想的"
+      ],
+      "motifTags": [
+        "花"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ディズニー",
+        "workTitle": "美女と野獣",
+        "role": "劇中歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -44831,18 +45464,42 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "genres": [
+        "ポップス"
+      ],
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "憧れ",
+        "自由",
+        "孤独"
+      ],
+      "moodTags": [
+        "壮大",
+        "切ない"
+      ],
+      "motifTags": [
+        "街",
+        "光"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ディズニー",
+        "workTitle": "ノートルダムの鐘",
+        "role": "劇中歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -44860,18 +45517,42 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "genres": [
+        "ポップス"
+      ],
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "自由",
+        "絆"
+      ],
+      "moodTags": [
+        "壮大",
+        "優しい"
+      ],
+      "motifTags": [
+        "風",
+        "空",
+        "川"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ディズニー",
+        "workTitle": "ポカホンタス",
+        "role": "劇中歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -44889,18 +45570,41 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "genres": [
+        "ポップス"
+      ],
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "憧れ",
+        "希望"
+      ],
+      "moodTags": [
+        "優しい",
+        "かわいい"
+      ],
+      "motifTags": [
+        "春"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ディズニー",
+        "workTitle": "白雪姫",
+        "role": "劇中歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -44918,18 +45622,40 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "劇伴音楽"
+      ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "インスト"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "冒険",
+        "戦い"
+      ],
+      "moodTags": [
+        "壮大",
+        "疾走感",
+        "緊張感"
+      ],
+      "motifTags": [
+        "海",
+        "船"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "パイレーツ・オブ・カリビアン",
+        "workTitle": "パイレーツ・オブ・カリビアン",
+        "role": "劇伴"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -44947,18 +45673,39 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "ポップス"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "冒険",
+        "旅立ち",
+        "希望"
+      ],
+      "moodTags": [
+        "壮大",
+        "爽やか"
+      ],
+      "motifTags": [
+        "海",
+        "船",
+        "旅路"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "東京ディズニーリゾート",
+        "workTitle": "シンドバッド・ストーリーブック・ヴォヤッジ",
+        "role": "テーマ曲"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -44976,18 +45723,36 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "エレクトロニック"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "インスト"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常"
+      ],
+      "moodTags": [
+        "楽しい",
+        "明るい"
+      ],
+      "motifTags": [
+        "光",
+        "音楽"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ディズニー",
+        "workTitle": "エレクトリカル・パレード",
+        "role": "テーマ曲"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -45005,18 +45770,37 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "キッズ"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "友情",
+        "日常"
+      ],
+      "moodTags": [
+        "明るい",
+        "楽しい",
+        "元気"
+      ],
+      "motifTags": [
+        "音楽"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ディズニー",
+        "workTitle": "ミッキーマウス・クラブ",
+        "role": "テーマ曲"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -45034,18 +45818,35 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "キッズ"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常"
+      ],
+      "moodTags": [
+        "元気",
+        "楽しい"
+      ],
+      "motifTags": [
+        "音楽"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "東京ディズニーリゾート",
+        "workTitle": "ジャンボリミッキー!",
+        "role": "テーマ曲"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -45063,18 +45864,40 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "genres": [
+        "ポップス"
+      ],
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "デュエット"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "成長"
+      ],
+      "moodTags": [
+        "優しい",
+        "かわいい"
+      ],
+      "motifTags": [
+        "花"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ディズニー",
+        "workTitle": "美女と野獣",
+        "role": "劇中歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -45092,18 +45915,38 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "ポップス"
+      ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常"
+      ],
+      "moodTags": [
+        "コミカル",
+        "楽しい"
+      ],
+      "motifTags": [
+        "舞台",
+        "音楽"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ディズニー",
+        "workTitle": "美女と野獣",
+        "role": "劇中歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -45121,18 +45964,42 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "genres": [
+        "ポップス"
+      ],
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "家族",
+        "記憶",
+        "絆"
+      ],
+      "moodTags": [
+        "優しい",
+        "泣ける"
+      ],
+      "motifTags": [
+        "音楽",
+        "声"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ディズニー",
+        "workTitle": "リメンバー・ミー",
+        "role": "劇中歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -45150,18 +46017,42 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "genres": [
+        "ポップス"
+      ],
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "夢",
+        "希望",
+        "祈り"
+      ],
+      "moodTags": [
+        "優しい",
+        "幻想的"
+      ],
+      "motifTags": [
+        "星",
+        "夜"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ディズニー",
+        "workTitle": "ピノキオ",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -45238,7 +46129,7 @@
     },
     "classification": {
       "genres": [
-        "サウンドトラック"
+        "劇伴音楽"
       ],
       "subgenres": [],
       "sourceCategories": [],
@@ -45269,7 +46160,7 @@
     },
     "classification": {
       "genres": [
-        "ミュージカル"
+        "ポップス"
       ],
       "subgenres": [],
       "sourceCategories": [],
@@ -45300,7 +46191,7 @@
     },
     "classification": {
       "genres": [
-        "サウンドトラック"
+        "劇伴音楽"
       ],
       "subgenres": [],
       "sourceCategories": [],
@@ -45505,7 +46396,7 @@
     },
     "classification": {
       "genres": [
-        "サウンドトラック"
+        "劇伴音楽"
       ],
       "subgenres": [],
       "sourceCategories": [],
@@ -45536,7 +46427,7 @@
     },
     "classification": {
       "genres": [
-        "J-Pop"
+        "J-POP"
       ],
       "subgenres": [],
       "sourceCategories": [],
@@ -45567,7 +46458,7 @@
     },
     "classification": {
       "genres": [
-        "サウンドトラック"
+        "劇伴音楽"
       ],
       "subgenres": [],
       "sourceCategories": [],
@@ -45627,7 +46518,7 @@
     },
     "classification": {
       "genres": [
-        "J-Pop"
+        "J-POP"
       ],
       "subgenres": [],
       "sourceCategories": [],
@@ -45658,7 +46549,7 @@
     },
     "classification": {
       "genres": [
-        "サウンドトラック"
+        "劇伴音楽"
       ],
       "subgenres": [],
       "sourceCategories": [],
@@ -45689,7 +46580,7 @@
     },
     "classification": {
       "genres": [
-        "J-Pop"
+        "J-POP"
       ],
       "subgenres": [],
       "sourceCategories": [],
@@ -45720,7 +46611,7 @@
     },
     "classification": {
       "genres": [
-        "サウンドトラック"
+        "劇伴音楽"
       ],
       "subgenres": [],
       "sourceCategories": [],
@@ -45751,7 +46642,7 @@
     },
     "classification": {
       "genres": [
-        "J-Pop"
+        "J-POP"
       ],
       "subgenres": [],
       "sourceCategories": [],
@@ -45840,7 +46731,7 @@
     },
     "classification": {
       "genres": [
-        "サウンドトラック"
+        "劇伴音楽"
       ],
       "subgenres": [],
       "sourceCategories": [],
@@ -45871,7 +46762,7 @@
     },
     "classification": {
       "genres": [
-        "J-Pop"
+        "J-POP"
       ],
       "subgenres": [],
       "sourceCategories": [],
@@ -45931,7 +46822,7 @@
     },
     "classification": {
       "genres": [
-        "サウンドトラック"
+        "劇伴音楽"
       ],
       "subgenres": [],
       "sourceCategories": [],
@@ -45993,7 +46884,7 @@
     },
     "classification": {
       "genres": [
-        "サウンドトラック"
+        "劇伴音楽"
       ],
       "subgenres": [],
       "sourceCategories": [],
@@ -46024,7 +46915,7 @@
     },
     "classification": {
       "genres": [
-        "サウンドトラック"
+        "劇伴音楽"
       ],
       "subgenres": [],
       "sourceCategories": [],
@@ -46055,7 +46946,7 @@
     },
     "classification": {
       "genres": [
-        "サウンドトラック"
+        "劇伴音楽"
       ],
       "subgenres": [],
       "sourceCategories": [],
@@ -46086,7 +46977,7 @@
     },
     "classification": {
       "genres": [
-        "J-Pop"
+        "J-POP"
       ],
       "subgenres": [],
       "sourceCategories": [],
@@ -46117,7 +47008,7 @@
     },
     "classification": {
       "genres": [
-        "サウンドトラック"
+        "劇伴音楽"
       ],
       "subgenres": [],
       "sourceCategories": [],
@@ -46206,7 +47097,7 @@
     },
     "classification": {
       "genres": [
-        "サウンドトラック"
+        "劇伴音楽"
       ],
       "subgenres": [],
       "sourceCategories": [],
@@ -46237,7 +47128,7 @@
     },
     "classification": {
       "genres": [
-        "サウンドトラック"
+        "劇伴音楽"
       ],
       "subgenres": [],
       "sourceCategories": [],
@@ -46268,7 +47159,7 @@
     },
     "classification": {
       "genres": [
-        "サウンドトラック"
+        "劇伴音楽"
       ],
       "subgenres": [],
       "sourceCategories": [],
@@ -46299,7 +47190,7 @@
     },
     "classification": {
       "genres": [
-        "J-Pop"
+        "J-POP"
       ],
       "subgenres": [],
       "sourceCategories": [],

--- a/nemupipiano-musiclist-search/data/dictionary/music_metadata.json
+++ b/nemupipiano-musiclist-search/data/dictionary/music_metadata.json
@@ -36518,17 +36518,41 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "アイドルポップ"
+      ],
+      "sourceCategories": [
+        "ドラマ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル",
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "希望",
+        "自由"
+      ],
+      "moodTags": [
+        "爽やか",
+        "明るい",
+        "疾走感"
+      ],
+      "motifTags": [
+        "空",
+        "風"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "徳山大五郎を誰が殺したか？",
+        "series": "徳山大五郎を誰が殺したか？",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1533414468
@@ -36549,14 +36573,30 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "記憶",
+        "祈り"
+      ],
+      "moodTags": [
+        "優しい",
+        "泣ける",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "海",
+        "声",
+        "風"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -36580,14 +36620,27 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "約束",
+        "祈り"
+      ],
+      "moodTags": [
+        "優しい",
+        "切ない"
+      ],
+      "motifTags": [
+        "星"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -36612,16 +36665,36 @@
         "J-POP"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "ドラマ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "日常",
+        "希望"
+      ],
+      "moodTags": [
+        "明るい",
+        "楽しい",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "音楽"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "味いちもんめ",
+        "series": "味いちもんめ",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1490814556
@@ -36644,12 +36717,25 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "家族",
+        "記憶",
+        "日常"
+      ],
+      "moodTags": [
+        "優しい",
+        "ノスタルジック",
+        "穏やか"
+      ],
+      "motifTags": [
+        "花",
+        "海"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -36670,20 +36756,39 @@
       "collectionName": "藤子・F・不二雄 生誕90周年 藤子・F・不二雄 TV MUSIC HISTORY II -藤子・F・不二雄作品集2-"
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "J-POP"
+      ],
       "subgenres": [],
       "sourceCategories": [
         "アニメ"
       ],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "日常"
+      ],
+      "moodTags": [
+        "かわいい",
+        "コミカル",
+        "優しい"
+      ],
+      "motifTags": [
+        "笑顔"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "キテレツ大百科",
+        "series": "キテレツ大百科",
+        "role": "ED"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1756878660
@@ -36704,17 +36809,38 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "ドラマ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "日常",
+        "約束"
+      ],
+      "moodTags": [
+        "優しい",
+        "切ない"
+      ],
+      "motifTags": [
+        "声"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "ピュア・ラブIII",
+        "series": "ピュア・ラブ",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1036794790
@@ -36736,16 +36862,38 @@
         "J-POP"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "ドラマ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル",
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "冒険",
+        "旅立ち",
+        "友情"
+      ],
+      "moodTags": [
+        "爽やか",
+        "元気",
+        "疾走感"
+      ],
+      "motifTags": [
+        "旅路",
+        "空"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "西遊記",
+        "series": "西遊記",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 122899374
@@ -36763,15 +36911,31 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
-      "subgenres": [],
+      "genres": [
+        "歌謡曲"
+      ],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル",
+        "デュエット"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "記憶",
+        "再会"
+      ],
+      "moodTags": [
+        "優しい",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "光"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -36795,14 +36959,27 @@
       "genres": [
         "ロック"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "孤独",
+        "祈り"
+      ],
+      "moodTags": [
+        "切ない",
+        "幻想的"
+      ],
+      "motifTags": [
+        "夜"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -36826,17 +37003,41 @@
       "genres": [
         "ロック"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "映画",
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "希望",
+        "祈り",
+        "絆"
+      ],
+      "moodTags": [
+        "優しい",
+        "泣ける",
+        "壮大"
+      ],
+      "motifTags": [
+        "空",
+        "光"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "天気の子",
+        "series": "天気の子",
+        "role": "劇中歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1518516241
@@ -36859,12 +37060,25 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "孤独",
+        "自由",
+        "葛藤"
+      ],
+      "moodTags": [
+        "ミステリアス",
+        "おしゃれ",
+        "儚い"
+      ],
+      "motifTags": [
+        "星",
+        "空"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -36889,16 +37103,37 @@
         "J-POP"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "戦い",
+        "成長",
+        "希望"
+      ],
+      "moodTags": [
+        "熱い",
+        "壮大",
+        "かっこいい"
+      ],
+      "motifTags": [
+        "炎",
+        "光"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "王様ランキング",
+        "series": "王様ランキング",
+        "role": "OP"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1600223385
@@ -36919,17 +37154,38 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "ドラマ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "片想い",
+        "祈り"
+      ],
+      "moodTags": [
+        "切ない",
+        "優しい"
+      ],
+      "motifTags": [
+        "手"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "私の家政夫ナギサさん",
+        "series": "私の家政夫ナギサさん",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1508133095
@@ -36948,17 +37204,33 @@
     },
     "classification": {
       "genres": [
-        "J-POP"
+        "キッズ"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
-      "eventTags": []
+      "themeTags": [
+        "別れ",
+        "旅立ち",
+        "記憶"
+      ],
+      "moodTags": [
+        "泣ける",
+        "優しい",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "教室"
+      ],
+      "eventTags": [
+        "卒業"
+      ]
     },
     "tieUps": [],
     "source": {
@@ -36982,16 +37254,35 @@
         "演歌"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常",
+        "自由"
+      ],
+      "moodTags": [
+        "楽しい",
+        "ノスタルジック",
+        "コミカル"
+      ],
+      "motifTags": [
+        "月"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "おじゃる丸",
+        "series": "おじゃる丸",
+        "role": "OP"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1598600874
@@ -37012,14 +37303,27 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "別れ",
+        "再会"
+      ],
+      "moodTags": [
+        "切ない",
+        "泣ける"
+      ],
+      "motifTags": [
+        "涙"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -37043,14 +37347,27 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "日常",
+        "憧れ"
+      ],
+      "moodTags": [
+        "優しい",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "花"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -37074,14 +37391,28 @@
       "genres": [
         "ロック"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル",
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "別れ",
+        "祈り"
+      ],
+      "moodTags": [
+        "切ない",
+        "泣ける"
+      ],
+      "motifTags": [
+        "声"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -37107,13 +37438,28 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
-      "eventTags": []
+      "themeTags": [
+        "日常",
+        "自由",
+        "祈り"
+      ],
+      "moodTags": [
+        "穏やか",
+        "楽しい",
+        "おしゃれ"
+      ],
+      "motifTags": [
+        "花",
+        "音楽"
+      ],
+      "eventTags": [
+        "夏祭り"
+      ]
     },
     "tieUps": [],
     "source": {
@@ -37136,15 +37482,30 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
-      "eventTags": []
+      "themeTags": [
+        "恋愛",
+        "約束",
+        "旅立ち"
+      ],
+      "moodTags": [
+        "優しい",
+        "明るい"
+      ],
+      "motifTags": [
+        "蝶"
+      ],
+      "eventTags": [
+        "結婚"
+      ]
     },
     "tieUps": [],
     "source": {
@@ -37167,14 +37528,27 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "片想い",
+        "葛藤"
+      ],
+      "moodTags": [
+        "切ない",
+        "泣ける"
+      ],
+      "motifTags": [
+        "涙"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -37198,15 +37572,32 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
-      "eventTags": []
+      "themeTags": [
+        "旅立ち",
+        "希望",
+        "家族"
+      ],
+      "moodTags": [
+        "優しい",
+        "泣ける",
+        "荘厳"
+      ],
+      "motifTags": [
+        "手",
+        "道"
+      ],
+      "eventTags": [
+        "結婚"
+      ]
     },
     "tieUps": [],
     "source": {
@@ -37231,12 +37622,25 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "希望",
+        "再会"
+      ],
+      "moodTags": [
+        "爽やか",
+        "明るい",
+        "優しい"
+      ],
+      "motifTags": [
+        "春",
+        "風"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -37261,16 +37665,36 @@
         "歌謡曲"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "青春",
+        "応援"
+      ],
+      "moodTags": [
+        "元気",
+        "爽やか",
+        "熱い"
+      ],
+      "motifTags": [
+        "太陽"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "タッチ",
+        "series": "タッチ",
+        "role": "OP"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 963626798
@@ -37291,17 +37715,40 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "アイドルポップ"
+      ],
+      "sourceCategories": [
+        "ドラマ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル",
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "希望",
+        "絆"
+      ],
+      "moodTags": [
+        "明るい",
+        "爽やか",
+        "優しい"
+      ],
+      "motifTags": [
+        "光"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "花より男子2（リターンズ）",
+        "series": "花より男子",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1485857408
@@ -37322,14 +37769,28 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "別れ",
+        "記憶"
+      ],
+      "moodTags": [
+        "切ない",
+        "泣ける"
+      ],
+      "motifTags": [
+        "桜",
+        "春"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -37353,14 +37814,28 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "記憶",
+        "祈り"
+      ],
+      "moodTags": [
+        "優しい",
+        "泣ける"
+      ],
+      "motifTags": [
+        "桜",
+        "春"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -37381,15 +37856,28 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "クラシック"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "インスト"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常",
+        "記憶"
+      ],
+      "moodTags": [
+        "穏やか",
+        "荘厳"
+      ],
+      "motifTags": [
+        "桜",
+        "春"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -37415,12 +37903,26 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "記憶",
+        "青春"
+      ],
+      "moodTags": [
+        "爽やか",
+        "切ない",
+        "明るい"
+      ],
+      "motifTags": [
+        "桜",
+        "春",
+        "花"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -37444,15 +37946,31 @@
       "genres": [
         "ロック"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
-      "eventTags": []
+      "themeTags": [
+        "家族",
+        "旅立ち",
+        "記憶"
+      ],
+      "moodTags": [
+        "泣ける",
+        "優しい"
+      ],
+      "motifTags": [
+        "桜",
+        "春"
+      ],
+      "eventTags": [
+        "卒業"
+      ]
     },
     "tieUps": [],
     "source": {
@@ -37475,14 +37993,28 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "祈り",
+        "記憶"
+      ],
+      "moodTags": [
+        "優しい",
+        "切ない"
+      ],
+      "motifTags": [
+        "桜",
+        "春"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -37508,12 +38040,24 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "友情",
+        "絆",
+        "希望"
+      ],
+      "moodTags": [
+        "熱い",
+        "元気",
+        "爽やか"
+      ],
+      "motifTags": [
+        "手"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -37537,14 +38081,28 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "エレクトロポップ"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "自由",
+        "日常",
+        "夢"
+      ],
+      "moodTags": [
+        "コミカル",
+        "おしゃれ",
+        "楽しい"
+      ],
+      "motifTags": [
+        "光"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -37568,14 +38126,27 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "片想い",
+        "祈り"
+      ],
+      "moodTags": [
+        "優しい",
+        "切ない"
+      ],
+      "motifTags": [
+        "声"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -37596,18 +38167,40 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "J-POP"
+      ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "夢",
+        "希望",
+        "冒険"
+      ],
+      "moodTags": [
+        "爽やか",
+        "元気",
+        "壮大"
+      ],
+      "motifTags": [
+        "光"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "ドラゴンクエスト",
+        "series": "ドラゴンクエスト",
+        "role": "ED"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -37625,15 +38218,29 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "ワールド"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常",
+        "自由"
+      ],
+      "moodTags": [
+        "明るい",
+        "楽しい",
+        "おしゃれ"
+      ],
+      "motifTags": [
+        "街",
+        "旅路"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -37654,15 +38261,31 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
-      "subgenres": [],
+      "genres": [
+        "J-POP"
+      ],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "青春",
+        "記憶"
+      ],
+      "moodTags": [
+        "切ない",
+        "優しい",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "影"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -37683,15 +38306,29 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "J-POP"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "青春",
+        "記憶",
+        "自由"
+      ],
+      "moodTags": [
+        "爽やか",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "虹",
+        "道"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -37717,12 +38354,23 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "日常",
+        "希望"
+      ],
+      "moodTags": [
+        "優しい",
+        "爽やか"
+      ],
+      "motifTags": [
+        "声"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -37748,12 +38396,24 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "応援",
+        "青春",
+        "成長"
+      ],
+      "moodTags": [
+        "熱い",
+        "疾走感",
+        "爽やか"
+      ],
+      "motifTags": [
+        "手紙"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -37777,17 +38437,40 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "アイドルポップ"
+      ],
+      "sourceCategories": [
+        "ドラマ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル",
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "希望",
+        "友情",
+        "応援"
+      ],
+      "moodTags": [
+        "明るい",
+        "元気",
+        "爽やか"
+      ],
+      "motifTags": [
+        "笑顔"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "山田太郎ものがたり",
+        "series": "山田太郎ものがたり",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1485847849
@@ -37809,16 +38492,35 @@
         "ロック"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "戦い",
+        "葛藤"
+      ],
+      "moodTags": [
+        "かっこいい",
+        "疾走感",
+        "ダーク"
+      ],
+      "motifTags": [
+        "空"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "銀魂",
+        "series": "銀魂",
+        "role": "OP"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1536371431
@@ -37839,14 +38541,29 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "アイドルポップ"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル",
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "秘密",
+        "日常"
+      ],
+      "moodTags": [
+        "かわいい",
+        "楽しい",
+        "コミカル"
+      ],
+      "motifTags": [
+        "声"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -37870,15 +38587,33 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル",
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
-      "eventTags": []
+      "themeTags": [
+        "友情",
+        "旅立ち",
+        "応援"
+      ],
+      "moodTags": [
+        "泣ける",
+        "優しい",
+        "壮大"
+      ],
+      "motifTags": [
+        "手紙",
+        "道"
+      ],
+      "eventTags": [
+        "卒業"
+      ]
     },
     "tieUps": [],
     "source": {
@@ -37901,14 +38636,27 @@
       "genres": [
         "ポップス"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "孤独",
+        "葛藤"
+      ],
+      "moodTags": [
+        "切ない",
+        "優しい"
+      ],
+      "motifTags": [
+        "声"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -37929,18 +38677,42 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "genres": [
+        "J-POP"
+      ],
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "ドラマ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "青春",
+        "記憶",
+        "成長"
+      ],
+      "moodTags": [
+        "切ない",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "声",
+        "音楽"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "都会の森",
+        "series": "都会の森",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -37961,14 +38733,28 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "アイドルポップ"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル",
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "自由"
+      ],
+      "moodTags": [
+        "熱い",
+        "楽しい",
+        "コミカル"
+      ],
+      "motifTags": [
+        "炎"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -37994,12 +38780,25 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "友情",
+        "応援",
+        "希望"
+      ],
+      "moodTags": [
+        "熱い",
+        "元気",
+        "爽やか"
+      ],
+      "motifTags": [
+        "道",
+        "手"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -38023,14 +38822,27 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "記憶",
+        "別れ"
+      ],
+      "moodTags": [
+        "切ない",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "街"
+      ],
       "eventTags": []
     },
     "tieUps": [],

--- a/nemupipiano-musiclist-search/data/dictionary/music_metadata.json
+++ b/nemupipiano-musiclist-search/data/dictionary/music_metadata.json
@@ -29478,12 +29478,24 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "希望",
+        "応援"
+      ],
+      "moodTags": [
+        "明るい",
+        "元気",
+        "優しい"
+      ],
+      "motifTags": [
+        "光"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -29507,14 +29519,28 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "家族",
+        "記憶",
+        "喪失"
+      ],
+      "moodTags": [
+        "切ない",
+        "泣ける",
+        "優しい"
+      ],
+      "motifTags": [
+        "涙"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -29535,15 +29561,27 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "キッズ"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常"
+      ],
+      "moodTags": [
+        "穏やか",
+        "優しい"
+      ],
+      "motifTags": [
+        "月",
+        "夜"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -29564,18 +29602,40 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "J-POP"
+      ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "冒険",
+        "希望"
+      ],
+      "moodTags": [
+        "かわいい",
+        "明るい",
+        "楽しい"
+      ],
+      "motifTags": [
+        "星"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "ドラゴンボール",
+        "series": "ドラゴンボール",
+        "role": "ED"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -29593,18 +29653,41 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "genres": [
+        "キッズ"
+      ],
+      "subgenres": [
+        "アイドルポップ"
+      ],
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常",
+        "友情"
+      ],
+      "moodTags": [
+        "かわいい",
+        "楽しい",
+        "元気"
+      ],
+      "motifTags": [
+        "笑顔"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "たまごっち!",
+        "series": "たまごっち!",
+        "role": "OP"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -29625,14 +29708,30 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "エレクトロポップ"
+      ],
+      "sourceCategories": [
+        "ボカロ"
+      ],
+      "vocalTypes": [
+        "VOCALOID"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "夢",
+        "自由",
+        "日常"
+      ],
+      "moodTags": [
+        "かわいい",
+        "明るい",
+        "爽やか"
+      ],
+      "motifTags": [
+        "音楽"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -29653,15 +29752,32 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "J-POP"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル",
+        "女性ボーカル",
+        "デュエット"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "秘密",
+        "葛藤",
+        "孤独"
+      ],
+      "moodTags": [
+        "ミステリアス",
+        "ダーク",
+        "おしゃれ"
+      ],
+      "motifTags": [
+        "影",
+        "夜"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -29682,18 +29798,42 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "ワールド"
+      ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "冒険",
+        "友情",
+        "記憶"
+      ],
+      "moodTags": [
+        "楽しい",
+        "ノスタルジック",
+        "泣ける"
+      ],
+      "motifTags": [
+        "海",
+        "船",
+        "旅路"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "ONE PIECE",
+        "series": "ONE PIECE",
+        "role": "劇中歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -29711,15 +29851,28 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "歌謡曲"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "日常"
+      ],
+      "moodTags": [
+        "おしゃれ",
+        "穏やか",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "夜"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -29745,12 +29898,24 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "片想い",
+        "青春"
+      ],
+      "moodTags": [
+        "かわいい",
+        "切ない",
+        "爽やか"
+      ],
+      "motifTags": [
+        "夏"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -29774,14 +29939,27 @@
       "genres": [
         "ロック"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "記憶",
+        "別れ"
+      ],
+      "moodTags": [
+        "切ない",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "花"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -29802,20 +29980,41 @@
       "collectionName": "美しき残酷な世界【通常盤】- EP"
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "J-POP"
+      ],
       "subgenres": [],
       "sourceCategories": [
         "アニメ"
       ],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "戦い",
+        "葛藤",
+        "祈り"
+      ],
+      "moodTags": [
+        "壮大",
+        "ダーク",
+        "緊張感"
+      ],
+      "motifTags": [
+        "影",
+        "空"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "進撃の巨人",
+        "series": "進撃の巨人",
+        "role": "ED"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 635819165
@@ -29838,12 +30037,25 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "日常",
+        "葛藤"
+      ],
+      "moodTags": [
+        "おしゃれ",
+        "切ない",
+        "爽やか"
+      ],
+      "motifTags": [
+        "光",
+        "影"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -29864,20 +30076,43 @@
       "collectionName": "THANATOS-IF I CAN'T BE YOURS- EP"
     },
     "classification": {
-      "genres": [],
-      "subgenres": [],
+      "genres": [
+        "J-POP"
+      ],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [
         "アニメ"
       ],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "喪失",
+        "祈り",
+        "葛藤"
+      ],
+      "moodTags": [
+        "泣ける",
+        "ダーク",
+        "荘厳"
+      ],
+      "motifTags": [
+        "涙",
+        "夜"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "新世紀エヴァンゲリオン劇場版 Air/まごころを、君に",
+        "series": "新世紀エヴァンゲリオン",
+        "role": "挿入歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 258929655
@@ -29895,20 +30130,42 @@
       "collectionName": "カラフル - Single"
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "J-POP"
+      ],
       "subgenres": [],
       "sourceCategories": [
         "アニメ"
       ],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル",
+        "デュエット"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "希望",
+        "記憶",
+        "絆"
+      ],
+      "moodTags": [
+        "爽やか",
+        "切ない",
+        "壮大"
+      ],
+      "motifTags": [
+        "光",
+        "虹"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "劇場版 魔法少女まどか☆マギカ［新編］叛逆の物語",
+        "series": "魔法少女まどか☆マギカ",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1537263406
@@ -29926,15 +30183,28 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "キッズ"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常"
+      ],
+      "moodTags": [
+        "かわいい",
+        "穏やか",
+        "明るい"
+      ],
+      "motifTags": [
+        "花",
+        "春"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -29955,15 +30225,27 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "キッズ"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常",
+        "冒険"
+      ],
+      "moodTags": [
+        "かわいい",
+        "楽しい"
+      ],
+      "motifTags": [
+        "旅路"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -29987,17 +30269,40 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "記憶",
+        "喪失"
+      ],
+      "moodTags": [
+        "切ない",
+        "ノスタルジック",
+        "透明感"
+      ],
+      "motifTags": [
+        "夜",
+        "旅路"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "泣きたい私は猫をかぶる",
+        "series": "泣きたい私は猫をかぶる",
+        "role": "挿入歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1498698119
@@ -30018,17 +30323,38 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "記憶",
+        "葛藤"
+      ],
+      "moodTags": [
+        "切ない",
+        "透明感"
+      ],
+      "motifTags": [
+        "手"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "今夜、世界からこの恋が消えても",
+        "series": "今夜、世界からこの恋が消えても",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1644782351
@@ -30050,16 +30376,36 @@
         "J-POP"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "ゲーム"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "希望",
+        "恋愛",
+        "冒険"
+      ],
+      "moodTags": [
+        "爽やか",
+        "壮大"
+      ],
+      "motifTags": [
+        "光",
+        "扉"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "KINGDOM HEARTS",
+        "series": "KINGDOM HEARTS",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1444860451
@@ -30081,16 +30427,38 @@
         "J-POP"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画",
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "別れ",
+        "記憶",
+        "祈り"
+      ],
+      "moodTags": [
+        "切ない",
+        "壮大",
+        "透明感"
+      ],
+      "motifTags": [
+        "涙",
+        "光"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "シン・エヴァンゲリオン劇場版",
+        "series": "新世紀エヴァンゲリオン",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1542953977
@@ -30111,17 +30479,40 @@
       "genres": [
         "ロック"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "別れ",
+        "記憶"
+      ],
+      "moodTags": [
+        "切ない",
+        "ノスタルジック",
+        "おしゃれ"
+      ],
+      "motifTags": [
+        "街",
+        "夜"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "シティーハンター2",
+        "series": "シティーハンター",
+        "role": "ED"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1537051814
@@ -30139,16 +30530,31 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "キッズ"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
-      "eventTags": []
+      "themeTags": [
+        "日常",
+        "成長"
+      ],
+      "moodTags": [
+        "かわいい",
+        "コミカル",
+        "楽しい"
+      ],
+      "motifTags": [
+        "夜"
+      ],
+      "eventTags": [
+        "ハロウィン"
+      ]
     },
     "tieUps": [],
     "source": {
@@ -30168,15 +30574,27 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "ポップス"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常",
+        "希望"
+      ],
+      "moodTags": [
+        "明るい",
+        "楽しい"
+      ],
+      "motifTags": [
+        "笑顔"
+      ],
       "eventTags": [
         "誕生日"
       ]
@@ -30204,12 +30622,24 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常",
+        "希望",
+        "家族"
+      ],
+      "moodTags": [
+        "明るい",
+        "楽しい",
+        "優しい"
+      ],
+      "motifTags": [
+        "笑顔"
+      ],
       "eventTags": [
         "誕生日"
       ]
@@ -30233,19 +30663,38 @@
     },
     "classification": {
       "genres": [
-        "J-POP"
+        "キッズ"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常",
+        "友情"
+      ],
+      "moodTags": [
+        "コミカル",
+        "楽しい",
+        "元気"
+      ],
+      "motifTags": [
+        "夜"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "妖怪ウォッチ",
+        "series": "妖怪ウォッチ",
+        "role": "ED"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 857572447
@@ -30267,16 +30716,37 @@
         "劇伴音楽"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "ゲーム"
+      ],
+      "vocalTypes": [
+        "女性ボーカル",
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "家族",
+        "日常",
+        "絆"
+      ],
+      "moodTags": [
+        "優しい",
+        "泣ける",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "花"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "ピクミン",
+        "series": "ピクミン",
+        "role": "CMソング"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 715708921
@@ -30297,14 +30767,27 @@
       "genres": [
         "ロック"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "約束",
+        "日常"
+      ],
+      "moodTags": [
+        "優しい",
+        "明るい"
+      ],
+      "motifTags": [
+        "笑顔"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -30330,12 +30813,26 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル",
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "自由",
+        "日常",
+        "希望"
+      ],
+      "moodTags": [
+        "楽しい",
+        "元気",
+        "おしゃれ"
+      ],
+      "motifTags": [
+        "光",
+        "音楽"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -30359,15 +30856,30 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
-      "eventTags": []
+      "themeTags": [
+        "恋愛",
+        "約束",
+        "祈り"
+      ],
+      "moodTags": [
+        "優しい",
+        "泣ける"
+      ],
+      "motifTags": [
+        "手紙"
+      ],
+      "eventTags": [
+        "結婚"
+      ]
     },
     "tieUps": [],
     "source": {
@@ -30390,14 +30902,29 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "アイドルポップ"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル",
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "自由",
+        "日常",
+        "応援"
+      ],
+      "moodTags": [
+        "元気",
+        "楽しい",
+        "コミカル"
+      ],
+      "motifTags": [
+        "笑顔"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -30423,12 +30950,24 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "応援",
+        "成長",
+        "希望"
+      ],
+      "moodTags": [
+        "元気",
+        "かわいい",
+        "疾走感"
+      ],
+      "motifTags": [
+        "道"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -30452,14 +30991,27 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "家族",
+        "記憶",
+        "祈り"
+      ],
+      "moodTags": [
+        "優しい",
+        "泣ける"
+      ],
+      "motifTags": [
+        "手紙"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -30484,16 +31036,36 @@
         "J-POP"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "ドラマ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "日常",
+        "憧れ"
+      ],
+      "moodTags": [
+        "明るい",
+        "優しい",
+        "かわいい"
+      ],
+      "motifTags": [
+        "笑顔"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "演歌の女王",
+        "series": "演歌の女王",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1536148866
@@ -30514,14 +31086,29 @@
       "genres": [
         "ロック"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "祈り",
+        "絆",
+        "希望"
+      ],
+      "moodTags": [
+        "優しい",
+        "壮大",
+        "切ない"
+      ],
+      "motifTags": [
+        "光",
+        "手"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -30542,17 +31129,33 @@
       "collectionName": "flos - Single"
     },
     "classification": {
-      "genres": [],
-      "subgenres": [],
-      "sourceCategories": [
-        "アニメ"
+      "genres": [
+        "J-POP"
       ],
-      "vocalTypes": []
+      "subgenres": [
+        "エレクトロポップ"
+      ],
+      "sourceCategories": [
+        "ボカロ"
+      ],
+      "vocalTypes": [
+        "VOCALOID"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "記憶",
+        "葛藤"
+      ],
+      "moodTags": [
+        "幻想的",
+        "おしゃれ",
+        "儚い"
+      ],
+      "motifTags": [
+        "花"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -30576,14 +31179,28 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "祈り",
+        "日常"
+      ],
+      "moodTags": [
+        "優しい",
+        "泣ける"
+      ],
+      "motifTags": [
+        "音楽",
+        "声"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -30607,17 +31224,38 @@
       "genres": [
         "歌謡曲"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "青春",
+        "記憶"
+      ],
+      "moodTags": [
+        "優しい",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "光"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "めぞん一刻",
+        "series": "めぞん一刻",
+        "role": "OP"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1538456299
@@ -30639,18 +31277,38 @@
         "劇伴音楽"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常",
+        "冒険"
+      ],
+      "moodTags": [
+        "コミカル",
+        "ミステリアス",
+        "楽しい"
+      ],
+      "motifTags": [
+        "夜",
+        "街"
+      ],
       "eventTags": [
         "ハロウィン"
       ]
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "ナイトメアー・ビフォア・クリスマス",
+        "series": "ナイトメアー・ビフォア・クリスマス",
+        "role": "劇中歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1669115108
@@ -30671,14 +31329,28 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "旅立ち",
+        "希望",
+        "記憶"
+      ],
+      "moodTags": [
+        "優しい",
+        "透明感"
+      ],
+      "motifTags": [
+        "旅路",
+        "道"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -30699,15 +31371,27 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "キッズ"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常"
+      ],
+      "moodTags": [
+        "かわいい",
+        "楽しい"
+      ],
+      "motifTags": [
+        "雨",
+        "川"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -30731,17 +31415,39 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "ドラマ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "孤独",
+        "喪失",
+        "祈り"
+      ],
+      "moodTags": [
+        "泣ける",
+        "切ない",
+        "ダーク"
+      ],
+      "motifTags": [
+        "涙"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "小さな巨人",
+        "series": "小さな巨人",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1538114935
@@ -30760,16 +31466,27 @@
     },
     "classification": {
       "genres": [
-        "演歌"
+        "歌謡曲"
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "憧れ"
+      ],
+      "moodTags": [
+        "明るい",
+        "おしゃれ",
+        "楽しい"
+      ],
+      "motifTags": [
+        "花"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -30793,14 +31510,28 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "再会",
+        "約束"
+      ],
+      "moodTags": [
+        "優しい",
+        "切ない"
+      ],
+      "motifTags": [
+        "冬",
+        "雪"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -30824,14 +31555,28 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "記憶",
+        "祈り"
+      ],
+      "moodTags": [
+        "優しい",
+        "切ない"
+      ],
+      "motifTags": [
+        "冬",
+        "雪"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -30857,13 +31602,26 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
-      "eventTags": []
+      "themeTags": [
+        "恋愛",
+        "日常"
+      ],
+      "moodTags": [
+        "明るい",
+        "優しい",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "冬"
+      ],
+      "eventTags": [
+        "クリスマス"
+      ]
     },
     "tieUps": [],
     "source": {
@@ -30886,14 +31644,28 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "別れ",
+        "記憶"
+      ],
+      "moodTags": [
+        "切ない",
+        "泣ける"
+      ],
+      "motifTags": [
+        "冬",
+        "春"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -30917,15 +31689,30 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
-      "eventTags": []
+      "themeTags": [
+        "恋愛",
+        "約束"
+      ],
+      "moodTags": [
+        "かわいい",
+        "優しい"
+      ],
+      "motifTags": [
+        "冬",
+        "雪"
+      ],
+      "eventTags": [
+        "クリスマス"
+      ]
     },
     "tieUps": [],
     "source": {
@@ -30948,14 +31735,28 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "家族",
+        "祈り",
+        "日常"
+      ],
+      "moodTags": [
+        "優しい",
+        "癒し"
+      ],
+      "motifTags": [
+        "冬",
+        "夜"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -30979,17 +31780,41 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "喪失",
+        "記憶"
+      ],
+      "moodTags": [
+        "切ない",
+        "泣ける",
+        "透明感"
+      ],
+      "motifTags": [
+        "夏",
+        "雪",
+        "花"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "夏雪ランデブー",
+        "series": "夏雪ランデブー",
+        "role": "ED"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1536123755

--- a/nemupipiano-musiclist-search/data/dictionary/music_metadata.json
+++ b/nemupipiano-musiclist-search/data/dictionary/music_metadata.json
@@ -27113,12 +27113,25 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "葛藤",
+        "孤独",
+        "戦い"
+      ],
+      "moodTags": [
+        "ミステリアス",
+        "ダーク",
+        "疾走感"
+      ],
+      "motifTags": [
+        "影",
+        "光"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -27139,15 +27152,30 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "ポップス"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル",
+        "デュエット"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "別れ",
+        "記憶"
+      ],
+      "moodTags": [
+        "切ない",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "雪",
+        "冬"
+      ],
       "eventTags": [
         "クリスマス"
       ]
@@ -27170,18 +27198,36 @@
       "collectionName": "ヴァンパイア - Single"
     },
     "classification": {
-      "genres": [],
-      "subgenres": [],
-      "sourceCategories": [
-        "アニメ"
+      "genres": [
+        "J-POP"
       ],
-      "vocalTypes": []
+      "subgenres": [
+        "エレクトロポップ"
+      ],
+      "sourceCategories": [
+        "ボカロ"
+      ],
+      "vocalTypes": [
+        "VOCALOID"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
-      "eventTags": []
+      "themeTags": [
+        "恋愛",
+        "葛藤",
+        "自由"
+      ],
+      "moodTags": [
+        "かわいい",
+        "ダーク",
+        "疾走感"
+      ],
+      "motifTags": [
+        "夜"
+      ],
+      "eventTags": [
+        "ハロウィン"
+      ]
     },
     "tieUps": [],
     "source": {
@@ -27206,12 +27252,25 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "憧れ",
+        "日常"
+      ],
+      "moodTags": [
+        "かわいい",
+        "明るい",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "雪",
+        "冬"
+      ],
       "eventTags": [
         "クリスマス"
       ]
@@ -27237,15 +27296,31 @@
       "genres": [
         "ロック"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
-      "eventTags": []
+      "themeTags": [
+        "恋愛",
+        "約束",
+        "祈り"
+      ],
+      "moodTags": [
+        "優しい",
+        "泣ける",
+        "壮大"
+      ],
+      "motifTags": [
+        "手"
+      ],
+      "eventTags": [
+        "結婚"
+      ]
     },
     "tieUps": [],
     "source": {
@@ -27268,17 +27343,40 @@
       "genres": [
         "ロック"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "ポップロック"
+      ],
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "夢",
+        "希望",
+        "成長"
+      ],
+      "moodTags": [
+        "爽やか",
+        "疾走感",
+        "元気"
+      ],
+      "motifTags": [
+        "星",
+        "光"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "僕のヒーローアカデミア",
+        "series": "僕のヒーローアカデミア",
+        "role": "OP"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1536466358
@@ -27299,17 +27397,38 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "ドラマ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "孤独",
+        "記憶"
+      ],
+      "moodTags": [
+        "切ない",
+        "優しい"
+      ],
+      "motifTags": [
+        "声"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "奇跡の人",
+        "series": "奇跡の人",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1442902260
@@ -27330,17 +27449,38 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "ドラマ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "日常",
+        "約束"
+      ],
+      "moodTags": [
+        "優しい",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "コーヒー"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "大恋愛〜僕を忘れる君と",
+        "series": "大恋愛",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1441482867
@@ -27361,14 +27501,30 @@
       "genres": [
         "演歌"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "別れ",
+        "旅立ち",
+        "記憶"
+      ],
+      "moodTags": [
+        "切ない",
+        "荘厳",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "雪",
+        "冬",
+        "海"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -27394,12 +27550,23 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "インスト"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常",
+        "希望"
+      ],
+      "moodTags": [
+        "爽やか",
+        "おしゃれ",
+        "透明感"
+      ],
+      "motifTags": [
+        "風"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -27424,16 +27591,36 @@
         "J-POP"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "ドラマ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "希望",
+        "日常"
+      ],
+      "moodTags": [
+        "明るい",
+        "優しい",
+        "元気"
+      ],
+      "motifTags": [
+        "笑顔"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "素顔のままで",
+        "series": "素顔のままで",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1537347334
@@ -27456,12 +27643,24 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "秘密",
+        "葛藤"
+      ],
+      "moodTags": [
+        "おしゃれ",
+        "ダーク",
+        "ミステリアス"
+      ],
+      "motifTags": [
+        "夜"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -27485,17 +27684,38 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "片想い",
+        "青春"
+      ],
+      "moodTags": [
+        "切ない",
+        "優しい"
+      ],
+      "motifTags": [
+        "手"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "のだめカンタービレ",
+        "series": "のだめカンタービレ",
+        "role": "ED"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1536254630
@@ -27513,20 +27733,40 @@
       "collectionName": "月灯りふんわり落ちてくる夜 - Single"
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "J-POP"
+      ],
       "subgenres": [],
       "sourceCategories": [
         "アニメ"
       ],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常",
+        "家族"
+      ],
+      "moodTags": [
+        "優しい",
+        "穏やか",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "月",
+        "夜"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "クレヨンしんちゃん",
+        "series": "クレヨンしんちゃん",
+        "role": "ED"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1657418958
@@ -27544,18 +27784,41 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "J-POP"
+      ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "ドラマ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "希望",
+        "恋愛",
+        "自由"
+      ],
+      "moodTags": [
+        "爽やか",
+        "疾走感",
+        "明るい"
+      ],
+      "motifTags": [
+        "光",
+        "空"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "リッチマン、プアウーマン",
+        "series": "リッチマン、プアウーマン",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -27577,16 +27840,35 @@
         "J-POP"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "ドラマ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "別れ",
+        "葛藤"
+      ],
+      "moodTags": [
+        "切ない",
+        "かっこいい"
+      ],
+      "motifTags": [
+        "夜"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "トドメの接吻",
+        "series": "トドメの接吻",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1536317386
@@ -27607,14 +27889,28 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "ポップロック"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "別れ",
+        "記憶"
+      ],
+      "moodTags": [
+        "切ない",
+        "疾走感"
+      ],
+      "motifTags": [
+        "海",
+        "風"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -27638,14 +27934,27 @@
       "genres": [
         "ロック"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "ポップロック"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "秘密",
+        "葛藤"
+      ],
+      "moodTags": [
+        "切ない",
+        "おしゃれ"
+      ],
+      "motifTags": [
+        "夜"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -27670,16 +27979,38 @@
         "J-POP"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "ドラマ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
-      "eventTags": []
+      "themeTags": [
+        "恋愛",
+        "青春"
+      ],
+      "moodTags": [
+        "熱い",
+        "元気",
+        "楽しい"
+      ],
+      "motifTags": [
+        "太陽",
+        "夏"
+      ],
+      "eventTags": [
+        "夏休み"
+      ]
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "花ざかりの君たちへ〜イケメン♂パラダイス〜",
+        "series": "花ざかりの君たちへ",
+        "role": "OP"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1537392624
@@ -27701,16 +28032,36 @@
         "ロック"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "戦い",
+        "喪失"
+      ],
+      "moodTags": [
+        "熱い",
+        "切ない",
+        "壮大"
+      ],
+      "motifTags": [
+        "空"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "SLAM DUNK",
+        "series": "SLAM DUNK",
+        "role": "ED"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 75465805
@@ -27733,12 +28084,23 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "日常"
+      ],
+      "moodTags": [
+        "楽しい",
+        "明るい",
+        "かわいい"
+      ],
+      "motifTags": [
+        "街"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -27760,16 +28122,29 @@
     },
     "classification": {
       "genres": [
-        "J-POP"
+        "ワールド"
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "家族",
+        "記憶",
+        "自由"
+      ],
+      "moodTags": [
+        "優しい",
+        "ノスタルジック",
+        "穏やか"
+      ],
+      "motifTags": [
+        "海",
+        "旅路"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -27793,14 +28168,27 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "別れ",
+        "喪失"
+      ],
+      "moodTags": [
+        "切ない",
+        "泣ける"
+      ],
+      "motifTags": [
+        "雨"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -27824,14 +28212,27 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "別れ",
+        "記憶"
+      ],
+      "moodTags": [
+        "切ない",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "夜"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -27855,14 +28256,28 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "アイドルポップ"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル",
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "自由"
+      ],
+      "moodTags": [
+        "楽しい",
+        "元気",
+        "コミカル"
+      ],
+      "motifTags": [
+        "夜"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -27887,16 +28302,36 @@
         "J-POP"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "ドラマ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "日常",
+        "青春"
+      ],
+      "moodTags": [
+        "かわいい",
+        "明るい",
+        "楽しい"
+      ],
+      "motifTags": [
+        "笑顔"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "セレブと貧乏太郎",
+        "series": "セレブと貧乏太郎",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1536256436
@@ -27919,12 +28354,23 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "青春",
+        "恋愛",
+        "自由"
+      ],
+      "moodTags": [
+        "爽やか",
+        "おしゃれ"
+      ],
+      "motifTags": [
+        "街"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -27949,16 +28395,35 @@
         "ヒップホップ／ラップ"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "自由",
+        "戦い"
+      ],
+      "moodTags": [
+        "かっこいい",
+        "疾走感",
+        "コミカル"
+      ],
+      "motifTags": [
+        "音楽"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "マッシュル-MASHLE-",
+        "series": "マッシュル-MASHLE-",
+        "role": "OP"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1720332181
@@ -27981,12 +28446,24 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "自由",
+        "葛藤"
+      ],
+      "moodTags": [
+        "かっこいい",
+        "ダーク",
+        "おしゃれ"
+      ],
+      "motifTags": [
+        "夜"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -28010,15 +28487,32 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル",
+        "デュエット"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
-      "eventTags": []
+      "themeTags": [
+        "恋愛",
+        "約束",
+        "絆"
+      ],
+      "moodTags": [
+        "優しい",
+        "切ない"
+      ],
+      "motifTags": [
+        "雪",
+        "冬"
+      ],
+      "eventTags": [
+        "クリスマス"
+      ]
     },
     "tieUps": [],
     "source": {
@@ -28042,16 +28536,36 @@
         "J-POP"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "ドラマ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "旅立ち",
+        "成長",
+        "記憶"
+      ],
+      "moodTags": [
+        "優しい",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "旅路",
+        "道"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "にじいろカルテ",
+        "series": "にじいろカルテ",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1555177261
@@ -28072,17 +28586,40 @@
       "genres": [
         "ロック"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "喪失",
+        "祈り",
+        "戦い"
+      ],
+      "moodTags": [
+        "切ない",
+        "壮大",
+        "ダーク"
+      ],
+      "motifTags": [
+        "月",
+        "花"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "ブラック・ジャック",
+        "series": "ブラック・ジャック",
+        "role": "OP"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 843626327
@@ -28103,14 +28640,27 @@
       "genres": [
         "ロック"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "片想い",
+        "葛藤"
+      ],
+      "moodTags": [
+        "切ない",
+        "おしゃれ"
+      ],
+      "motifTags": [
+        "夜"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -28131,14 +28681,24 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "キッズ"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
+      "themeTags": [
+        "日常",
+        "家族"
+      ],
+      "moodTags": [
+        "かわいい",
+        "穏やか"
+      ],
       "motifTags": [],
       "eventTags": []
     },
@@ -28160,15 +28720,27 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "キッズ"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常",
+        "冒険"
+      ],
+      "moodTags": [
+        "かわいい",
+        "楽しい"
+      ],
+      "motifTags": [
+        "旅路"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -28194,12 +28766,24 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "青春",
+        "葛藤"
+      ],
+      "moodTags": [
+        "爽やか",
+        "切ない"
+      ],
+      "motifTags": [
+        "夏",
+        "風"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -28225,11 +28809,21 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
+      "themeTags": [
+        "恋愛",
+        "別れ",
+        "葛藤"
+      ],
+      "moodTags": [
+        "コミカル",
+        "楽しい",
+        "切ない"
+      ],
       "motifTags": [],
       "eventTags": []
     },
@@ -28254,14 +28848,27 @@
       "genres": [
         "エレクトロニック"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "エレクトロポップ"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常",
+        "自由"
+      ],
+      "moodTags": [
+        "おしゃれ",
+        "疾走感",
+        "かわいい"
+      ],
+      "motifTags": [
+        "音楽"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -28285,15 +28892,31 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル",
+        "デュエット"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
-      "eventTags": []
+      "themeTags": [
+        "恋愛",
+        "約束"
+      ],
+      "moodTags": [
+        "優しい",
+        "かわいい"
+      ],
+      "motifTags": [
+        "雪",
+        "冬"
+      ],
+      "eventTags": [
+        "クリスマス"
+      ]
     },
     "tieUps": [],
     "source": {
@@ -28318,13 +28941,28 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル",
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
-      "eventTags": []
+      "themeTags": [
+        "恋愛",
+        "日常"
+      ],
+      "moodTags": [
+        "楽しい",
+        "元気",
+        "おしゃれ"
+      ],
+      "motifTags": [
+        "夏",
+        "海"
+      ],
+      "eventTags": [
+        "夏休み"
+      ]
     },
     "tieUps": [],
     "source": {
@@ -28347,17 +28985,38 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "記憶",
+        "恋愛",
+        "別れ"
+      ],
+      "moodTags": [
+        "切ない",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "声"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "時をかける少女",
+        "series": "時をかける少女",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1536260454
@@ -28379,16 +29038,38 @@
         "J-POP"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画",
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "希望",
+        "友情",
+        "絆"
+      ],
+      "moodTags": [
+        "優しい",
+        "泣ける",
+        "壮大"
+      ],
+      "motifTags": [
+        "笑顔",
+        "光"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "劇場版ポケットモンスター ベストウイッシュ 神速のゲノセクト ミュウツー覚醒",
+        "series": "ポケットモンスター",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1536269605
@@ -28409,17 +29090,39 @@
       "genres": [
         "ロック"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "映画",
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "記憶",
+        "葛藤"
+      ],
+      "moodTags": [
+        "切ない",
+        "壮大"
+      ],
+      "motifTags": [
+        "音楽"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "かがみの孤城",
+        "series": "かがみの孤城",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1657348387
@@ -28437,15 +29140,26 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "キッズ"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常"
+      ],
+      "moodTags": [
+        "かわいい",
+        "楽しい"
+      ],
+      "motifTags": [
+        "花"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -28466,18 +29180,44 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "genres": [
+        "J-POP"
+      ],
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "映画",
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "別れ",
+        "記憶",
+        "青春"
+      ],
+      "moodTags": [
+        "切ない",
+        "泣ける",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "夏",
+        "海"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "コクリコ坂から",
+        "series": "コクリコ坂から",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -28495,15 +29235,29 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "キッズ"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常",
+        "希望"
+      ],
+      "moodTags": [
+        "楽しい",
+        "明るい",
+        "元気"
+      ],
+      "motifTags": [
+        "手",
+        "笑顔"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -28524,20 +29278,40 @@
       "collectionName": "スーパーロボット魂 ボーカルベストセレクション"
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "J-POP"
+      ],
       "subgenres": [],
       "sourceCategories": [
         "アニメ"
       ],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "戦い",
+        "希望"
+      ],
+      "moodTags": [
+        "熱い",
+        "かっこいい",
+        "壮大"
+      ],
+      "motifTags": [
+        "炎",
+        "光"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "マジンガーZ",
+        "series": "マジンガーZ",
+        "role": "OP"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 458237797
@@ -28559,16 +29333,35 @@
         "歌謡曲"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "希望",
+        "自由",
+        "日常"
+      ],
+      "moodTags": [
+        "明るい",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "空"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "鉄腕アトム",
+        "series": "鉄腕アトム",
+        "role": "OP"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1018806356
@@ -28586,18 +29379,41 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "J-POP"
+      ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "冒険",
+        "友情",
+        "戦い"
+      ],
+      "moodTags": [
+        "元気",
+        "熱い",
+        "楽しい"
+      ],
+      "motifTags": [
+        "旅路",
+        "空"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "ドラゴンボール",
+        "series": "ドラゴンボール",
+        "role": "OP"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -28620,12 +29436,23 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "インスト"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常"
+      ],
+      "moodTags": [
+        "おしゃれ",
+        "穏やか",
+        "癒し"
+      ],
+      "motifTags": [
+        "花",
+        "音楽"
+      ],
       "eventTags": []
     },
     "tieUps": [],

--- a/nemupipiano-musiclist-search/data/dictionary/music_metadata.json
+++ b/nemupipiano-musiclist-search/data/dictionary/music_metadata.json
@@ -46070,18 +46070,39 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "ポップス"
+      ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常",
+        "希望"
+      ],
+      "moodTags": [
+        "明るい",
+        "楽しい"
+      ],
+      "motifTags": [
+        "晴れ",
+        "虹"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ディズニー",
+        "workTitle": "南部の唄",
+        "role": "劇中歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -46099,18 +46120,40 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "ポップス"
+      ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "自由",
+        "憧れ",
+        "冒険"
+      ],
+      "moodTags": [
+        "明るい",
+        "爽やか"
+      ],
+      "motifTags": [
+        "光",
+        "空"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ディズニー",
+        "workTitle": "塔の上のラプンツェル",
+        "role": "劇中歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -46129,19 +46172,37 @@
     },
     "classification": {
       "genres": [
-        "劇伴音楽"
+        "ポップス"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "友情",
+        "絆"
+      ],
+      "moodTags": [
+        "優しい",
+        "楽しい"
+      ],
+      "motifTags": [
+        "手"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ディズニー",
+        "workTitle": "トイ・ストーリー",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1456073416
@@ -46163,16 +46224,36 @@
         "ポップス"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "成長",
+        "家族",
+        "希望"
+      ],
+      "moodTags": [
+        "壮大",
+        "荘厳"
+      ],
+      "motifTags": [
+        "太陽",
+        "光"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ディズニー",
+        "workTitle": "ライオン・キング",
+        "role": "劇中歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1445732940
@@ -46191,19 +46272,40 @@
     },
     "classification": {
       "genres": [
-        "劇伴音楽"
+        "ポップス"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "絆"
+      ],
+      "moodTags": [
+        "優しい",
+        "壮大"
+      ],
+      "motifTags": [
+        "夜",
+        "星"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ディズニー",
+        "workTitle": "ライオン・キング",
+        "role": "劇中歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1770152904
@@ -46221,18 +46323,40 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "ポップス"
+      ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "家族",
+        "友情",
+        "日常"
+      ],
+      "moodTags": [
+        "明るい",
+        "楽しい"
+      ],
+      "motifTags": [
+        "海",
+        "夏"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ディズニー",
+        "workTitle": "リロ・アンド・スティッチ",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -46250,18 +46374,39 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "劇伴音楽"
+      ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "インスト"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "孤独"
+      ],
+      "moodTags": [
+        "幻想的",
+        "優しい"
+      ],
+      "motifTags": [
+        "星",
+        "空"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ピクサー",
+        "workTitle": "ウォーリー",
+        "role": "劇伴"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -46279,18 +46424,40 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "ポップス"
+      ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "友情",
+        "冒険"
+      ],
+      "moodTags": [
+        "コミカル",
+        "楽しい",
+        "元気"
+      ],
+      "motifTags": [
+        "幻",
+        "舞台"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ディズニー",
+        "workTitle": "アラジン",
+        "role": "劇中歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -46308,18 +46475,42 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "genres": [
+        "劇伴音楽"
+      ],
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "約束",
+        "恋愛",
+        "祈り"
+      ],
+      "moodTags": [
+        "優しい",
+        "幻想的",
+        "切ない"
+      ],
+      "motifTags": [
+        "空"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ジブリ",
+        "workTitle": "ハウルの動く城",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -46337,18 +46528,40 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "劇伴音楽"
+      ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "インスト"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "冒険",
+        "記憶"
+      ],
+      "moodTags": [
+        "幻想的",
+        "壮大",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "舞台"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ジブリ",
+        "workTitle": "ハウルの動く城",
+        "role": "劇伴"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -46366,18 +46579,39 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "劇伴音楽"
+      ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "インスト"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常",
+        "冒険"
+      ],
+      "moodTags": [
+        "穏やか",
+        "幻想的"
+      ],
+      "motifTags": [
+        "風",
+        "道"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ジブリ",
+        "workTitle": "となりのトトロ",
+        "role": "劇伴"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -46399,16 +46633,37 @@
         "劇伴音楽"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "インスト"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "旅立ち",
+        "日常",
+        "成長"
+      ],
+      "moodTags": [
+        "爽やか",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "海",
+        "街",
+        "空"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ジブリ",
+        "workTitle": "魔女の宅急便",
+        "role": "劇伴"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 667779092
@@ -46430,16 +46685,37 @@
         "J-POP"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "冒険",
+        "日常",
+        "家族"
+      ],
+      "moodTags": [
+        "元気",
+        "明るい",
+        "楽しい"
+      ],
+      "motifTags": [
+        "道",
+        "風"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ジブリ",
+        "workTitle": "となりのトトロ",
+        "role": "OP"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 299841835
@@ -46460,17 +46736,39 @@
       "genres": [
         "劇伴音楽"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "祈り",
+        "記憶",
+        "旅立ち"
+      ],
+      "moodTags": [
+        "優しい",
+        "幻想的",
+        "癒し"
+      ],
+      "motifTags": [
+        "声"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ジブリ",
+        "workTitle": "千と千尋の神隠し",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 668520684
@@ -46488,18 +46786,40 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "劇伴音楽"
+      ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "家族",
+        "日常",
+        "冒険"
+      ],
+      "moodTags": [
+        "優しい",
+        "楽しい"
+      ],
+      "motifTags": [
+        "猫",
+        "風"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ジブリ",
+        "workTitle": "となりのトトロ",
+        "role": "ED"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -46521,16 +46841,35 @@
         "J-POP"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "家族",
+        "日常"
+      ],
+      "moodTags": [
+        "かわいい",
+        "楽しい",
+        "元気"
+      ],
+      "motifTags": [
+        "海"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ジブリ",
+        "workTitle": "崖の上のポニョ",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 299841905
@@ -46552,16 +46891,38 @@
         "劇伴音楽"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "インスト"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
-      "eventTags": []
+      "themeTags": [
+        "記憶",
+        "成長",
+        "冒険"
+      ],
+      "moodTags": [
+        "幻想的",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "夏",
+        "川"
+      ],
+      "eventTags": [
+        "夏休み"
+      ]
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ジブリ",
+        "workTitle": "千と千尋の神隠し",
+        "role": "劇伴"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 668520663
@@ -46583,16 +46944,36 @@
         "J-POP"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "自由",
+        "成長",
+        "恋愛"
+      ],
+      "moodTags": [
+        "爽やか",
+        "明るい"
+      ],
+      "motifTags": [
+        "風",
+        "空"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ジブリ",
+        "workTitle": "猫の恩返し",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 160599783
@@ -46611,19 +46992,39 @@
     },
     "classification": {
       "genres": [
-        "劇伴音楽"
+        "ポップス"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "旅立ち",
+        "憧れ",
+        "成長"
+      ],
+      "moodTags": [
+        "ノスタルジック",
+        "優しい"
+      ],
+      "motifTags": [
+        "帰り道",
+        "街"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ジブリ",
+        "workTitle": "耳をすませば",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 667855313
@@ -46644,17 +47045,39 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "孤独",
+        "祈り",
+        "葛藤"
+      ],
+      "moodTags": [
+        "切ない",
+        "荘厳"
+      ],
+      "motifTags": [
+        "声",
+        "空"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ジブリ",
+        "workTitle": "ゲド戦記",
+        "role": "挿入歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 258494351
@@ -46672,18 +47095,42 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "genres": [
+        "劇伴音楽"
+      ],
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "冒険",
+        "希望",
+        "絆"
+      ],
+      "moodTags": [
+        "壮大",
+        "優しい"
+      ],
+      "motifTags": [
+        "空",
+        "光"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ジブリ",
+        "workTitle": "天空の城ラピュタ",
+        "role": "ED"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -46701,18 +47148,40 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "劇伴音楽"
+      ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "インスト"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "祈り",
+        "冒険"
+      ],
+      "moodTags": [
+        "荘厳",
+        "壮大"
+      ],
+      "motifTags": [
+        "空",
+        "翼",
+        "風"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ジブリ",
+        "workTitle": "風の谷のナウシカ",
+        "role": "劇伴"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -46734,16 +47203,35 @@
         "劇伴音楽"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "インスト"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常",
+        "成長"
+      ],
+      "moodTags": [
+        "明るい",
+        "爽やか"
+      ],
+      "motifTags": [
+        "街",
+        "朝"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ジブリ",
+        "workTitle": "魔女の宅急便",
+        "role": "劇伴"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 667779095
@@ -46765,16 +47253,36 @@
         "J-POP"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常",
+        "希望",
+        "成長"
+      ],
+      "moodTags": [
+        "優しい",
+        "明るい"
+      ],
+      "motifTags": [
+        "光",
+        "朝"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ジブリ",
+        "workTitle": "魔女の宅急便",
+        "role": "ED"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1436010457
@@ -46792,18 +47300,39 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "J-POP"
+      ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "日常"
+      ],
+      "moodTags": [
+        "おしゃれ",
+        "明るい"
+      ],
+      "motifTags": [
+        "手紙",
+        "街"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ジブリ",
+        "workTitle": "魔女の宅急便",
+        "role": "OP"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -46825,16 +47354,34 @@
         "劇伴音楽"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "インスト"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常",
+        "家族"
+      ],
+      "moodTags": [
+        "コミカル",
+        "穏やか"
+      ],
+      "motifTags": [
+        "風"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ジブリ",
+        "workTitle": "平成狸合戦ぽんぽこ",
+        "role": "劇伴"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 667831625
@@ -46855,17 +47402,39 @@
       "genres": [
         "歌謡曲"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "記憶",
+        "喪失",
+        "旅立ち"
+      ],
+      "moodTags": [
+        "ノスタルジック",
+        "切ない"
+      ],
+      "motifTags": [
+        "空",
+        "旅路"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ジブリ",
+        "workTitle": "紅の豚",
+        "role": "ED"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1443337669
@@ -46887,16 +47456,35 @@
         "劇伴音楽"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "インスト"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "再会",
+        "記憶",
+        "祈り"
+      ],
+      "moodTags": [
+        "幻想的",
+        "泣ける"
+      ],
+      "motifTags": [
+        "光"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ジブリ",
+        "workTitle": "千と千尋の神隠し",
+        "role": "劇伴"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 668520682
@@ -46918,16 +47506,35 @@
         "劇伴音楽"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "インスト"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "記憶",
+        "喪失"
+      ],
+      "moodTags": [
+        "ノスタルジック",
+        "切ない"
+      ],
+      "motifTags": [
+        "街",
+        "夕暮れ"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ジブリ",
+        "workTitle": "紅の豚",
+        "role": "劇伴"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 667811546
@@ -46949,16 +47556,35 @@
         "劇伴音楽"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "インスト"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "冒険",
+        "自由"
+      ],
+      "moodTags": [
+        "おしゃれ",
+        "爽やか"
+      ],
+      "motifTags": [
+        "空",
+        "海"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ジブリ",
+        "workTitle": "紅の豚",
+        "role": "劇伴"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 667811544
@@ -46979,17 +47605,39 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "旅立ち",
+        "記憶",
+        "喪失"
+      ],
+      "moodTags": [
+        "切ない",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "空",
+        "風"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ジブリ",
+        "workTitle": "風立ちぬ",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1436009093
@@ -47011,16 +47659,35 @@
         "劇伴音楽"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "インスト"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "冒険",
+        "日常"
+      ],
+      "moodTags": [
+        "楽しい",
+        "コミカル"
+      ],
+      "motifTags": [
+        "猫",
+        "道"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ジブリ",
+        "workTitle": "となりのトトロ",
+        "role": "劇伴"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 667366557
@@ -47038,18 +47705,40 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "genres": [
+        "劇伴音楽"
+      ],
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "家族",
+        "祈り"
+      ],
+      "moodTags": [
+        "優しい",
+        "幻想的"
+      ],
+      "motifTags": [
+        "海"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ジブリ",
+        "workTitle": "崖の上のポニョ",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -47067,18 +47756,42 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "genres": [
+        "劇伴音楽"
+      ],
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "祈り",
+        "戦い",
+        "絆"
+      ],
+      "moodTags": [
+        "荘厳",
+        "幻想的"
+      ],
+      "motifTags": [
+        "影",
+        "風"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ジブリ",
+        "workTitle": "もののけ姫",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -47100,16 +47813,34 @@
         "劇伴音楽"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "インスト"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常",
+        "冒険"
+      ],
+      "moodTags": [
+        "かわいい",
+        "ミステリアス"
+      ],
+      "motifTags": [
+        "影"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ジブリ",
+        "workTitle": "となりのトトロ",
+        "role": "劇伴"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 667366549
@@ -47131,16 +47862,34 @@
         "劇伴音楽"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "インスト"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常",
+        "家族"
+      ],
+      "moodTags": [
+        "かわいい",
+        "コミカル"
+      ],
+      "motifTags": [
+        "道"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ジブリ",
+        "workTitle": "となりのトトロ",
+        "role": "劇伴"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 667366424
@@ -47162,16 +47911,37 @@
         "劇伴音楽"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "インスト"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "戦い",
+        "祈り",
+        "冒険"
+      ],
+      "moodTags": [
+        "荘厳",
+        "壮大",
+        "緊張感"
+      ],
+      "motifTags": [
+        "風",
+        "影"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ジブリ",
+        "workTitle": "もののけ姫",
+        "role": "劇伴"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 667870482
@@ -47192,17 +47962,39 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "祈り",
+        "希望",
+        "戦い"
+      ],
+      "moodTags": [
+        "幻想的",
+        "切ない"
+      ],
+      "motifTags": [
+        "風",
+        "空"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ジブリ",
+        "workTitle": "風の谷のナウシカ",
+        "role": "シンボルテーマ"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 257124398
@@ -47220,18 +48012,39 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "劇伴音楽"
+      ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "インスト"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "記憶",
+        "祈り"
+      ],
+      "moodTags": [
+        "幻想的",
+        "切ない"
+      ],
+      "motifTags": [
+        "風",
+        "空"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "series": "ジブリ",
+        "workTitle": "風の谷のナウシカ",
+        "role": "劇伴"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null

--- a/nemupipiano-musiclist-search/data/dictionary/music_metadata.json
+++ b/nemupipiano-musiclist-search/data/dictionary/music_metadata.json
@@ -22384,8 +22384,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "ねらわれた学園",
         "series": "ねらわれた学園",
+        "workTitle": "ねらわれた学園",
         "role": "主題歌"
       }
     ],
@@ -22435,8 +22435,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "雨に唄えば",
         "series": "雨に唄えば",
+        "workTitle": "雨に唄えば",
         "role": "主題歌"
       }
     ],
@@ -22833,8 +22833,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "新世紀エヴァンゲリオン劇場版 シト新生",
         "series": "新世紀エヴァンゲリオン",
+        "workTitle": "新世紀エヴァンゲリオン劇場版 シト新生",
         "role": "主題歌"
       }
     ],
@@ -22929,8 +22929,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "呪術廻戦",
         "series": "呪術廻戦",
+        "workTitle": "呪術廻戦",
         "role": "ED"
       }
     ],
@@ -22981,8 +22981,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "呪術廻戦",
         "series": "呪術廻戦",
+        "workTitle": "呪術廻戦",
         "role": "OP"
       }
     ],
@@ -23170,8 +23170,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "真夏のシンデレラ",
         "series": "真夏のシンデレラ",
+        "workTitle": "真夏のシンデレラ",
         "role": "主題歌"
       }
     ],
@@ -23223,8 +23223,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "機動戦士ガンダムIII めぐりあい宇宙編",
         "series": "機動戦士ガンダム",
+        "workTitle": "機動戦士ガンダムIII めぐりあい宇宙編",
         "role": "主題歌"
       }
     ],
@@ -23276,8 +23276,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "サクラ大戦",
         "series": "サクラ大戦",
+        "workTitle": "サクラ大戦",
         "role": "OP"
       }
     ],
@@ -23369,8 +23369,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "魔法騎士レイアース",
         "series": "魔法騎士レイアース",
+        "workTitle": "魔法騎士レイアース",
         "role": "OP"
       }
     ],
@@ -23514,8 +23514,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "FINAL FANTASY XIII",
         "series": "FINAL FANTASY",
+        "workTitle": "FINAL FANTASY XIII",
         "role": "主題歌"
       }
     ],
@@ -23608,8 +23608,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "THE FIRST SLAM DUNK",
         "series": "SLAM DUNK",
+        "workTitle": "THE FIRST SLAM DUNK",
         "role": "エンディング主題歌"
       }
     ],
@@ -23659,8 +23659,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "恋は雨上がりのように",
         "series": "恋は雨上がりのように",
+        "workTitle": "恋は雨上がりのように",
         "role": "OP"
       }
     ],
@@ -23754,8 +23754,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "世界の中心で、愛をさけぶ",
         "series": "世界の中心で、愛をさけぶ",
+        "workTitle": "世界の中心で、愛をさけぶ",
         "role": "主題歌"
       }
     ],
@@ -23806,8 +23806,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "50回目のファーストキス",
         "series": "50回目のファーストキス",
+        "workTitle": "50回目のファーストキス",
         "role": "主題歌"
       }
     ],
@@ -24037,8 +24037,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "薬屋のひとりごと",
         "series": "薬屋のひとりごと",
+        "workTitle": "薬屋のひとりごと",
         "role": "ED"
       }
     ],
@@ -24088,8 +24088,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "薬屋のひとりごと",
         "series": "薬屋のひとりごと",
+        "workTitle": "薬屋のひとりごと",
         "role": "OP"
       }
     ],
@@ -24138,8 +24138,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "薬屋のひとりごと",
         "series": "薬屋のひとりごと",
+        "workTitle": "薬屋のひとりごと",
         "role": "OP"
       }
     ],
@@ -24188,8 +24188,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "薬屋のひとりごと",
         "series": "薬屋のひとりごと",
+        "workTitle": "薬屋のひとりごと",
         "role": "ED"
       }
     ],
@@ -24240,8 +24240,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "薬屋のひとりごと",
         "series": "薬屋のひとりごと",
+        "workTitle": "薬屋のひとりごと",
         "role": "ED"
       }
     ],
@@ -24291,8 +24291,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "機動戦士ガンダムIII めぐりあい宇宙編",
         "series": "機動戦士ガンダム",
+        "workTitle": "機動戦士ガンダムIII めぐりあい宇宙編",
         "role": "挿入歌"
       }
     ],
@@ -24341,8 +24341,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "こちら葛飾区亀有公園前派出所",
         "series": "こちら葛飾区亀有公園前派出所",
+        "workTitle": "こちら葛飾区亀有公園前派出所",
         "role": "OP"
       }
     ],
@@ -24393,8 +24393,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "ソマリと森の神様",
         "series": "ソマリと森の神様",
+        "workTitle": "ソマリと森の神様",
         "role": "ED"
       }
     ],
@@ -24489,8 +24489,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "ONE PIECE FILM RED",
         "series": "ONE PIECE",
+        "workTitle": "ONE PIECE FILM RED",
         "role": "劇中歌"
       }
     ],
@@ -24538,8 +24538,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "きかんしゃトーマス",
         "series": "きかんしゃトーマス",
+        "workTitle": "きかんしゃトーマス",
         "role": "テーマ曲"
       }
     ],
@@ -24632,8 +24632,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "Dr.コトー診療所",
         "series": "Dr.コトー診療所",
+        "workTitle": "Dr.コトー診療所",
         "role": "主題歌"
       }
     ],
@@ -24683,8 +24683,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "トップガン",
         "series": "トップガン",
+        "workTitle": "トップガン",
         "role": "主題歌"
       }
     ],
@@ -25003,8 +25003,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "対岸の家事〜これが、私の生きる道！〜",
         "series": "対岸の家事",
+        "workTitle": "対岸の家事〜これが、私の生きる道！〜",
         "role": "主題歌"
       }
     ],
@@ -25369,8 +25369,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "振り返れば奴がいる",
         "series": "振り返れば奴がいる",
+        "workTitle": "振り返れば奴がいる",
         "role": "主題歌"
       }
     ],
@@ -25423,8 +25423,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "うる星やつら",
         "series": "うる星やつら",
+        "workTitle": "うる星やつら",
         "role": "ED"
       }
     ],
@@ -25476,8 +25476,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "ヒロイン失格",
         "series": "ヒロイン失格",
+        "workTitle": "ヒロイン失格",
         "role": "主題歌"
       }
     ],
@@ -25710,8 +25710,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "キミとアイドルプリキュア♪",
         "series": "プリキュア",
+        "workTitle": "キミとアイドルプリキュア♪",
         "role": "ED"
       }
     ],
@@ -25761,8 +25761,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "アナログ",
         "series": "アナログ",
+        "workTitle": "アナログ",
         "role": "インスパイアソング"
       }
     ],
@@ -25814,8 +25814,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "鬼滅の刃",
         "series": "鬼滅の刃",
+        "workTitle": "鬼滅の刃",
         "role": "主題歌"
       }
     ],
@@ -26304,8 +26304,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "ウルトラマン",
         "series": "ウルトラマン",
+        "workTitle": "ウルトラマン",
         "role": "主題歌"
       }
     ],
@@ -26400,8 +26400,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "マクロスF",
         "series": "マクロス",
+        "workTitle": "マクロスF",
         "role": "挿入歌"
       }
     ],
@@ -26501,8 +26501,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "プロポーズ大作戦",
         "series": "プロポーズ大作戦",
+        "workTitle": "プロポーズ大作戦",
         "role": "主題歌"
       }
     ],
@@ -26554,8 +26554,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "HELLO WORLD",
         "series": "HELLO WORLD",
+        "workTitle": "HELLO WORLD",
         "role": "主題歌"
       }
     ],
@@ -26606,8 +26606,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "炎炎ノ消防隊",
         "series": "炎炎ノ消防隊",
+        "workTitle": "炎炎ノ消防隊",
         "role": "OP"
       }
     ],
@@ -26749,8 +26749,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "機動戦士ガンダムUC",
         "series": "機動戦士ガンダム",
+        "workTitle": "機動戦士ガンダムUC",
         "role": "劇伴"
       }
     ],
@@ -26799,8 +26799,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "BLUE DRAGON",
         "series": "BLUE DRAGON",
+        "workTitle": "BLUE DRAGON",
         "role": "劇伴"
       }
     ],
@@ -26852,8 +26852,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "甲鉄城のカバネリ",
         "series": "甲鉄城のカバネリ",
+        "workTitle": "甲鉄城のカバネリ",
         "role": "ED"
       }
     ],
@@ -27086,8 +27086,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "サウンド・オブ・ミュージック",
         "series": "サウンド・オブ・ミュージック",
+        "workTitle": "サウンド・オブ・ミュージック",
         "role": "劇中歌"
       }
     ],
@@ -27372,8 +27372,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "僕のヒーローアカデミア",
         "series": "僕のヒーローアカデミア",
+        "workTitle": "僕のヒーローアカデミア",
         "role": "OP"
       }
     ],
@@ -27424,8 +27424,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "奇跡の人",
         "series": "奇跡の人",
+        "workTitle": "奇跡の人",
         "role": "主題歌"
       }
     ],
@@ -27476,8 +27476,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "大恋愛〜僕を忘れる君と",
         "series": "大恋愛",
+        "workTitle": "大恋愛〜僕を忘れる君と",
         "role": "主題歌"
       }
     ],
@@ -27616,8 +27616,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "素顔のままで",
         "series": "素顔のままで",
+        "workTitle": "素顔のままで",
         "role": "主題歌"
       }
     ],
@@ -27711,8 +27711,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "のだめカンタービレ",
         "series": "のだめカンタービレ",
+        "workTitle": "のだめカンタービレ",
         "role": "ED"
       }
     ],
@@ -27762,8 +27762,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "クレヨンしんちゃん",
         "series": "クレヨンしんちゃん",
+        "workTitle": "クレヨンしんちゃん",
         "role": "ED"
       }
     ],
@@ -27814,8 +27814,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "リッチマン、プアウーマン",
         "series": "リッチマン、プアウーマン",
+        "workTitle": "リッチマン、プアウーマン",
         "role": "主題歌"
       }
     ],
@@ -27864,8 +27864,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "トドメの接吻",
         "series": "トドメの接吻",
+        "workTitle": "トドメの接吻",
         "role": "主題歌"
       }
     ],
@@ -28006,8 +28006,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "花ざかりの君たちへ〜イケメン♂パラダイス〜",
         "series": "花ざかりの君たちへ",
+        "workTitle": "花ざかりの君たちへ〜イケメン♂パラダイス〜",
         "role": "OP"
       }
     ],
@@ -28057,8 +28057,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "SLAM DUNK",
         "series": "SLAM DUNK",
+        "workTitle": "SLAM DUNK",
         "role": "ED"
       }
     ],
@@ -28327,8 +28327,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "セレブと貧乏太郎",
         "series": "セレブと貧乏太郎",
+        "workTitle": "セレブと貧乏太郎",
         "role": "主題歌"
       }
     ],
@@ -28419,8 +28419,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "マッシュル-MASHLE-",
         "series": "マッシュル-MASHLE-",
+        "workTitle": "マッシュル-MASHLE-",
         "role": "OP"
       }
     ],
@@ -28561,8 +28561,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "にじいろカルテ",
         "series": "にじいろカルテ",
+        "workTitle": "にじいろカルテ",
         "role": "主題歌"
       }
     ],
@@ -28615,8 +28615,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "ブラック・ジャック",
         "series": "ブラック・ジャック",
+        "workTitle": "ブラック・ジャック",
         "role": "OP"
       }
     ],
@@ -29012,8 +29012,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "時をかける少女",
         "series": "時をかける少女",
+        "workTitle": "時をかける少女",
         "role": "主題歌"
       }
     ],
@@ -29065,8 +29065,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "劇場版ポケットモンスター ベストウイッシュ 神速のゲノセクト ミュウツー覚醒",
         "series": "ポケットモンスター",
+        "workTitle": "劇場版ポケットモンスター ベストウイッシュ 神速のゲノセクト ミュウツー覚醒",
         "role": "主題歌"
       }
     ],
@@ -29118,8 +29118,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "かがみの孤城",
         "series": "かがみの孤城",
+        "workTitle": "かがみの孤城",
         "role": "主題歌"
       }
     ],
@@ -29213,8 +29213,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "コクリコ坂から",
         "series": "コクリコ坂から",
+        "workTitle": "コクリコ坂から",
         "role": "主題歌"
       }
     ],
@@ -29307,8 +29307,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "マジンガーZ",
         "series": "マジンガーZ",
+        "workTitle": "マジンガーZ",
         "role": "OP"
       }
     ],
@@ -29357,8 +29357,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "鉄腕アトム",
         "series": "鉄腕アトム",
+        "workTitle": "鉄腕アトム",
         "role": "OP"
       }
     ],
@@ -29409,8 +29409,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "ドラゴンボール",
         "series": "ドラゴンボール",
+        "workTitle": "ドラゴンボール",
         "role": "OP"
       }
     ],
@@ -29631,8 +29631,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "ドラゴンボール",
         "series": "ドラゴンボール",
+        "workTitle": "ドラゴンボール",
         "role": "ED"
       }
     ],
@@ -29683,8 +29683,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "たまごっち!",
         "series": "たまごっち!",
+        "workTitle": "たまごっち!",
         "role": "OP"
       }
     ],
@@ -29829,8 +29829,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "ONE PIECE",
         "series": "ONE PIECE",
+        "workTitle": "ONE PIECE",
         "role": "劇中歌"
       }
     ],
@@ -30010,8 +30010,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "進撃の巨人",
         "series": "進撃の巨人",
+        "workTitle": "進撃の巨人",
         "role": "ED"
       }
     ],
@@ -30108,8 +30108,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "新世紀エヴァンゲリオン劇場版 Air/まごころを、君に",
         "series": "新世紀エヴァンゲリオン",
+        "workTitle": "新世紀エヴァンゲリオン劇場版 Air/まごころを、君に",
         "role": "挿入歌"
       }
     ],
@@ -30161,8 +30161,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "劇場版 魔法少女まどか☆マギカ［新編］叛逆の物語",
         "series": "魔法少女まどか☆マギカ",
+        "workTitle": "劇場版 魔法少女まどか☆マギカ［新編］叛逆の物語",
         "role": "主題歌"
       }
     ],
@@ -30298,8 +30298,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "泣きたい私は猫をかぶる",
         "series": "泣きたい私は猫をかぶる",
+        "workTitle": "泣きたい私は猫をかぶる",
         "role": "挿入歌"
       }
     ],
@@ -30350,8 +30350,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "今夜、世界からこの恋が消えても",
         "series": "今夜、世界からこの恋が消えても",
+        "workTitle": "今夜、世界からこの恋が消えても",
         "role": "主題歌"
       }
     ],
@@ -30401,8 +30401,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "KINGDOM HEARTS",
         "series": "KINGDOM HEARTS",
+        "workTitle": "KINGDOM HEARTS",
         "role": "主題歌"
       }
     ],
@@ -30454,8 +30454,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "シン・エヴァンゲリオン劇場版",
         "series": "新世紀エヴァンゲリオン",
+        "workTitle": "シン・エヴァンゲリオン劇場版",
         "role": "主題歌"
       }
     ],
@@ -30508,8 +30508,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "シティーハンター2",
         "series": "シティーハンター",
+        "workTitle": "シティーハンター2",
         "role": "ED"
       }
     ],
@@ -30690,8 +30690,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "妖怪ウォッチ",
         "series": "妖怪ウォッチ",
+        "workTitle": "妖怪ウォッチ",
         "role": "ED"
       }
     ],
@@ -30742,8 +30742,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "ピクミン",
         "series": "ピクミン",
+        "workTitle": "ピクミン",
         "role": "CMソング"
       }
     ],
@@ -31061,8 +31061,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "演歌の女王",
         "series": "演歌の女王",
+        "workTitle": "演歌の女王",
         "role": "主題歌"
       }
     ],
@@ -31251,8 +31251,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "めぞん一刻",
         "series": "めぞん一刻",
+        "workTitle": "めぞん一刻",
         "role": "OP"
       }
     ],
@@ -31304,8 +31304,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "ナイトメアー・ビフォア・クリスマス",
         "series": "ナイトメアー・ビフォア・クリスマス",
+        "workTitle": "ナイトメアー・ビフォア・クリスマス",
         "role": "劇中歌"
       }
     ],
@@ -31443,8 +31443,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "小さな巨人",
         "series": "小さな巨人",
+        "workTitle": "小さな巨人",
         "role": "主題歌"
       }
     ],
@@ -31810,8 +31810,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "夏雪ランデブー",
         "series": "夏雪ランデブー",
+        "workTitle": "夏雪ランデブー",
         "role": "ED"
       }
     ],
@@ -31946,8 +31946,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "コクリコ坂から",
         "series": "コクリコ坂から",
+        "workTitle": "コクリコ坂から",
         "role": "挿入歌"
       }
     ],
@@ -32046,8 +32046,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "野生の島のロズ",
         "series": "野生の島のロズ",
+        "workTitle": "野生の島のロズ",
         "role": "日本版スペシャルソング"
       }
     ],
@@ -32239,8 +32239,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "初めて恋をした日に読む話",
         "series": "初めて恋をした日に読む話",
+        "workTitle": "初めて恋をした日に読む話",
         "role": "主題歌"
       }
     ],
@@ -32291,8 +32291,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "砂時計",
         "series": "砂時計",
+        "workTitle": "砂時計",
         "role": "主題歌"
       }
     ],
@@ -32383,8 +32383,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "チェンソーマン",
         "series": "チェンソーマン",
+        "workTitle": "チェンソーマン",
         "role": "OP"
       }
     ],
@@ -32476,8 +32476,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "ラストマイル",
         "series": "ラストマイル",
+        "workTitle": "ラストマイル",
         "role": "主題歌"
       }
     ],
@@ -32530,8 +32530,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "僕のいた時間",
         "series": "僕のいた時間",
+        "workTitle": "僕のいた時間",
         "role": "主題歌"
       }
     ],
@@ -32673,8 +32673,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "サウンド・オブ・ミュージック",
         "series": "サウンド・オブ・ミュージック",
+        "workTitle": "サウンド・オブ・ミュージック",
         "role": "劇中歌"
       }
     ],
@@ -32725,8 +32725,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "カードキャプターさくら",
         "series": "カードキャプターさくら",
+        "workTitle": "カードキャプターさくら",
         "role": "OP"
       }
     ],
@@ -32998,8 +32998,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "orange",
         "series": "orange",
+        "workTitle": "orange",
         "role": "主題歌"
       }
     ],
@@ -33098,8 +33098,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "劇場版 魔法少女まどか☆マギカ［前編］始まりの物語",
         "series": "魔法少女まどか☆マギカ",
+        "workTitle": "劇場版 魔法少女まどか☆マギカ［前編］始まりの物語",
         "role": "挿入歌"
       }
     ],
@@ -33428,8 +33428,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "X",
         "series": "X",
+        "workTitle": "X",
         "role": "主題歌"
       }
     ],
@@ -33837,8 +33837,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "名探偵コナン",
         "series": "名探偵コナン",
+        "workTitle": "名探偵コナン",
         "role": "OP"
       }
     ],
@@ -34197,8 +34197,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "セカンド・チャンス",
         "series": "セカンド・チャンス",
+        "workTitle": "セカンド・チャンス",
         "role": "主題歌"
       }
     ],
@@ -34295,8 +34295,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "君の名は。",
         "series": "君の名は。",
+        "workTitle": "君の名は。",
         "role": "主題歌"
       }
     ],
@@ -34612,8 +34612,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "若草の頃",
         "series": "若草の頃",
+        "workTitle": "若草の頃",
         "role": "劇中歌"
       }
     ],
@@ -34888,8 +34888,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "ひゃくえむ。",
         "series": "ひゃくえむ。",
+        "workTitle": "ひゃくえむ。",
         "role": "主題歌"
       }
     ],
@@ -34985,8 +34985,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "ONE PIECE",
         "series": "ONE PIECE",
+        "workTitle": "ONE PIECE",
         "role": "OP"
       }
     ],
@@ -35127,8 +35127,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "ティファニーで朝食を",
         "series": "ティファニーで朝食を",
+        "workTitle": "ティファニーで朝食を",
         "role": "主題歌"
       }
     ],
@@ -35264,8 +35264,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "美少女戦士セーラームーン",
         "series": "美少女戦士セーラームーン",
+        "workTitle": "美少女戦士セーラームーン",
         "role": "OP"
       }
     ],
@@ -35365,8 +35365,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "劇場版ポケットモンスター ミュウツーの逆襲",
         "series": "ポケットモンスター",
+        "workTitle": "劇場版ポケットモンスター ミュウツーの逆襲",
         "role": "主題歌"
       }
     ],
@@ -35419,8 +35419,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "ラブライブ！シリーズ",
         "series": "ラブライブ！",
+        "workTitle": "ラブライブ！シリーズ",
         "role": "キャラクターソング"
       }
     ],
@@ -35472,8 +35472,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "劇場版 チェンソーマン レゼ篇",
         "series": "チェンソーマン",
+        "workTitle": "劇場版 チェンソーマン レゼ篇",
         "role": "ED"
       }
     ],
@@ -35964,8 +35964,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "あいのり",
         "series": "あいのり",
+        "workTitle": "あいのり",
         "role": "主題歌"
       }
     ],
@@ -36060,8 +36060,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "ひとつ屋根の下2",
         "series": "ひとつ屋根の下",
+        "workTitle": "ひとつ屋根の下2",
         "role": "挿入歌"
       }
     ],
@@ -36114,8 +36114,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "スワロウテイル",
         "series": "スワロウテイル",
+        "workTitle": "スワロウテイル",
         "role": "主題歌"
       }
     ],
@@ -36251,8 +36251,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "乱歩奇譚 Game of Laplace",
         "series": "乱歩奇譚",
+        "workTitle": "乱歩奇譚 Game of Laplace",
         "role": "ED"
       }
     ],
@@ -36304,8 +36304,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "ヲタクに恋は難しい",
         "series": "ヲタクに恋は難しい",
+        "workTitle": "ヲタクに恋は難しい",
         "role": "OP"
       }
     ],
@@ -36356,8 +36356,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "白衣の戦士！",
         "series": "白衣の戦士！",
+        "workTitle": "白衣の戦士！",
         "role": "主題歌"
       }
     ],
@@ -36493,8 +36493,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "ラ・ラ・ランド",
         "series": "ラ・ラ・ランド",
+        "workTitle": "ラ・ラ・ランド",
         "role": "劇中歌"
       }
     ],
@@ -36548,8 +36548,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "徳山大五郎を誰が殺したか？",
         "series": "徳山大五郎を誰が殺したか？",
+        "workTitle": "徳山大五郎を誰が殺したか？",
         "role": "主題歌"
       }
     ],
@@ -36690,8 +36690,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "味いちもんめ",
         "series": "味いちもんめ",
+        "workTitle": "味いちもんめ",
         "role": "主題歌"
       }
     ],
@@ -36784,8 +36784,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "キテレツ大百科",
         "series": "キテレツ大百科",
+        "workTitle": "キテレツ大百科",
         "role": "ED"
       }
     ],
@@ -36836,8 +36836,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "ピュア・ラブIII",
         "series": "ピュア・ラブ",
+        "workTitle": "ピュア・ラブIII",
         "role": "主題歌"
       }
     ],
@@ -36889,8 +36889,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "西遊記",
         "series": "西遊記",
+        "workTitle": "西遊記",
         "role": "主題歌"
       }
     ],
@@ -37033,8 +37033,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "天気の子",
         "series": "天気の子",
+        "workTitle": "天気の子",
         "role": "劇中歌"
       }
     ],
@@ -37129,8 +37129,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "王様ランキング",
         "series": "王様ランキング",
+        "workTitle": "王様ランキング",
         "role": "OP"
       }
     ],
@@ -37181,8 +37181,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "私の家政夫ナギサさん",
         "series": "私の家政夫ナギサさん",
+        "workTitle": "私の家政夫ナギサさん",
         "role": "主題歌"
       }
     ],
@@ -37278,8 +37278,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "おじゃる丸",
         "series": "おじゃる丸",
+        "workTitle": "おじゃる丸",
         "role": "OP"
       }
     ],
@@ -37690,8 +37690,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "タッチ",
         "series": "タッチ",
+        "workTitle": "タッチ",
         "role": "OP"
       }
     ],
@@ -37744,8 +37744,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "花より男子2（リターンズ）",
         "series": "花より男子",
+        "workTitle": "花より男子2（リターンズ）",
         "role": "主題歌"
       }
     ],
@@ -38196,8 +38196,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "ドラゴンクエスト",
         "series": "ドラゴンクエスト",
+        "workTitle": "ドラゴンクエスト",
         "role": "ED"
       }
     ],
@@ -38466,8 +38466,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "山田太郎ものがたり",
         "series": "山田太郎ものがたり",
+        "workTitle": "山田太郎ものがたり",
         "role": "主題歌"
       }
     ],
@@ -38516,8 +38516,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "銀魂",
         "series": "銀魂",
+        "workTitle": "銀魂",
         "role": "OP"
       }
     ],
@@ -38708,8 +38708,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "都会の森",
         "series": "都会の森",
+        "workTitle": "都会の森",
         "role": "主題歌"
       }
     ],
@@ -39026,8 +39026,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "血界戦線 & BEYOND",
         "series": "血界戦線",
+        "workTitle": "血界戦線 & BEYOND",
         "role": "OP"
       }
     ],
@@ -39127,8 +39127,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "First Love",
         "series": "First Love",
+        "workTitle": "First Love",
         "role": "主題歌"
       }
     ],
@@ -39230,8 +39230,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "花束みたいな恋をした",
         "series": "花束みたいな恋をした",
+        "workTitle": "花束みたいな恋をした",
         "role": "インスパイアソング"
       }
     ],
@@ -39325,8 +39325,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "はじまりの歌",
         "series": "はじまりの歌",
+        "workTitle": "はじまりの歌",
         "role": "主題歌"
       }
     ],
@@ -39467,8 +39467,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "子供が寝たあとで",
         "series": "子供が寝たあとで",
+        "workTitle": "子供が寝たあとで",
         "role": "主題歌"
       }
     ],
@@ -39607,8 +39607,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "ヴァイオレット・エヴァーガーデン",
         "series": "ヴァイオレット・エヴァーガーデン",
+        "workTitle": "ヴァイオレット・エヴァーガーデン",
         "role": "OP"
       }
     ],
@@ -39659,8 +39659,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "8年越しの花嫁 奇跡の実話",
         "series": "8年越しの花嫁",
+        "workTitle": "8年越しの花嫁 奇跡の実話",
         "role": "主題歌"
       }
     ],
@@ -39757,8 +39757,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "ドク",
         "series": "ドク",
+        "workTitle": "ドク",
         "role": "主題歌"
       }
     ],
@@ -39854,8 +39854,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "仮面ライダー THE NEXT",
         "series": "仮面ライダー",
+        "workTitle": "仮面ライダー THE NEXT",
         "role": "主題歌"
       }
     ],
@@ -39949,8 +39949,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "ちびまる子ちゃん",
         "series": "ちびまる子ちゃん",
+        "workTitle": "ちびまる子ちゃん",
         "role": "ED"
       }
     ],
@@ -40046,8 +40046,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "半分、青い。",
         "series": "半分、青い。",
+        "workTitle": "半分、青い。",
         "role": "主題歌"
       }
     ],
@@ -40101,8 +40101,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "ONE PIECE FILM RED",
         "series": "ONE PIECE",
+        "workTitle": "ONE PIECE FILM RED",
         "role": "劇中歌"
       }
     ],
@@ -40194,8 +40194,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "全開ガール",
         "series": "全開ガール",
+        "workTitle": "全開ガール",
         "role": "主題歌"
       }
     ],
@@ -40248,8 +40248,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "FINAL FANTASY X",
         "series": "FINAL FANTASY",
+        "workTitle": "FINAL FANTASY X",
         "role": "挿入歌"
       }
     ],
@@ -40299,8 +40299,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "映画クレヨンしんちゃん 新婚旅行ハリケーン ～失われたひろし～",
         "series": "クレヨンしんちゃん",
+        "workTitle": "映画クレヨンしんちゃん 新婚旅行ハリケーン ～失われたひろし～",
         "role": "主題歌"
       }
     ],
@@ -40397,8 +40397,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "王様ランキング",
         "series": "王様ランキング",
+        "workTitle": "王様ランキング",
         "role": "ED"
       }
     ],
@@ -40496,8 +40496,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "そのうち結婚する君へ",
         "series": "そのうち結婚する君へ",
+        "workTitle": "そのうち結婚する君へ",
         "role": "主題歌"
       }
     ],
@@ -40639,8 +40639,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "さよならの朝に約束の花をかざろう",
         "series": "さよならの朝に約束の花をかざろう",
+        "workTitle": "さよならの朝に約束の花をかざろう",
         "role": "主題歌"
       }
     ],
@@ -40870,8 +40870,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "オレンジデイズ",
         "series": "オレンジデイズ",
+        "workTitle": "オレンジデイズ",
         "role": "主題歌"
       }
     ],
@@ -40966,8 +40966,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "プリンセッション・オーケストラ",
         "series": "プリンセッション・オーケストラ",
+        "workTitle": "プリンセッション・オーケストラ",
         "role": "挿入歌"
       }
     ],
@@ -41063,8 +41063,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "勇者王ガオガイガー",
         "series": "勇者王ガオガイガー",
+        "workTitle": "勇者王ガオガイガー",
         "role": "OP"
       }
     ],
@@ -41116,8 +41116,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "ヱヴァンゲリヲン新劇場版:序",
         "series": "新世紀エヴァンゲリオン",
+        "workTitle": "ヱヴァンゲリヲン新劇場版:序",
         "role": "主題歌"
       }
     ],
@@ -41167,8 +41167,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "NINKU -忍空-",
         "series": "NINKU -忍空-",
+        "workTitle": "NINKU -忍空-",
         "role": "OP"
       }
     ],
@@ -41222,8 +41222,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "マクロスΔ",
         "series": "マクロス",
+        "workTitle": "マクロスΔ",
         "role": "挿入歌"
       }
     ],
@@ -41367,8 +41367,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "ヱヴァンゲリヲン新劇場版:Q",
         "series": "新世紀エヴァンゲリオン",
+        "workTitle": "ヱヴァンゲリヲン新劇場版:Q",
         "role": "主題歌"
       }
     ],
@@ -41419,8 +41419,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "キングダム",
         "series": "キングダム",
+        "workTitle": "キングダム",
         "role": "OP"
       }
     ],
@@ -41833,8 +41833,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "平家物語",
         "series": "平家物語",
+        "workTitle": "平家物語",
         "role": "OP"
       }
     ],
@@ -41887,8 +41887,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "PSYCHO-PASS サイコパス",
         "series": "PSYCHO-PASS",
+        "workTitle": "PSYCHO-PASS サイコパス",
         "role": "ED"
       }
     ],
@@ -41983,8 +41983,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "BEASTARS",
         "series": "BEASTARS",
+        "workTitle": "BEASTARS",
         "role": "OP"
       }
     ],
@@ -42036,8 +42036,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "とある科学の超電磁砲",
         "series": "とあるシリーズ",
+        "workTitle": "とある科学の超電磁砲",
         "role": "OP"
       }
     ],
@@ -42089,8 +42089,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "バジリスク 〜甲賀忍法帖〜",
         "series": "バジリスク",
+        "workTitle": "バジリスク 〜甲賀忍法帖〜",
         "role": "OP"
       }
     ],
@@ -42142,8 +42142,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "宇宙のステルヴィア",
         "series": "宇宙のステルヴィア",
+        "workTitle": "宇宙のステルヴィア",
         "role": "OP"
       }
     ],
@@ -42285,8 +42285,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "マクロスΔ",
         "series": "マクロス",
+        "workTitle": "マクロスΔ",
         "role": "挿入歌"
       }
     ],
@@ -42383,8 +42383,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "タイヨウのうた",
         "series": "タイヨウのうた",
+        "workTitle": "タイヨウのうた",
         "role": "主題歌"
       }
     ],
@@ -42436,8 +42436,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "後妻業",
         "series": "後妻業",
+        "workTitle": "後妻業",
         "role": "主題歌"
       }
     ],
@@ -42981,8 +42981,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "監察医 朝顔",
         "series": "監察医 朝顔",
+        "workTitle": "監察医 朝顔",
         "role": "主題歌"
       }
     ],
@@ -43033,8 +43033,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "海月姫",
         "series": "海月姫",
+        "workTitle": "海月姫",
         "role": "主題歌"
       }
     ],
@@ -43130,8 +43130,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "ホリック xxxHOLiC",
         "series": "xxxHOLiC",
+        "workTitle": "ホリック xxxHOLiC",
         "role": "主題歌"
       }
     ],
@@ -43316,8 +43316,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "若者のすべて",
         "series": "若者のすべて",
+        "workTitle": "若者のすべて",
         "role": "主題歌"
       }
     ],
@@ -43412,8 +43412,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "高校教師",
         "series": "高校教師",
+        "workTitle": "高校教師",
         "role": "主題歌"
       }
     ],
@@ -43506,8 +43506,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "機動戦士ガンダムUC",
         "series": "機動戦士ガンダム",
+        "workTitle": "機動戦士ガンダムUC",
         "role": "主題歌"
       }
     ],
@@ -43558,8 +43558,8 @@
     },
     "tieUps": [
       {
-        "workTitle": "ゾイド -ZOIDS-",
         "series": "ゾイド",
+        "workTitle": "ゾイド -ZOIDS-",
         "role": "OP"
       }
     ],
@@ -44615,5 +44615,1737 @@
     },
     "status": "auto_matched",
     "generatedAt": "2026-07-04T08:37:08+09:00"
+  },
+  {
+    "title": "輝く未来",
+    "artist": "アラン・メンケン",
+    "metadata": {
+      "releaseDate": null,
+      "releaseDecade": null,
+      "durationSeconds": null,
+      "collectionName": null
+    },
+    "classification": {
+      "genres": [],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": null
+    },
+    "status": "not_found",
+    "generatedAt": "2026-07-07T19:17:58+09:00"
+  },
+  {
+    "title": "Part of your world",
+    "artist": "アラン・メンケン",
+    "metadata": {
+      "releaseDate": null,
+      "releaseDecade": null,
+      "durationSeconds": null,
+      "collectionName": null
+    },
+    "classification": {
+      "genres": [],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": null
+    },
+    "status": "not_found",
+    "generatedAt": "2026-07-07T19:18:00+09:00"
+  },
+  {
+    "title": "雪だるまつくろう",
+    "artist": "クリステン・アンダーソン＝ロペス/ロバート・ロペス",
+    "metadata": {
+      "releaseDate": null,
+      "releaseDecade": null,
+      "durationSeconds": null,
+      "collectionName": null
+    },
+    "classification": {
+      "genres": [],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": null
+    },
+    "status": "not_found",
+    "generatedAt": "2026-07-07T19:18:02+09:00"
+  },
+  {
+    "title": "A whole new world",
+    "artist": "アラン・メンケン",
+    "metadata": {
+      "releaseDate": null,
+      "releaseDecade": null,
+      "durationSeconds": null,
+      "collectionName": null
+    },
+    "classification": {
+      "genres": [],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": null
+    },
+    "status": "not_found",
+    "generatedAt": "2026-07-07T19:18:04+09:00"
+  },
+  {
+    "title": "Let it go",
+    "artist": "イディナ・メンゼル",
+    "metadata": {
+      "releaseDate": "2013-10-21",
+      "releaseDecade": "2010年代",
+      "durationSeconds": 225,
+      "collectionName": "Frozen (Original Motion Picture Soundtrack)"
+    },
+    "classification": {
+      "genres": [
+        "ミュージカル"
+      ],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": 1440618281
+    },
+    "status": "needs_review",
+    "generatedAt": "2026-07-07T19:18:05+09:00"
+  },
+  {
+    "title": "小さな世界",
+    "artist": "シャーマン兄弟",
+    "metadata": {
+      "releaseDate": null,
+      "releaseDecade": null,
+      "durationSeconds": null,
+      "collectionName": null
+    },
+    "classification": {
+      "genres": [],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": null
+    },
+    "status": "not_found",
+    "generatedAt": "2026-07-07T19:18:07+09:00"
+  },
+  {
+    "title": "美女と野獣",
+    "artist": "アラン・メンケン",
+    "metadata": {
+      "releaseDate": null,
+      "releaseDecade": null,
+      "durationSeconds": null,
+      "collectionName": null
+    },
+    "classification": {
+      "genres": [],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": null
+    },
+    "status": "not_found",
+    "generatedAt": "2026-07-07T19:18:09+09:00"
+  },
+  {
+    "title": "僕の願い",
+    "artist": "アラン・メンケン",
+    "metadata": {
+      "releaseDate": null,
+      "releaseDecade": null,
+      "durationSeconds": null,
+      "collectionName": null
+    },
+    "classification": {
+      "genres": [],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": null
+    },
+    "status": "not_found",
+    "generatedAt": "2026-07-07T19:18:11+09:00"
+  },
+  {
+    "title": "Colors of the Wind",
+    "artist": "アラン・メンケン",
+    "metadata": {
+      "releaseDate": null,
+      "releaseDecade": null,
+      "durationSeconds": null,
+      "collectionName": null
+    },
+    "classification": {
+      "genres": [],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": null
+    },
+    "status": "not_found",
+    "generatedAt": "2026-07-07T19:18:13+09:00"
+  },
+  {
+    "title": "いつか王子様が",
+    "artist": "フランク・チャーチル",
+    "metadata": {
+      "releaseDate": null,
+      "releaseDecade": null,
+      "durationSeconds": null,
+      "collectionName": null
+    },
+    "classification": {
+      "genres": [],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": null
+    },
+    "status": "not_found",
+    "generatedAt": "2026-07-07T19:18:15+09:00"
+  },
+  {
+    "title": "彼こそが海賊",
+    "artist": "クラウス・バデルト、ハンス・ジマー",
+    "metadata": {
+      "releaseDate": null,
+      "releaseDecade": null,
+      "durationSeconds": null,
+      "collectionName": null
+    },
+    "classification": {
+      "genres": [],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": null
+    },
+    "status": "not_found",
+    "generatedAt": "2026-07-07T19:18:17+09:00"
+  },
+  {
+    "title": "コンパス・オブ・ユア・ハート",
+    "artist": "アラン・メンケン",
+    "metadata": {
+      "releaseDate": null,
+      "releaseDecade": null,
+      "durationSeconds": null,
+      "collectionName": null
+    },
+    "classification": {
+      "genres": [],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": null
+    },
+    "status": "not_found",
+    "generatedAt": "2026-07-07T19:18:19+09:00"
+  },
+  {
+    "title": "バロック・ホウダウン(エレクトリカル・パレード)",
+    "artist": "ペリー&キングスレイ",
+    "metadata": {
+      "releaseDate": null,
+      "releaseDecade": null,
+      "durationSeconds": null,
+      "collectionName": null
+    },
+    "classification": {
+      "genres": [],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": null
+    },
+    "status": "not_found",
+    "generatedAt": "2026-07-07T19:18:21+09:00"
+  },
+  {
+    "title": "ミッキーマウス・クラブ・マーチ",
+    "artist": "ジミー・ドッド",
+    "metadata": {
+      "releaseDate": null,
+      "releaseDecade": null,
+      "durationSeconds": null,
+      "collectionName": null
+    },
+    "classification": {
+      "genres": [],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": null
+    },
+    "status": "not_found",
+    "generatedAt": "2026-07-07T19:18:23+09:00"
+  },
+  {
+    "title": "ジャンボリミッキー!",
+    "artist": "マルコ・マリナンジェリ",
+    "metadata": {
+      "releaseDate": null,
+      "releaseDecade": null,
+      "durationSeconds": null,
+      "collectionName": null
+    },
+    "classification": {
+      "genres": [],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": null
+    },
+    "status": "not_found",
+    "generatedAt": "2026-07-07T19:18:25+09:00"
+  },
+  {
+    "title": "愛の芽生え",
+    "artist": "アラン・メンケン",
+    "metadata": {
+      "releaseDate": null,
+      "releaseDecade": null,
+      "durationSeconds": null,
+      "collectionName": null
+    },
+    "classification": {
+      "genres": [],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": null
+    },
+    "status": "not_found",
+    "generatedAt": "2026-07-07T19:18:27+09:00"
+  },
+  {
+    "title": "ひとりぼっちの晩餐会",
+    "artist": "アラン・メンケン",
+    "metadata": {
+      "releaseDate": null,
+      "releaseDecade": null,
+      "durationSeconds": null,
+      "collectionName": null
+    },
+    "classification": {
+      "genres": [],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": null
+    },
+    "status": "not_found",
+    "generatedAt": "2026-07-07T19:18:29+09:00"
+  },
+  {
+    "title": "Remember Me",
+    "artist": "クリステン・アンダーソン＝ロペス、ロバート・ロペス",
+    "metadata": {
+      "releaseDate": null,
+      "releaseDecade": null,
+      "durationSeconds": null,
+      "collectionName": null
+    },
+    "classification": {
+      "genres": [],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": null
+    },
+    "status": "not_found",
+    "generatedAt": "2026-07-07T19:18:31+09:00"
+  },
+  {
+    "title": "星に願いを",
+    "artist": "リー・ハーライン",
+    "metadata": {
+      "releaseDate": null,
+      "releaseDecade": null,
+      "durationSeconds": null,
+      "collectionName": null
+    },
+    "classification": {
+      "genres": [],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": null
+    },
+    "status": "not_found",
+    "generatedAt": "2026-07-07T19:18:33+09:00"
+  },
+  {
+    "title": "ジッパ・ディー・ドゥー・ダー",
+    "artist": "アリー・リューベル",
+    "metadata": {
+      "releaseDate": null,
+      "releaseDecade": null,
+      "durationSeconds": null,
+      "collectionName": null
+    },
+    "classification": {
+      "genres": [],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": null
+    },
+    "status": "not_found",
+    "generatedAt": "2026-07-07T19:18:35+09:00"
+  },
+  {
+    "title": "自由への扉",
+    "artist": "小此木麻里",
+    "metadata": {
+      "releaseDate": null,
+      "releaseDecade": null,
+      "durationSeconds": null,
+      "collectionName": null
+    },
+    "classification": {
+      "genres": [],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": null
+    },
+    "status": "not_found",
+    "generatedAt": "2026-07-07T19:18:37+09:00"
+  },
+  {
+    "title": "君はともだち",
+    "artist": "ランディ・ニューマン",
+    "metadata": {
+      "releaseDate": "1995-11-19",
+      "releaseDecade": "1990年代",
+      "durationSeconds": 124,
+      "collectionName": "トイ・ストーリー (オリジナル・サウンドトラック)"
+    },
+    "classification": {
+      "genres": [
+        "サウンドトラック"
+      ],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": 1456073416
+    },
+    "status": "auto_matched",
+    "generatedAt": "2026-07-07T19:18:38+09:00"
+  },
+  {
+    "title": "Circle of Life",
+    "artist": "エルトン・ジョン",
+    "metadata": {
+      "releaseDate": "1994-05-31",
+      "releaseDecade": "1990年代",
+      "durationSeconds": 292,
+      "collectionName": "The Lion King (Original Motion Picture Soundtrack)"
+    },
+    "classification": {
+      "genres": [
+        "ミュージカル"
+      ],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": 1445732940
+    },
+    "status": "needs_review",
+    "generatedAt": "2026-07-07T19:18:39+09:00"
+  },
+  {
+    "title": "愛を感じて",
+    "artist": "エルトン・ジョン",
+    "metadata": {
+      "releaseDate": "1994-05-12",
+      "releaseDecade": "1990年代",
+      "durationSeconds": 242,
+      "collectionName": "ライオン・キング (オリジナル・サウンドトラック – 30周年記念盤)"
+    },
+    "classification": {
+      "genres": [
+        "サウンドトラック"
+      ],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": 1770152904
+    },
+    "status": "auto_matched",
+    "generatedAt": "2026-07-07T19:18:40+09:00"
+  },
+  {
+    "title": "アロハ・エ・コモ・マイ",
+    "artist": "Jump5",
+    "metadata": {
+      "releaseDate": null,
+      "releaseDecade": null,
+      "durationSeconds": null,
+      "collectionName": null
+    },
+    "classification": {
+      "genres": [],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": null
+    },
+    "status": "not_found",
+    "generatedAt": "2026-07-07T19:18:42+09:00"
+  },
+  {
+    "title": "Define Dancing（宇宙空間でダンスを）",
+    "artist": "トーマス・ニューマン",
+    "metadata": {
+      "releaseDate": null,
+      "releaseDecade": null,
+      "durationSeconds": null,
+      "collectionName": null
+    },
+    "classification": {
+      "genres": [],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": null
+    },
+    "status": "not_found",
+    "generatedAt": "2026-07-07T19:19:00+09:00"
+  },
+  {
+    "title": "フレンド・ライク・ミー",
+    "artist": "アラン・メンケン",
+    "metadata": {
+      "releaseDate": null,
+      "releaseDecade": null,
+      "durationSeconds": null,
+      "collectionName": null
+    },
+    "classification": {
+      "genres": [],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": null
+    },
+    "status": "not_found",
+    "generatedAt": "2026-07-07T19:19:02+09:00"
+  },
+  {
+    "title": "世界の約束",
+    "artist": "久石譲",
+    "metadata": {
+      "releaseDate": null,
+      "releaseDecade": null,
+      "durationSeconds": null,
+      "collectionName": null
+    },
+    "classification": {
+      "genres": [],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": null
+    },
+    "status": "not_found",
+    "generatedAt": "2026-07-07T19:19:04+09:00"
+  },
+  {
+    "title": "人生のメリーゴーランド",
+    "artist": "久石譲",
+    "metadata": {
+      "releaseDate": null,
+      "releaseDecade": null,
+      "durationSeconds": null,
+      "collectionName": null
+    },
+    "classification": {
+      "genres": [],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": null
+    },
+    "status": "not_found",
+    "generatedAt": "2026-07-07T19:19:06+09:00"
+  },
+  {
+    "title": "風のとおり道",
+    "artist": "久石譲",
+    "metadata": {
+      "releaseDate": null,
+      "releaseDecade": null,
+      "durationSeconds": null,
+      "collectionName": null
+    },
+    "classification": {
+      "genres": [],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": null
+    },
+    "status": "not_found",
+    "generatedAt": "2026-07-07T19:19:08+09:00"
+  },
+  {
+    "title": "海の見える街",
+    "artist": "久石譲",
+    "metadata": {
+      "releaseDate": "1989-08-10",
+      "releaseDecade": "1980年代",
+      "durationSeconds": 180,
+      "collectionName": "魔女の宅急便 サントラ音楽集"
+    },
+    "classification": {
+      "genres": [
+        "サウンドトラック"
+      ],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": 667779092
+    },
+    "status": "auto_matched",
+    "generatedAt": "2026-07-07T19:19:09+09:00"
+  },
+  {
+    "title": "さんぽ",
+    "artist": "久石譲",
+    "metadata": {
+      "releaseDate": "2008-12-24",
+      "releaseDecade": "2000年代",
+      "durationSeconds": 168,
+      "collectionName": "ノンちゃん雲に乗る"
+    },
+    "classification": {
+      "genres": [
+        "J-Pop"
+      ],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": 299841835
+    },
+    "status": "needs_review",
+    "generatedAt": "2026-07-07T19:19:10+09:00"
+  },
+  {
+    "title": "いつも何度でも",
+    "artist": "木村弓",
+    "metadata": {
+      "releaseDate": "2000-01-01",
+      "releaseDecade": "2000年代",
+      "durationSeconds": 215,
+      "collectionName": "千と千尋の神隠し サウンドトラック"
+    },
+    "classification": {
+      "genres": [
+        "サウンドトラック"
+      ],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": 668520684
+    },
+    "status": "needs_review",
+    "generatedAt": "2026-07-07T19:19:12+09:00"
+  },
+  {
+    "title": "となりのトトロ",
+    "artist": "久石譲",
+    "metadata": {
+      "releaseDate": null,
+      "releaseDecade": null,
+      "durationSeconds": null,
+      "collectionName": null
+    },
+    "classification": {
+      "genres": [],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": null
+    },
+    "status": "not_found",
+    "generatedAt": "2026-07-07T19:19:13+09:00"
+  },
+  {
+    "title": "崖の上のポニョ",
+    "artist": "久石譲",
+    "metadata": {
+      "releaseDate": "2007-12-05",
+      "releaseDecade": "2000年代",
+      "durationSeconds": 165,
+      "collectionName": "ノンちゃん雲に乗る"
+    },
+    "classification": {
+      "genres": [
+        "J-Pop"
+      ],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": 299841905
+    },
+    "status": "needs_review",
+    "generatedAt": "2026-07-07T19:19:14+09:00"
+  },
+  {
+    "title": "あの夏へ",
+    "artist": "久石譲",
+    "metadata": {
+      "releaseDate": "2001-07-18",
+      "releaseDecade": "2000年代",
+      "durationSeconds": 190,
+      "collectionName": "千と千尋の神隠し サウンドトラック"
+    },
+    "classification": {
+      "genres": [
+        "サウンドトラック"
+      ],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": 668520663
+    },
+    "status": "needs_review",
+    "generatedAt": "2026-07-07T19:19:15+09:00"
+  },
+  {
+    "title": "風になる",
+    "artist": "つじあやの",
+    "metadata": {
+      "releaseDate": "2002-06-26",
+      "releaseDecade": "2000年代",
+      "durationSeconds": 277,
+      "collectionName": "恋恋風歌"
+    },
+    "classification": {
+      "genres": [
+        "J-Pop"
+      ],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": 160599783
+    },
+    "status": "auto_matched",
+    "generatedAt": "2026-07-07T19:19:16+09:00"
+  },
+  {
+    "title": "カントリー・ロード",
+    "artist": "本名陽子",
+    "metadata": {
+      "releaseDate": "1995-07-10",
+      "releaseDecade": "1990年代",
+      "durationSeconds": 264,
+      "collectionName": "耳をすませば サウンドトラック"
+    },
+    "classification": {
+      "genres": [
+        "サウンドトラック"
+      ],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": 667855313
+    },
+    "status": "auto_matched",
+    "generatedAt": "2026-07-07T19:19:17+09:00"
+  },
+  {
+    "title": "テルーの唄",
+    "artist": "手嶌葵",
+    "metadata": {
+      "releaseDate": "2006-06-07",
+      "releaseDecade": "2000年代",
+      "durationSeconds": 289,
+      "collectionName": "テルーの唄 - Single"
+    },
+    "classification": {
+      "genres": [
+        "J-Pop"
+      ],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": 258494351
+    },
+    "status": "auto_matched",
+    "generatedAt": "2026-07-07T19:19:19+09:00"
+  },
+  {
+    "title": "君をのせて",
+    "artist": "久石譲",
+    "metadata": {
+      "releaseDate": null,
+      "releaseDecade": null,
+      "durationSeconds": null,
+      "collectionName": null
+    },
+    "classification": {
+      "genres": [],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": null
+    },
+    "status": "not_found",
+    "generatedAt": "2026-07-07T19:19:21+09:00"
+  },
+  {
+    "title": "鳥の人",
+    "artist": "久石譲",
+    "metadata": {
+      "releaseDate": null,
+      "releaseDecade": null,
+      "durationSeconds": null,
+      "collectionName": null
+    },
+    "classification": {
+      "genres": [],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": null
+    },
+    "status": "not_found",
+    "generatedAt": "2026-07-07T19:19:23+09:00"
+  },
+  {
+    "title": "仕事はじめ",
+    "artist": "久石譲",
+    "metadata": {
+      "releaseDate": "1989-08-10",
+      "releaseDecade": "1980年代",
+      "durationSeconds": 135,
+      "collectionName": "魔女の宅急便 サントラ音楽集"
+    },
+    "classification": {
+      "genres": [
+        "サウンドトラック"
+      ],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": 667779095
+    },
+    "status": "auto_matched",
+    "generatedAt": "2026-07-07T19:19:24+09:00"
+  },
+  {
+    "title": "やさしさに包まれたなら",
+    "artist": "荒井由実",
+    "metadata": {
+      "releaseDate": "1974-10-05",
+      "releaseDecade": "1970年代",
+      "durationSeconds": 192,
+      "collectionName": "MISSLIM"
+    },
+    "classification": {
+      "genres": [
+        "J-Pop"
+      ],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": 1436010457
+    },
+    "status": "auto_matched",
+    "generatedAt": "2026-07-07T19:19:25+09:00"
+  },
+  {
+    "title": "ルージュの伝言",
+    "artist": "松任谷由実",
+    "metadata": {
+      "releaseDate": null,
+      "releaseDecade": null,
+      "durationSeconds": null,
+      "collectionName": null
+    },
+    "classification": {
+      "genres": [],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": null
+    },
+    "status": "not_found",
+    "generatedAt": "2026-07-07T19:19:27+09:00"
+  },
+  {
+    "title": "たぬきの暮らし",
+    "artist": "八草楽団",
+    "metadata": {
+      "releaseDate": "1977-04-21",
+      "releaseDecade": "1970年代",
+      "durationSeconds": 104,
+      "collectionName": "平成狸合戦ぽんぽこ サウンドトラック"
+    },
+    "classification": {
+      "genres": [
+        "サウンドトラック"
+      ],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": 667831625
+    },
+    "status": "auto_matched",
+    "generatedAt": "2026-07-07T19:19:27+09:00"
+  },
+  {
+    "title": "時には昔の話を",
+    "artist": "加藤登紀子",
+    "metadata": {
+      "releaseDate": "1987-01-01",
+      "releaseDecade": "1980年代",
+      "durationSeconds": 281,
+      "collectionName": "My Story 時には、昔の話を"
+    },
+    "classification": {
+      "genres": [
+        "歌謡曲"
+      ],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": 1443337669
+    },
+    "status": "needs_review",
+    "generatedAt": "2026-07-07T19:19:29+09:00"
+  },
+  {
+    "title": "ふたたび",
+    "artist": "久石譲",
+    "metadata": {
+      "releaseDate": "2001-07-18",
+      "releaseDecade": "2000年代",
+      "durationSeconds": 294,
+      "collectionName": "千と千尋の神隠し サウンドトラック"
+    },
+    "classification": {
+      "genres": [
+        "サウンドトラック"
+      ],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": 668520682
+    },
+    "status": "auto_matched",
+    "generatedAt": "2026-07-07T19:19:30+09:00"
+  },
+  {
+    "title": "帰らざる日々",
+    "artist": "久石譲",
+    "metadata": {
+      "releaseDate": "1992-07-25",
+      "releaseDecade": "1990年代",
+      "durationSeconds": 136,
+      "collectionName": "紅の豚 サウンドトラック - 飛ばねえ豚はただの豚だ!"
+    },
+    "classification": {
+      "genres": [
+        "サウンドトラック"
+      ],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": 667811546
+    },
+    "status": "auto_matched",
+    "generatedAt": "2026-07-07T19:19:31+09:00"
+  },
+  {
+    "title": "MAMMAIUTO",
+    "artist": "久石譲",
+    "metadata": {
+      "releaseDate": "1992-07-25",
+      "releaseDecade": "1990年代",
+      "durationSeconds": 81,
+      "collectionName": "紅の豚 サウンドトラック - 飛ばねえ豚はただの豚だ!"
+    },
+    "classification": {
+      "genres": [
+        "サウンドトラック"
+      ],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": 667811544
+    },
+    "status": "auto_matched",
+    "generatedAt": "2026-07-07T19:19:32+09:00"
+  },
+  {
+    "title": "ひこうき雲",
+    "artist": "荒井由実",
+    "metadata": {
+      "releaseDate": "1973-11-05",
+      "releaseDecade": "1970年代",
+      "durationSeconds": 206,
+      "collectionName": "ひこうき雲"
+    },
+    "classification": {
+      "genres": [
+        "J-Pop"
+      ],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": 1436009093
+    },
+    "status": "auto_matched",
+    "generatedAt": "2026-07-07T19:19:33+09:00"
+  },
+  {
+    "title": "ねこバス",
+    "artist": "久石譲",
+    "metadata": {
+      "releaseDate": "1988-05-01",
+      "releaseDecade": "1980年代",
+      "durationSeconds": 131,
+      "collectionName": "となりのトトロ サウンドトラック"
+    },
+    "classification": {
+      "genres": [
+        "サウンドトラック"
+      ],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": 667366557
+    },
+    "status": "auto_matched",
+    "generatedAt": "2026-07-07T19:19:34+09:00"
+  },
+  {
+    "title": "海のお母さん",
+    "artist": "林正子",
+    "metadata": {
+      "releaseDate": null,
+      "releaseDecade": null,
+      "durationSeconds": null,
+      "collectionName": null
+    },
+    "classification": {
+      "genres": [],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": null
+    },
+    "status": "not_found",
+    "generatedAt": "2026-07-07T19:19:36+09:00"
+  },
+  {
+    "title": "もののけ姫",
+    "artist": "米良美一",
+    "metadata": {
+      "releaseDate": null,
+      "releaseDecade": null,
+      "durationSeconds": null,
+      "collectionName": null
+    },
+    "classification": {
+      "genres": [],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": null
+    },
+    "status": "not_found",
+    "generatedAt": "2026-07-07T19:19:38+09:00"
+  },
+  {
+    "title": "小さなオバケ",
+    "artist": "久石譲",
+    "metadata": {
+      "releaseDate": "1988-05-01",
+      "releaseDecade": "1980年代",
+      "durationSeconds": 235,
+      "collectionName": "となりのトトロ サウンドトラック"
+    },
+    "classification": {
+      "genres": [
+        "サウンドトラック"
+      ],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": 667366549
+    },
+    "status": "auto_matched",
+    "generatedAt": "2026-07-07T19:19:39+09:00"
+  },
+  {
+    "title": "メイとすすわたり",
+    "artist": "久石譲",
+    "metadata": {
+      "releaseDate": "1988-05-01",
+      "releaseDecade": "1980年代",
+      "durationSeconds": 94,
+      "collectionName": "となりのトトロ サウンドトラック"
+    },
+    "classification": {
+      "genres": [
+        "サウンドトラック"
+      ],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": 667366424
+    },
+    "status": "auto_matched",
+    "generatedAt": "2026-07-07T19:19:40+09:00"
+  },
+  {
+    "title": "アシタカせっ記",
+    "artist": "久石譲",
+    "metadata": {
+      "releaseDate": "1997-07-02",
+      "releaseDecade": "1990年代",
+      "durationSeconds": 100,
+      "collectionName": "もののけ姫 サウンドトラック"
+    },
+    "classification": {
+      "genres": [
+        "サウンドトラック"
+      ],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": 667870482
+    },
+    "status": "needs_review",
+    "generatedAt": "2026-07-07T19:19:59+09:00"
+  },
+  {
+    "title": "風の谷のナウシカ",
+    "artist": "安田成美",
+    "metadata": {
+      "releaseDate": "1991-12-21",
+      "releaseDecade": "1990年代",
+      "durationSeconds": 245,
+      "collectionName": "安田成美"
+    },
+    "classification": {
+      "genres": [
+        "J-Pop"
+      ],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": 257124398
+    },
+    "status": "auto_matched",
+    "generatedAt": "2026-07-07T19:20:00+09:00"
+  },
+  {
+    "title": "遠い日々",
+    "artist": "久石譲",
+    "metadata": {
+      "releaseDate": null,
+      "releaseDecade": null,
+      "durationSeconds": null,
+      "collectionName": null
+    },
+    "classification": {
+      "genres": [],
+      "subgenres": [],
+      "sourceCategories": [],
+      "vocalTypes": []
+    },
+    "tags": {
+      "themeTags": [],
+      "moodTags": [],
+      "motifTags": [],
+      "eventTags": []
+    },
+    "tieUps": [],
+    "source": {
+      "provider": "itunes",
+      "trackId": null
+    },
+    "status": "not_found",
+    "generatedAt": "2026-07-07T19:20:02+09:00"
   }
 ]

--- a/nemupipiano-musiclist-search/data/dictionary/music_metadata.json
+++ b/nemupipiano-musiclist-search/data/dictionary/music_metadata.json
@@ -41288,15 +41288,31 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
-      "subgenres": [],
+      "genres": [
+        "J-POP"
+      ],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "別れ",
+        "記憶"
+      ],
+      "moodTags": [
+        "切ない",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "街",
+        "帰り道"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -41320,17 +41336,42 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "映画",
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "喪失",
+        "祈り",
+        "記憶"
+      ],
+      "moodTags": [
+        "泣ける",
+        "壮大",
+        "透明感"
+      ],
+      "motifTags": [
+        "桜",
+        "涙",
+        "光"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "ヱヴァンゲリヲン新劇場版:Q",
+        "series": "新世紀エヴァンゲリオン",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1428769931
@@ -41352,16 +41393,37 @@
         "ロック"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル",
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "戦い",
+        "希望",
+        "成長"
+      ],
+      "moodTags": [
+        "熱い",
+        "疾走感",
+        "かっこいい"
+      ],
+      "motifTags": [
+        "光"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "キングダム",
+        "series": "キングダム",
+        "role": "OP"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1506752177
@@ -41384,12 +41446,25 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "希望",
+        "旅立ち",
+        "自由"
+      ],
+      "moodTags": [
+        "爽やか",
+        "明るい",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "道",
+        "海"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -41410,15 +41485,32 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
-      "subgenres": [],
+      "genres": [
+        "ポップス"
+      ],
+      "subgenres": [
+        "シティポップ"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "自由",
+        "希望",
+        "日常"
+      ],
+      "moodTags": [
+        "爽やか",
+        "おしゃれ",
+        "疾走感"
+      ],
+      "motifTags": [
+        "空",
+        "風"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -41442,14 +41534,29 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "アイドルポップ"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル",
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "秘密",
+        "葛藤"
+      ],
+      "moodTags": [
+        "ミステリアス",
+        "かわいい",
+        "ダーク"
+      ],
+      "motifTags": [
+        "夜"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -41475,12 +41582,27 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル",
+        "女性ボーカル",
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "夢",
+        "希望",
+        "祈り"
+      ],
+      "moodTags": [
+        "幻想的",
+        "壮大",
+        "優しい"
+      ],
+      "motifTags": [
+        "星",
+        "空"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -41504,14 +41626,29 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "ポップロック"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "自由",
+        "日常",
+        "成長"
+      ],
+      "moodTags": [
+        "疾走感",
+        "爽やか",
+        "かっこいい"
+      ],
+      "motifTags": [
+        "川",
+        "風"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -41533,16 +41670,31 @@
     },
     "classification": {
       "genres": [
-        "J-POP"
+        "R&B／ソウル"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル",
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "秘密",
+        "別れ"
+      ],
+      "moodTags": [
+        "切ない",
+        "おしゃれ",
+        "ダーク"
+      ],
+      "motifTags": [
+        "夜"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -41566,14 +41718,27 @@
       "genres": [
         "歌謡曲"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "青春",
+        "成長",
+        "記憶"
+      ],
+      "moodTags": [
+        "切ない",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "秋"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -41597,14 +41762,27 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "再会",
+        "記憶"
+      ],
+      "moodTags": [
+        "優しい",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "花"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -41629,16 +41807,37 @@
         "オルタナティブ"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "祈り",
+        "絆",
+        "希望"
+      ],
+      "moodTags": [
+        "透明感",
+        "壮大",
+        "切ない"
+      ],
+      "motifTags": [
+        "光",
+        "手"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "平家物語",
+        "series": "平家物語",
+        "role": "OP"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1822254657
@@ -41656,20 +41855,43 @@
       "collectionName": "名前のない怪物"
     },
     "classification": {
-      "genres": [],
-      "subgenres": [],
+      "genres": [
+        "J-POP"
+      ],
+      "subgenres": [
+        "エレクトロポップ"
+      ],
       "sourceCategories": [
         "アニメ"
       ],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "戦い",
+        "葛藤",
+        "秘密"
+      ],
+      "moodTags": [
+        "ダーク",
+        "緊張感",
+        "疾走感"
+      ],
+      "motifTags": [
+        "影",
+        "夜"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "PSYCHO-PASS サイコパス",
+        "series": "PSYCHO-PASS",
+        "role": "ED"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1537444998
@@ -41688,16 +41910,29 @@
     },
     "classification": {
       "genres": [
-        "J-POP"
+        "歌謡曲"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "別れ",
+        "祈り"
+      ],
+      "moodTags": [
+        "切ない",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "涙"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -41722,16 +41957,37 @@
         "J-POP"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "戦い",
+        "葛藤",
+        "自由"
+      ],
+      "moodTags": [
+        "かっこいい",
+        "ダーク",
+        "疾走感"
+      ],
+      "motifTags": [
+        "怪獣",
+        "影"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "BEASTARS",
+        "series": "BEASTARS",
+        "role": "OP"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1544083979
@@ -41749,20 +42005,42 @@
       "collectionName": "infinite synthesis"
     },
     "classification": {
-      "genres": [],
-      "subgenres": [],
+      "genres": [
+        "エレクトロニック"
+      ],
+      "subgenres": [
+        "エレクトロポップ"
+      ],
       "sourceCategories": [
         "アニメ"
       ],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "戦い",
+        "希望",
+        "自由"
+      ],
+      "moodTags": [
+        "疾走感",
+        "かっこいい",
+        "熱い"
+      ],
+      "motifTags": [
+        "光"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "とある科学の超電磁砲",
+        "series": "とあるシリーズ",
+        "role": "OP"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1804662307
@@ -41784,16 +42062,38 @@
         "メタル"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル",
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "戦い",
+        "恋愛",
+        "葛藤"
+      ],
+      "moodTags": [
+        "熱い",
+        "ダーク",
+        "緊張感"
+      ],
+      "motifTags": [
+        "炎",
+        "夜"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "バジリスク 〜甲賀忍法帖〜",
+        "series": "バジリスク",
+        "role": "OP"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 537847103
@@ -41811,20 +42111,42 @@
       "collectionName": "宝箱 -TREASURE BOX-"
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "J-POP"
+      ],
       "subgenres": [],
       "sourceCategories": [
         "アニメ"
       ],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル",
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "希望",
+        "旅立ち",
+        "冒険"
+      ],
+      "moodTags": [
+        "爽やか",
+        "壮大",
+        "熱い"
+      ],
+      "motifTags": [
+        "空",
+        "道"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "宇宙のステルヴィア",
+        "series": "宇宙のステルヴィア",
+        "role": "OP"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 270010825
@@ -41847,12 +42169,25 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "旅立ち",
+        "冒険",
+        "自由"
+      ],
+      "moodTags": [
+        "楽しい",
+        "爽やか",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "旅路",
+        "道"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -41876,14 +42211,27 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "約束",
+        "日常"
+      ],
+      "moodTags": [
+        "優しい",
+        "切ない"
+      ],
+      "motifTags": [
+        "手"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -41904,20 +42252,44 @@
       "collectionName": "TVアニメーション「マクロスΔ」ボーカルアルバム　Walkure Attack!"
     },
     "classification": {
-      "genres": [],
-      "subgenres": [],
+      "genres": [
+        "J-POP"
+      ],
+      "subgenres": [
+        "アイドルポップ"
+      ],
       "sourceCategories": [
         "アニメ"
       ],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル",
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "戦い",
+        "別れ"
+      ],
+      "moodTags": [
+        "切ない",
+        "壮大",
+        "疾走感"
+      ],
+      "motifTags": [
+        "空",
+        "声"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "マクロスΔ",
+        "series": "マクロス",
+        "role": "挿入歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -41938,14 +42310,28 @@
       "genres": [
         "ワールド"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "祈り",
+        "約束"
+      ],
+      "moodTags": [
+        "荘厳",
+        "泣ける",
+        "優しい"
+      ],
+      "motifTags": [
+        "光"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -41969,17 +42355,39 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "別れ",
+        "記憶"
+      ],
+      "moodTags": [
+        "切ない",
+        "泣ける"
+      ],
+      "motifTags": [
+        "雨",
+        "太陽"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "タイヨウのうた",
+        "series": "タイヨウのうた",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1537445927
@@ -42000,17 +42408,39 @@
       "genres": [
         "ロック"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "ドラマ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "別れ",
+        "葛藤"
+      ],
+      "moodTags": [
+        "切ない",
+        "ダーク"
+      ],
+      "motifTags": [
+        "冬",
+        "花"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "後妻業",
+        "series": "後妻業",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1451684198
@@ -42033,12 +42463,25 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "自由",
+        "日常",
+        "葛藤"
+      ],
+      "moodTags": [
+        "おしゃれ",
+        "ミステリアス",
+        "疾走感"
+      ],
+      "motifTags": [
+        "夜",
+        "街"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -42062,14 +42505,31 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル",
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "孤独",
+        "葛藤",
+        "夢"
+      ],
+      "moodTags": [
+        "ダーク",
+        "ミステリアス",
+        "切ない"
+      ],
+      "motifTags": [
+        "星",
+        "街",
+        "夜"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -42091,16 +42551,28 @@
     },
     "classification": {
       "genres": [
-        "J-POP"
+        "歌謡曲"
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "旅立ち",
+        "孤独",
+        "自由"
+      ],
+      "moodTags": [
+        "ノスタルジック",
+        "ミステリアス"
+      ],
+      "motifTags": [
+        "旅路",
+        "街"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -42124,14 +42596,28 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "別れ",
+        "記憶"
+      ],
+      "moodTags": [
+        "切ない",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "帰り道",
+        "街"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -42157,12 +42643,24 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "記憶",
+        "葛藤"
+      ],
+      "moodTags": [
+        "切ない",
+        "ミステリアス"
+      ],
+      "motifTags": [
+        "花",
+        "雨"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -42184,16 +42682,30 @@
     },
     "classification": {
       "genres": [
-        "歌謡曲"
+        "演歌"
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "葛藤",
+        "別れ"
+      ],
+      "moodTags": [
+        "熱い",
+        "ダーク",
+        "荘厳"
+      ],
+      "motifTags": [
+        "桜",
+        "夜",
+        "炎"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -42217,14 +42729,27 @@
       "genres": [
         "ロック"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "別れ",
+        "記憶"
+      ],
+      "moodTags": [
+        "切ない",
+        "泣ける"
+      ],
+      "motifTags": [
+        "涙"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -42248,14 +42773,29 @@
       "genres": [
         "歌謡曲"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "旅立ち",
+        "記憶",
+        "希望"
+      ],
+      "moodTags": [
+        "ノスタルジック",
+        "優しい",
+        "壮大"
+      ],
+      "motifTags": [
+        "旅路",
+        "風"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -42279,14 +42819,28 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "アイドルポップ"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル",
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "友情",
+        "絆",
+        "記憶"
+      ],
+      "moodTags": [
+        "優しい",
+        "泣ける"
+      ],
+      "motifTags": [
+        "手"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -42308,16 +42862,28 @@
     },
     "classification": {
       "genres": [
-        "J-POP"
+        "歌謡曲"
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "青春",
+        "葛藤",
+        "自由"
+      ],
+      "moodTags": [
+        "かっこいい",
+        "ダーク",
+        "疾走感"
+      ],
+      "motifTags": [
+        "街"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -42338,17 +42904,32 @@
       "collectionName": "カーテンコールが止む前に"
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "J-POP"
+      ],
       "subgenres": [],
       "sourceCategories": [
-        "アニメ"
+        "ボカロ"
       ],
-      "vocalTypes": []
+      "vocalTypes": [
+        "VOCALOID"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "孤独",
+        "葛藤",
+        "祈り"
+      ],
+      "moodTags": [
+        "切ない",
+        "爽やか",
+        "疾走感"
+      ],
+      "motifTags": [
+        "海",
+        "花"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -42372,17 +42953,39 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "ドラマ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "家族",
+        "記憶",
+        "祈り"
+      ],
+      "moodTags": [
+        "優しい",
+        "泣ける"
+      ],
+      "motifTags": [
+        "朝",
+        "花"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "監察医 朝顔",
+        "series": "監察医 朝顔",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1554822811
@@ -42404,16 +43007,37 @@
         "J-POP"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "男性ボーカル",
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "夢",
+        "自由"
+      ],
+      "moodTags": [
+        "幻想的",
+        "爽やか",
+        "切ない"
+      ],
+      "motifTags": [
+        "海"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "海月姫",
+        "series": "海月姫",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 955796412
@@ -42436,12 +43060,27 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル",
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "夢",
+        "冒険",
+        "日常"
+      ],
+      "moodTags": [
+        "幻想的",
+        "楽しい",
+        "ミステリアス"
+      ],
+      "motifTags": [
+        "炎",
+        "夜",
+        "舞台"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -42466,16 +43105,36 @@
         "J-POP"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "自由",
+        "葛藤",
+        "成長"
+      ],
+      "moodTags": [
+        "コミカル",
+        "かっこいい",
+        "疾走感"
+      ],
+      "motifTags": [
+        "舞台"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "ホリック xxxHOLiC",
+        "series": "xxxHOLiC",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1618345214
@@ -42498,12 +43157,26 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル",
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "戦い",
+        "祈り",
+        "自由"
+      ],
+      "moodTags": [
+        "熱い",
+        "ダーク",
+        "幻想的"
+      ],
+      "motifTags": [
+        "虹",
+        "炎"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -42527,14 +43200,28 @@
       "genres": [
         "ロック"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "ポップロック"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常",
+        "記憶",
+        "自由"
+      ],
+      "moodTags": [
+        "爽やか",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "風",
+        "街"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -42560,12 +43247,24 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "青春",
+        "祈り"
+      ],
+      "moodTags": [
+        "幻想的",
+        "切ない"
+      ],
+      "motifTags": [
+        "星",
+        "夕暮れ"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -42589,17 +43288,39 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "ドラマ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "希望",
+        "成長",
+        "葛藤"
+      ],
+      "moodTags": [
+        "壮大",
+        "切ない",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "光"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "若者のすべて",
+        "series": "若者のすべて",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1374950946
@@ -42622,12 +43343,24 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "葛藤",
+        "孤独",
+        "秘密"
+      ],
+      "moodTags": [
+        "ミステリアス",
+        "疾走感",
+        "ダーク"
+      ],
+      "motifTags": [
+        "夜"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -42651,17 +43384,39 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "ドラマ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "青春",
+        "喪失",
+        "記憶"
+      ],
+      "moodTags": [
+        "切ない",
+        "ダーク",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "影"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "高校教師",
+        "series": "高校教師",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1439290787
@@ -42679,15 +43434,26 @@
       "collectionName": "ピタゴラスイッチ うたのCD"
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "キッズ"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "インスト"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常"
+      ],
+      "moodTags": [
+        "コミカル",
+        "楽しい"
+      ],
+      "motifTags": [
+        "音楽"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -42711,17 +43477,40 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "戦い",
+        "祈り",
+        "再会"
+      ],
+      "moodTags": [
+        "壮大",
+        "切ない",
+        "かっこいい"
+      ],
+      "motifTags": [
+        "光",
+        "空"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "機動戦士ガンダムUC",
+        "series": "機動戦士ガンダム",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1536126125
@@ -42740,19 +43529,40 @@
     },
     "classification": {
       "genres": [
-        "J-POP"
+        "ロック"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "冒険",
+        "戦い",
+        "希望"
+      ],
+      "moodTags": [
+        "熱い",
+        "爽やか",
+        "疾走感"
+      ],
+      "motifTags": [
+        "花",
+        "空"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "ゾイド -ZOIDS-",
+        "series": "ゾイド",
+        "role": "OP"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 345885292
@@ -42773,14 +43583,29 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "家族",
+        "記憶",
+        "祈り"
+      ],
+      "moodTags": [
+        "泣ける",
+        "優しい",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "涙",
+        "海"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -42806,12 +43631,26 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "旅立ち",
+        "希望",
+        "成長"
+      ],
+      "moodTags": [
+        "爽やか",
+        "明るい",
+        "疾走感"
+      ],
+      "motifTags": [
+        "春",
+        "風",
+        "桜"
+      ],
       "eventTags": []
     },
     "tieUps": [],

--- a/nemupipiano-musiclist-search/data/dictionary/music_metadata.json
+++ b/nemupipiano-musiclist-search/data/dictionary/music_metadata.json
@@ -21793,10 +21793,10 @@
     "title": "恋のメガラバ",
     "artist": "マキシマム ザ ホルモン",
     "metadata": {
-      "releaseDate": null,
-      "releaseDecade": null,
+      "releaseDate": "2006-07-05",
+      "releaseDecade": "2000年代",
       "durationSeconds": null,
-      "collectionName": null
+      "collectionName": "ぶっ生き返す"
     },
     "classification": {
       "genres": [

--- a/nemupipiano-musiclist-search/data/dictionary/music_metadata.json
+++ b/nemupipiano-musiclist-search/data/dictionary/music_metadata.json
@@ -24753,14 +24753,27 @@
       "genres": [
         "ポップス"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "別れ",
+        "記憶",
+        "祈り"
+      ],
+      "moodTags": [
+        "切ない",
+        "優しい"
+      ],
+      "motifTags": [
+        "手紙"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -24784,14 +24797,28 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "記憶",
+        "祈り",
+        "絆"
+      ],
+      "moodTags": [
+        "優しい",
+        "切ない"
+      ],
+      "motifTags": [
+        "手紙",
+        "声"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -24815,14 +24842,27 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "別れ",
+        "記憶"
+      ],
+      "moodTags": [
+        "切ない",
+        "優しい"
+      ],
+      "motifTags": [
+        "手紙"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -24846,14 +24886,29 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "別れ",
+        "孤独"
+      ],
+      "moodTags": [
+        "切ない",
+        "泣ける",
+        "幻想的"
+      ],
+      "motifTags": [
+        "星",
+        "夜"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -24879,12 +24934,25 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "希望",
+        "日常",
+        "友情"
+      ],
+      "moodTags": [
+        "明るい",
+        "楽しい",
+        "爽やか"
+      ],
+      "motifTags": [
+        "笑顔",
+        "光"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -24908,17 +24976,38 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "ドラマ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "別れ",
+        "記憶"
+      ],
+      "moodTags": [
+        "切ない",
+        "優しい"
+      ],
+      "motifTags": [
+        "声"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "対岸の家事〜これが、私の生きる道！〜",
+        "series": "対岸の家事",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1550243871
@@ -24936,15 +25025,30 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "J-POP"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "自由",
+        "戦い",
+        "成長"
+      ],
+      "moodTags": [
+        "かっこいい",
+        "疾走感",
+        "熱い"
+      ],
+      "motifTags": [
+        "道",
+        "炎"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -24968,14 +25072,29 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "記憶",
+        "絆"
+      ],
+      "moodTags": [
+        "切ない",
+        "優しい",
+        "透明感"
+      ],
+      "motifTags": [
+        "手",
+        "声"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -25001,12 +25120,24 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "再会",
+        "日常"
+      ],
+      "moodTags": [
+        "おしゃれ",
+        "切ない"
+      ],
+      "motifTags": [
+        "街",
+        "夜"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -25032,12 +25163,23 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "記憶",
+        "別れ"
+      ],
+      "moodTags": [
+        "切ない",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "コーヒー"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -25061,14 +25203,29 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "アイドルポップ"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル",
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "応援",
+        "希望"
+      ],
+      "moodTags": [
+        "かわいい",
+        "元気",
+        "明るい"
+      ],
+      "motifTags": [
+        "笑顔"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -25092,14 +25249,29 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "アイドルポップ"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル",
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "希望",
+        "日常"
+      ],
+      "moodTags": [
+        "楽しい",
+        "明るい",
+        "元気"
+      ],
+      "motifTags": [
+        "笑顔"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -25123,15 +25295,31 @@
       "genres": [
         "ロック"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
-      "eventTags": []
+      "themeTags": [
+        "青春",
+        "記憶",
+        "喪失"
+      ],
+      "moodTags": [
+        "切ない",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "夏",
+        "影"
+      ],
+      "eventTags": [
+        "夏休み"
+      ]
     },
     "tieUps": [],
     "source": {
@@ -25151,18 +25339,41 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "J-POP"
+      ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "ドラマ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル",
+        "デュエット"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "応援",
+        "戦い",
+        "絆"
+      ],
+      "moodTags": [
+        "熱い",
+        "元気",
+        "かっこいい"
+      ],
+      "motifTags": [
+        "声"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "振り返れば奴がいる",
+        "series": "振り返れば奴がいる",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -25183,17 +25394,40 @@
       "genres": [
         "オルタナティブ"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "エレクトロポップ"
+      ],
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "日常",
+        "自由"
+      ],
+      "moodTags": [
+        "おしゃれ",
+        "コミカル",
+        "疾走感"
+      ],
+      "motifTags": [
+        "街",
+        "夜"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "うる星やつら",
+        "series": "うる星やつら",
+        "role": "ED"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1649923942
@@ -25215,16 +25449,38 @@
         "J-POP"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
-      "eventTags": []
+      "themeTags": [
+        "恋愛",
+        "日常",
+        "秘密"
+      ],
+      "moodTags": [
+        "かわいい",
+        "コミカル",
+        "明るい"
+      ],
+      "motifTags": [
+        "手紙"
+      ],
+      "eventTags": [
+        "結婚"
+      ]
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "ヒロイン失格",
+        "series": "ヒロイン失格",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1537253742
@@ -25245,14 +25501,27 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "片想い",
+        "孤独"
+      ],
+      "moodTags": [
+        "切ない",
+        "泣ける"
+      ],
+      "motifTags": [
+        "涙"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -25276,15 +25545,31 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "ポップロック"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
-      "eventTags": []
+      "themeTags": [
+        "恋愛",
+        "応援",
+        "日常"
+      ],
+      "moodTags": [
+        "明るい",
+        "楽しい",
+        "爽やか"
+      ],
+      "motifTags": [
+        "笑顔"
+      ],
+      "eventTags": [
+        "結婚"
+      ]
     },
     "tieUps": [],
     "source": {
@@ -25307,14 +25592,28 @@
       "genres": [
         "演歌"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "家族",
+        "祈り",
+        "記憶"
+      ],
+      "moodTags": [
+        "優しい",
+        "泣ける",
+        "荘厳"
+      ],
+      "motifTags": [
+        "光"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -25340,12 +25639,24 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "自由",
+        "日常",
+        "希望"
+      ],
+      "moodTags": [
+        "コミカル",
+        "元気",
+        "楽しい"
+      ],
+      "motifTags": [
+        "笑顔"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -25366,18 +25677,44 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "genres": [
+        "キッズ"
+      ],
+      "subgenres": [
+        "アイドルポップ"
+      ],
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル",
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "友情",
+        "夢",
+        "希望"
+      ],
+      "moodTags": [
+        "かわいい",
+        "明るい",
+        "楽しい"
+      ],
+      "motifTags": [
+        "音楽",
+        "光"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "キミとアイドルプリキュア♪",
+        "series": "プリキュア",
+        "role": "ED"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -25399,16 +25736,36 @@
         "J-POP"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "青春",
+        "片想い"
+      ],
+      "moodTags": [
+        "爽やか",
+        "優しい"
+      ],
+      "motifTags": [
+        "風",
+        "春"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "アナログ",
+        "series": "アナログ",
+        "role": "インスパイアソング"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1805325622
@@ -25426,18 +25783,42 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "J-POP"
+      ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "戦い",
+        "希望",
+        "祈り"
+      ],
+      "moodTags": [
+        "熱い",
+        "壮大",
+        "ダーク"
+      ],
+      "motifTags": [
+        "夜",
+        "光",
+        "炎"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "鬼滅の刃",
+        "series": "鬼滅の刃",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -25458,14 +25839,29 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "シティポップ"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "別れ",
+        "記憶"
+      ],
+      "moodTags": [
+        "切ない",
+        "おしゃれ",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "夜",
+        "音楽"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -25489,14 +25885,27 @@
       "genres": [
         "ロック"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "別れ",
+        "葛藤"
+      ],
+      "moodTags": [
+        "切ない",
+        "ダーク"
+      ],
+      "motifTags": [
+        "夜"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -25520,14 +25929,29 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "再会",
+        "約束"
+      ],
+      "moodTags": [
+        "切ない",
+        "優しい",
+        "泣ける"
+      ],
+      "motifTags": [
+        "月",
+        "夜"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -25548,15 +25972,28 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "キッズ"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常",
+        "記憶"
+      ],
+      "moodTags": [
+        "穏やか",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "秋",
+        "夕暮れ"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -25577,15 +26014,28 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "キッズ"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常",
+        "記憶"
+      ],
+      "moodTags": [
+        "明るい",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "秋",
+        "夕暮れ"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -25606,15 +26056,28 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "キッズ"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常",
+        "記憶"
+      ],
+      "moodTags": [
+        "穏やか",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "秋",
+        "川"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -25638,14 +26101,28 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "別れ",
+        "記憶"
+      ],
+      "moodTags": [
+        "切ない",
+        "泣ける"
+      ],
+      "motifTags": [
+        "花",
+        "月"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -25671,12 +26148,24 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "片想い",
+        "青春"
+      ],
+      "moodTags": [
+        "かわいい",
+        "切ない",
+        "明るい"
+      ],
+      "motifTags": [
+        "笑顔"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -25697,15 +26186,32 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
-      "subgenres": [],
+      "genres": [
+        "ポップス"
+      ],
+      "subgenres": [
+        "シティポップ"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "孤独",
+        "日常"
+      ],
+      "moodTags": [
+        "おしゃれ",
+        "ノスタルジック",
+        "ミステリアス"
+      ],
+      "motifTags": [
+        "街",
+        "夜"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -25731,12 +26237,26 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "夢",
+        "希望",
+        "日常"
+      ],
+      "moodTags": [
+        "幻想的",
+        "楽しい",
+        "壮大"
+      ],
+      "motifTags": [
+        "星",
+        "夜",
+        "光"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -25757,18 +26277,38 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "キッズ"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "戦い",
+        "希望"
+      ],
+      "moodTags": [
+        "熱い",
+        "元気",
+        "壮大"
+      ],
+      "motifTags": [
+        "光",
+        "空"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "ウルトラマン",
+        "series": "ウルトラマン",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -25791,12 +26331,23 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "片想い",
+        "葛藤"
+      ],
+      "moodTags": [
+        "おしゃれ",
+        "切ない"
+      ],
+      "motifTags": [
+        "夜"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -25817,20 +26368,43 @@
       "collectionName": "MBS・TBS系TVアニメーション マクロスF(フロンティア) オリジナルサウンドトラック2 娘トラ☆"
     },
     "classification": {
-      "genres": [],
-      "subgenres": [],
+      "genres": [
+        "J-POP"
+      ],
+      "subgenres": [
+        "アイドルポップ"
+      ],
       "sourceCategories": [
         "アニメ"
       ],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "夢",
+        "自由"
+      ],
+      "moodTags": [
+        "かわいい",
+        "楽しい",
+        "爽やか"
+      ],
+      "motifTags": [
+        "星",
+        "空"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "マクロスF",
+        "series": "マクロス",
+        "role": "挿入歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 469329897
@@ -25848,17 +26422,33 @@
       "collectionName": "KING - Single"
     },
     "classification": {
-      "genres": [],
-      "subgenres": [],
-      "sourceCategories": [
-        "アニメ"
+      "genres": [
+        "J-POP"
       ],
-      "vocalTypes": []
+      "subgenres": [
+        "エレクトロポップ"
+      ],
+      "sourceCategories": [
+        "ボカロ"
+      ],
+      "vocalTypes": [
+        "VOCALOID"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "自由",
+        "憧れ",
+        "葛藤"
+      ],
+      "moodTags": [
+        "かっこいい",
+        "ダーク",
+        "疾走感"
+      ],
+      "motifTags": [
+        "影"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -25882,17 +26472,40 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "ドラマ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "希望",
+        "再会"
+      ],
+      "moodTags": [
+        "優しい",
+        "泣ける",
+        "壮大"
+      ],
+      "motifTags": [
+        "晴れ",
+        "空"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "プロポーズ大作戦",
+        "series": "プロポーズ大作戦",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1082738072
@@ -25914,16 +26527,38 @@
         "J-POP"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画",
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "青春",
+        "記憶"
+      ],
+      "moodTags": [
+        "爽やか",
+        "切ない",
+        "疾走感"
+      ],
+      "motifTags": [
+        "空",
+        "風"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "HELLO WORLD",
+        "series": "HELLO WORLD",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1479397583
@@ -25945,16 +26580,37 @@
         "ロック"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "戦い",
+        "希望",
+        "葛藤"
+      ],
+      "moodTags": [
+        "熱い",
+        "疾走感",
+        "かっこいい"
+      ],
+      "motifTags": [
+        "炎",
+        "光"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "炎炎ノ消防隊",
+        "series": "炎炎ノ消防隊",
+        "role": "OP"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1471459432
@@ -25972,15 +26628,33 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "genres": [
+        "J-POP"
+      ],
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "ボカロ"
+      ],
+      "vocalTypes": [
+        "VOCALOID"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "約束",
+        "祈り"
+      ],
+      "moodTags": [
+        "優しい",
+        "切ない"
+      ],
+      "motifTags": [
+        "手",
+        "声"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -26006,13 +26680,27 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
-      "eventTags": []
+      "themeTags": [
+        "恋愛",
+        "日常",
+        "約束"
+      ],
+      "moodTags": [
+        "優しい",
+        "かわいい"
+      ],
+      "motifTags": [
+        "手",
+        "笑顔"
+      ],
+      "eventTags": [
+        "結婚"
+      ]
     },
     "tieUps": [],
     "source": {
@@ -26036,16 +26724,36 @@
         "劇伴音楽"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "インスト"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "戦い",
+        "希望"
+      ],
+      "moodTags": [
+        "壮大",
+        "荘厳",
+        "緊張感"
+      ],
+      "motifTags": [
+        "光",
+        "空"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "機動戦士ガンダムUC",
+        "series": "機動戦士ガンダム",
+        "role": "劇伴"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1524640234
@@ -26067,16 +26775,35 @@
         "劇伴音楽"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "インスト"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "冒険",
+        "戦い"
+      ],
+      "moodTags": [
+        "壮大",
+        "熱い"
+      ],
+      "motifTags": [
+        "空",
+        "翼"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "BLUE DRAGON",
+        "series": "BLUE DRAGON",
+        "role": "劇伴"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1443237459
@@ -26094,18 +26821,42 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "J-POP"
+      ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル",
+        "デュエット"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "戦い",
+        "祈り",
+        "喪失"
+      ],
+      "moodTags": [
+        "切ない",
+        "ダーク",
+        "壮大"
+      ],
+      "motifTags": [
+        "夜",
+        "炎"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "甲鉄城のカバネリ",
+        "series": "甲鉄城のカバネリ",
+        "role": "ED"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -26123,17 +26874,31 @@
       "collectionName": "七つの大罪 オリジナル・サウンドトラック 2"
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "劇伴音楽"
+      ],
       "subgenres": [],
       "sourceCategories": [
         "アニメ"
       ],
-      "vocalTypes": []
+      "vocalTypes": [
+        "インスト"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "戦い",
+        "葛藤"
+      ],
+      "moodTags": [
+        "緊張感",
+        "ダーク",
+        "壮大"
+      ],
+      "motifTags": [
+        "炎",
+        "影"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -26157,14 +26922,28 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "別れ",
+        "記憶",
+        "恋愛"
+      ],
+      "moodTags": [
+        "切ない",
+        "泣ける"
+      ],
+      "motifTags": [
+        "秋",
+        "声"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -26188,14 +26967,27 @@
       "genres": [
         "エレクトロニック"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "エレクトロポップ"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常",
+        "自由"
+      ],
+      "moodTags": [
+        "コミカル",
+        "楽しい",
+        "かわいい"
+      ],
+      "motifTags": [
+        "夜"
+      ],
       "eventTags": [
         "ハロウィン"
       ]
@@ -26221,14 +27013,28 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "アイドルポップ"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル",
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "日常"
+      ],
+      "moodTags": [
+        "楽しい",
+        "コミカル",
+        "元気"
+      ],
+      "motifTags": [
+        "夜"
+      ],
       "eventTags": [
         "ハロウィン"
       ]
@@ -26251,18 +27057,40 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "ポップス"
+      ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "インスト"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常",
+        "希望"
+      ],
+      "moodTags": [
+        "楽しい",
+        "優しい",
+        "おしゃれ"
+      ],
+      "motifTags": [
+        "雨",
+        "花"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "サウンド・オブ・ミュージック",
+        "series": "サウンド・オブ・ミュージック",
+        "role": "劇中歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null

--- a/nemupipiano-musiclist-search/data/dictionary/music_metadata.json
+++ b/nemupipiano-musiclist-search/data/dictionary/music_metadata.json
@@ -38868,12 +38868,23 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "応援",
+        "祈り",
+        "絆"
+      ],
+      "moodTags": [
+        "優しい",
+        "明るい"
+      ],
+      "motifTags": [
+        "手紙"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -38897,14 +38908,28 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "再会",
+        "希望",
+        "成長"
+      ],
+      "moodTags": [
+        "泣ける",
+        "壮大",
+        "優しい"
+      ],
+      "motifTags": [
+        "光"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -38928,14 +38953,28 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "エレクトロポップ"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "秘密",
+        "自由"
+      ],
+      "moodTags": [
+        "かわいい",
+        "コミカル",
+        "楽しい"
+      ],
+      "motifTags": [
+        "声"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -38959,17 +38998,39 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "ポップロック"
+      ],
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常",
+        "自由",
+        "友情"
+      ],
+      "moodTags": [
+        "楽しい",
+        "疾走感",
+        "コミカル"
+      ],
+      "motifTags": [
+        "音楽"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "血界戦線 & BEYOND",
+        "series": "血界戦線",
+        "role": "OP"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1128654736
@@ -38990,14 +39051,30 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "ボカロ"
+      ],
+      "vocalTypes": [
+        "VOCALOID"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "孤独",
+        "祈り",
+        "希望"
+      ],
+      "moodTags": [
+        "優しい",
+        "癒し",
+        "切ない"
+      ],
+      "motifTags": [
+        "夜"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -39021,17 +39098,40 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "ドラマ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "別れ",
+        "記憶"
+      ],
+      "moodTags": [
+        "切ない",
+        "幻想的",
+        "おしゃれ"
+      ],
+      "motifTags": [
+        "桜",
+        "春"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "First Love",
+        "series": "First Love",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1444862816
@@ -39052,15 +39152,33 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "アイドルポップ"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル",
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
-      "eventTags": []
+      "themeTags": [
+        "応援",
+        "希望",
+        "成長"
+      ],
+      "moodTags": [
+        "明るい",
+        "元気",
+        "爽やか"
+      ],
+      "motifTags": [
+        "桜",
+        "春"
+      ],
+      "eventTags": [
+        "入学"
+      ]
     },
     "tieUps": [],
     "source": {
@@ -39083,17 +39201,40 @@
       "genres": [
         "ロック"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "女性ボーカル",
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "記憶",
+        "別れ"
+      ],
+      "moodTags": [
+        "切ない",
+        "泣ける"
+      ],
+      "motifTags": [
+        "花",
+        "春"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "花束みたいな恋をした",
+        "series": "花束みたいな恋をした",
+        "role": "インスパイアソング"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1548406507
@@ -39116,12 +39257,24 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "希望",
+        "成長",
+        "応援"
+      ],
+      "moodTags": [
+        "爽やか",
+        "明るい"
+      ],
+      "motifTags": [
+        "空",
+        "光"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -39145,17 +39298,38 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "ドラマ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "家族",
+        "記憶",
+        "祈り"
+      ],
+      "moodTags": [
+        "優しい",
+        "泣ける"
+      ],
+      "motifTags": [
+        "花"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "はじまりの歌",
+        "series": "はじまりの歌",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1883590250
@@ -39176,14 +39350,29 @@
       "genres": [
         "ロック"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "ポップロック"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "希望",
+        "日常",
+        "応援"
+      ],
+      "moodTags": [
+        "明るい",
+        "元気",
+        "爽やか"
+      ],
+      "motifTags": [
+        "太陽",
+        "空"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -39207,14 +39396,28 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "青春",
+        "記憶"
+      ],
+      "moodTags": [
+        "切ない",
+        "優しい"
+      ],
+      "motifTags": [
+        "桜",
+        "春"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -39239,16 +39442,36 @@
         "J-POP"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "ドラマ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "別れ",
+        "日常"
+      ],
+      "moodTags": [
+        "切ない",
+        "ノスタルジック",
+        "優しい"
+      ],
+      "motifTags": [
+        "涙"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "子供が寝たあとで",
+        "series": "子供が寝たあとで",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 284522040
@@ -39271,12 +39494,24 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "別れ",
+        "記憶"
+      ],
+      "moodTags": [
+        "切ない",
+        "おしゃれ",
+        "かわいい"
+      ],
+      "motifTags": [
+        "コーヒー"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -39302,12 +39537,24 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "希望",
+        "旅立ち",
+        "成長"
+      ],
+      "moodTags": [
+        "爽やか",
+        "明るい",
+        "元気"
+      ],
+      "motifTags": [
+        "空"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -39328,20 +39575,43 @@
       "collectionName": "Sincerely - Single"
     },
     "classification": {
-      "genres": [],
-      "subgenres": [],
+      "genres": [
+        "J-POP"
+      ],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [
         "アニメ"
       ],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "祈り",
+        "記憶",
+        "絆"
+      ],
+      "moodTags": [
+        "優しい",
+        "泣ける",
+        "壮大"
+      ],
+      "motifTags": [
+        "手紙",
+        "声"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "ヴァイオレット・エヴァーガーデン",
+        "series": "ヴァイオレット・エヴァーガーデン",
+        "role": "OP"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1486980090
@@ -39362,17 +39632,38 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "映画"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "家族",
+        "祈り"
+      ],
+      "moodTags": [
+        "優しい",
+        "泣ける"
+      ],
+      "motifTags": [
+        "手"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "8年越しの花嫁 奇跡の実話",
+        "series": "8年越しの花嫁",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1440902624
@@ -39390,15 +39681,32 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
-      "subgenres": [],
+      "genres": [
+        "歌謡曲"
+      ],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "祈り",
+        "記憶",
+        "家族"
+      ],
+      "moodTags": [
+        "荘厳",
+        "切ない",
+        "優しい"
+      ],
+      "motifTags": [
+        "川",
+        "雨"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -39422,17 +39730,38 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "ドラマ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "希望",
+        "祈り"
+      ],
+      "moodTags": [
+        "優しい",
+        "壮大"
+      ],
+      "motifTags": [
+        "光"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "ドク",
+        "series": "ドク",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 142415286
@@ -39453,14 +39782,27 @@
       "genres": [
         "ジャズ"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "フュージョン"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "インスト"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "自由",
+        "日常"
+      ],
+      "moodTags": [
+        "おしゃれ",
+        "爽やか",
+        "疾走感"
+      ],
+      "motifTags": [
+        "音楽"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -39485,16 +39827,38 @@
         "ロック"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画",
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "戦い",
+        "希望",
+        "絆"
+      ],
+      "moodTags": [
+        "熱い",
+        "壮大",
+        "かっこいい"
+      ],
+      "motifTags": [
+        "光",
+        "空"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "仮面ライダー THE NEXT",
+        "series": "仮面ライダー",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 887388931
@@ -39512,15 +39876,30 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "J-POP"
+      ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "夢",
+        "希望",
+        "成長"
+      ],
+      "moodTags": [
+        "幻想的",
+        "壮大",
+        "透明感"
+      ],
+      "motifTags": [
+        "光",
+        "空"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -39545,16 +39924,36 @@
         "J-POP"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル",
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常",
+        "家族"
+      ],
+      "moodTags": [
+        "楽しい",
+        "コミカル",
+        "元気"
+      ],
+      "motifTags": [
+        "街"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "ちびまる子ちゃん",
+        "series": "ちびまる子ちゃん",
+        "role": "ED"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1893019546
@@ -39575,14 +39974,29 @@
       "genres": [
         "ジャズ"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "フュージョン"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "インスト"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "冒険",
+        "希望",
+        "自由"
+      ],
+      "moodTags": [
+        "明るい",
+        "爽やか",
+        "壮大"
+      ],
+      "motifTags": [
+        "海",
+        "旅路"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -39607,16 +40021,36 @@
         "J-POP"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "ドラマ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常",
+        "自由",
+        "希望"
+      ],
+      "moodTags": [
+        "明るい",
+        "楽しい",
+        "おしゃれ"
+      ],
+      "motifTags": [
+        "朝"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "半分、青い。",
+        "series": "半分、青い。",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1417065830
@@ -39637,17 +40071,41 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "映画",
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "自由",
+        "旅立ち",
+        "祈り"
+      ],
+      "moodTags": [
+        "切ない",
+        "壮大",
+        "透明感"
+      ],
+      "motifTags": [
+        "風",
+        "海"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "ONE PIECE FILM RED",
+        "series": "ONE PIECE",
+        "role": "劇中歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1636447280
@@ -39670,12 +40128,24 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "別れ",
+        "自由"
+      ],
+      "moodTags": [
+        "コミカル",
+        "切ない",
+        "かわいい"
+      ],
+      "motifTags": [
+        "声"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -39700,16 +40170,35 @@
         "J-POP"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "ドラマ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "日常",
+        "希望"
+      ],
+      "moodTags": [
+        "明るい",
+        "爽やか"
+      ],
+      "motifTags": [
+        "笑顔"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "全開ガール",
+        "series": "全開ガール",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1036800906
@@ -39727,18 +40216,43 @@
       "collectionName": "FINAL FANTASY X Original Soundtrack"
     },
     "classification": {
-      "genres": [],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "genres": [
+        "ワールド"
+      ],
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "ゲーム"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "祈り",
+        "冒険"
+      ],
+      "moodTags": [
+        "幻想的",
+        "泣ける",
+        "壮大"
+      ],
+      "motifTags": [
+        "海",
+        "光"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "FINAL FANTASY X",
+        "series": "FINAL FANTASY",
+        "role": "挿入歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 62445434
@@ -39760,16 +40274,36 @@
         "J-POP"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画",
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "家族",
+        "希望"
+      ],
+      "moodTags": [
+        "優しい",
+        "明るい"
+      ],
+      "motifTags": [
+        "春"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "映画クレヨンしんちゃん 新婚旅行ハリケーン ～失われたひろし～",
+        "series": "クレヨンしんちゃん",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1455341000
@@ -39790,14 +40324,28 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "旅立ち",
+        "記憶"
+      ],
+      "moodTags": [
+        "優しい",
+        "爽やか"
+      ],
+      "motifTags": [
+        "桜",
+        "春"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -39821,17 +40369,39 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "家族",
+        "孤独",
+        "絆"
+      ],
+      "moodTags": [
+        "優しい",
+        "泣ける",
+        "癒し"
+      ],
+      "motifTags": [
+        "手"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "王様ランキング",
+        "series": "王様ランキング",
+        "role": "ED"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1589026080
@@ -39852,14 +40422,27 @@
       "genres": [
         "歌謡曲"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "片想い",
+        "青春"
+      ],
+      "moodTags": [
+        "切ない",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "教室"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -39883,17 +40466,41 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "ドラマ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル",
+        "男性ボーカル",
+        "デュエット"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "再会",
+        "希望"
+      ],
+      "moodTags": [
+        "優しい",
+        "壮大",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "光"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "そのうち結婚する君へ",
+        "series": "そのうち結婚する君へ",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1712831431
@@ -39914,15 +40521,30 @@
       "genres": [
         "ロック"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
-      "eventTags": []
+      "themeTags": [
+        "恋愛",
+        "約束",
+        "祈り"
+      ],
+      "moodTags": [
+        "優しい",
+        "明るい"
+      ],
+      "motifTags": [
+        "声"
+      ],
+      "eventTags": [
+        "結婚"
+      ]
     },
     "tieUps": [],
     "source": {
@@ -39945,14 +40567,26 @@
       "genres": [
         "ポップス"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "約束"
+      ],
+      "moodTags": [
+        "優しい",
+        "おしゃれ"
+      ],
+      "motifTags": [
+        "手"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -39973,20 +40607,43 @@
       "collectionName": "映画『さよならの朝に約束の花をかざろう』オリジナルサウンドトラック"
     },
     "classification": {
-      "genres": [],
-      "subgenres": [],
+      "genres": [
+        "J-POP"
+      ],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [
         "アニメ"
       ],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "祈り",
+        "絆",
+        "家族"
+      ],
+      "moodTags": [
+        "壮大",
+        "泣ける",
+        "幻想的"
+      ],
+      "motifTags": [
+        "光",
+        "空"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "さよならの朝に約束の花をかざろう",
+        "series": "さよならの朝に約束の花をかざろう",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1857550678
@@ -40007,15 +40664,31 @@
       "genres": [
         "ロック"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
-      "eventTags": []
+      "themeTags": [
+        "恋愛",
+        "夢",
+        "記憶"
+      ],
+      "moodTags": [
+        "切ない",
+        "爽やか"
+      ],
+      "motifTags": [
+        "花火",
+        "夏"
+      ],
+      "eventTags": [
+        "夏祭り"
+      ]
     },
     "tieUps": [],
     "source": {
@@ -40038,14 +40711,27 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常",
+        "希望",
+        "祈り"
+      ],
+      "moodTags": [
+        "優しい",
+        "穏やか"
+      ],
+      "motifTags": [
+        "光"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -40071,12 +40757,24 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常",
+        "自由",
+        "友情"
+      ],
+      "moodTags": [
+        "楽しい",
+        "元気",
+        "コミカル"
+      ],
+      "motifTags": [
+        "笑顔"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -40098,16 +40796,30 @@
     },
     "classification": {
       "genres": [
-        "J-POP"
+        "歌謡曲"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "バラード"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "秘密",
+        "葛藤"
+      ],
+      "moodTags": [
+        "切ない",
+        "おしゃれ",
+        "ノスタルジック"
+      ],
+      "motifTags": [
+        "夜"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -40131,17 +40843,38 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "subgenres": [
+        "バラード"
+      ],
+      "sourceCategories": [
+        "ドラマ"
+      ],
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "絆",
+        "祈り"
+      ],
+      "moodTags": [
+        "優しい",
+        "泣ける"
+      ],
+      "motifTags": [
+        "手"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "オレンジデイズ",
+        "series": "オレンジデイズ",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1374928853
@@ -40164,12 +40897,23 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "日常",
+        "家族"
+      ],
+      "moodTags": [
+        "コミカル",
+        "楽しい",
+        "優しい"
+      ],
+      "motifTags": [
+        "笑顔"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -40190,18 +40934,43 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "genres": [
+        "J-POP"
+      ],
+      "subgenres": [
+        "アイドルポップ"
+      ],
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "夢",
+        "希望",
+        "恋愛"
+      ],
+      "moodTags": [
+        "幻想的",
+        "優しい",
+        "透明感"
+      ],
+      "motifTags": [
+        "星",
+        "海"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "プリンセッション・オーケストラ",
+        "series": "プリンセッション・オーケストラ",
+        "role": "挿入歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -40222,14 +40991,28 @@
       "genres": [
         "J-POP"
       ],
-      "subgenres": [],
+      "subgenres": [
+        "ポップロック"
+      ],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "孤独",
+        "希望",
+        "再会"
+      ],
+      "moodTags": [
+        "爽やか",
+        "疾走感",
+        "切ない"
+      ],
+      "motifTags": [
+        "光"
+      ],
       "eventTags": []
     },
     "tieUps": [],
@@ -40250,20 +41033,41 @@
       "collectionName": "「勇者王ガオガイガー」オープニングテーマ 勇者王誕生! - Single"
     },
     "classification": {
-      "genres": [],
+      "genres": [
+        "J-POP"
+      ],
       "subgenres": [],
       "sourceCategories": [
         "アニメ"
       ],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "戦い",
+        "希望",
+        "絆"
+      ],
+      "moodTags": [
+        "熱い",
+        "壮大",
+        "かっこいい"
+      ],
+      "motifTags": [
+        "炎",
+        "光"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "勇者王ガオガイガー",
+        "series": "勇者王ガオガイガー",
+        "role": "OP"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1535175166
@@ -40285,16 +41089,38 @@
         "J-POP"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "映画",
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "恋愛",
+        "葛藤",
+        "祈り"
+      ],
+      "moodTags": [
+        "ミステリアス",
+        "切ない",
+        "壮大"
+      ],
+      "motifTags": [
+        "光",
+        "空"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "ヱヴァンゲリヲン新劇場版:序",
+        "series": "新世紀エヴァンゲリオン",
+        "role": "主題歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1440747562
@@ -40316,16 +41142,36 @@
         "J-POP"
       ],
       "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "友情",
+        "成長",
+        "希望"
+      ],
+      "moodTags": [
+        "爽やか",
+        "元気",
+        "熱い"
+      ],
+      "motifTags": [
+        "光"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "NINKU -忍空-",
+        "series": "NINKU -忍空-",
+        "role": "OP"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": 1835392997
@@ -40343,18 +41189,44 @@
       "collectionName": null
     },
     "classification": {
-      "genres": [],
-      "subgenres": [],
-      "sourceCategories": [],
-      "vocalTypes": []
+      "genres": [
+        "J-POP"
+      ],
+      "subgenres": [
+        "アイドルポップ"
+      ],
+      "sourceCategories": [
+        "アニメ"
+      ],
+      "vocalTypes": [
+        "女性ボーカル",
+        "合唱"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "戦い",
+        "絆",
+        "自由"
+      ],
+      "moodTags": [
+        "熱い",
+        "疾走感",
+        "壮大"
+      ],
+      "motifTags": [
+        "空",
+        "光"
+      ],
       "eventTags": []
     },
-    "tieUps": [],
+    "tieUps": [
+      {
+        "workTitle": "マクロスΔ",
+        "series": "マクロス",
+        "role": "挿入歌"
+      }
+    ],
     "source": {
       "provider": "itunes",
       "trackId": null
@@ -40377,12 +41249,25 @@
       ],
       "subgenres": [],
       "sourceCategories": [],
-      "vocalTypes": []
+      "vocalTypes": [
+        "男性ボーカル"
+      ]
     },
     "tags": {
-      "themeTags": [],
-      "moodTags": [],
-      "motifTags": [],
+      "themeTags": [
+        "自由",
+        "葛藤",
+        "青春"
+      ],
+      "moodTags": [
+        "熱い",
+        "ダーク",
+        "疾走感"
+      ],
+      "motifTags": [
+        "夜",
+        "街"
+      ],
       "eventTags": []
     },
     "tieUps": [],


### PR DESCRIPTION
## PR#41 修正内容

- `music_metadata.json` のメタ情報・タグ情報を更新
  - 451〜989曲目までの楽曲に対して、タグ情報を追加・整理
  - 対象項目:
    - `classification`
    - `tags`
    - `tieUps`

- タグ付けルールに沿って各曲の情報を補完
  - 曲名だけではなく、歌詞・曲調・作品文脈・一般的な受け取られ方を踏まえてタグを設定
  - `themeTags`、`moodTags`、`motifTags`、`eventTags` を用途に応じて整理
  - 1曲あたりのタグ数が過剰にならないよう調整

- Disney・ジブリ系楽曲の作品情報を補完
  - `sourceCategories` に `映画` を設定
  - 主題歌・劇中歌・劇伴などを `tieUps.role` に設定
  - `tieUps.series`、`tieUps.workTitle` を追加

- タグ辞書との整合性を修正
  - 辞書外の genre を既存タグへ置換
  - `サウンドトラック` → `劇伴音楽`
  - `J-Pop` → `J-POP`
  - `ミュージカル` → `ポップス`
